### PR TITLE
Sync package-lock.json on Version Packages PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: changesets/action@v1
         with:
+          version: npm run version-packages
           publish: npm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4589,10 +4589,10 @@
     },
     "packages/airport-data": {
       "name": "@squawk/airport-data",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4603,14 +4603,14 @@
     },
     "packages/airports": {
       "name": "@squawk/airports",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@squawk/geo": "^0.3.1",
-        "@squawk/types": "^0.6.0"
+        "@squawk/geo": "^0.3.2",
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/airport-data": "^0.6.0",
+        "@squawk/airport-data": "^0.6.1",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4619,14 +4619,14 @@
     },
     "packages/airspace": {
       "name": "@squawk/airspace",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@squawk/geo": "^0.3.1",
-        "@squawk/types": "^0.6.0"
+        "@squawk/geo": "^0.3.2",
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/airspace-data": "^0.3.2",
+        "@squawk/airspace-data": "^0.4.0",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4635,7 +4635,7 @@
     },
     "packages/airspace-data": {
       "name": "@squawk/airspace-data",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.16"
@@ -4649,10 +4649,10 @@
     },
     "packages/airway-data": {
       "name": "@squawk/airway-data",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4663,14 +4663,14 @@
     },
     "packages/airways": {
       "name": "@squawk/airways",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0",
+        "@squawk/types": "^0.7.0",
         "@squawk/units": "^0.4.0"
       },
       "devDependencies": {
-        "@squawk/airway-data": "^0.4.1",
+        "@squawk/airway-data": "^0.4.2",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4679,10 +4679,10 @@
     },
     "packages/fix-data": {
       "name": "@squawk/fix-data",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4693,14 +4693,14 @@
     },
     "packages/fixes": {
       "name": "@squawk/fixes",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/geo": "^0.3.1",
-        "@squawk/types": "^0.6.0"
+        "@squawk/geo": "^0.3.2",
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/fix-data": "^0.5.1",
+        "@squawk/fix-data": "^0.5.2",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4720,23 +4720,23 @@
     },
     "packages/flightplan": {
       "name": "@squawk/flightplan",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/geo": "^0.3.1",
-        "@squawk/types": "^0.6.0"
+        "@squawk/geo": "^0.3.2",
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/airport-data": "^0.6.0",
-        "@squawk/airports": "^0.5.0",
-        "@squawk/airway-data": "^0.4.1",
-        "@squawk/airways": "^0.3.1",
-        "@squawk/fix-data": "^0.5.1",
-        "@squawk/fixes": "^0.2.1",
-        "@squawk/navaid-data": "^0.5.1",
-        "@squawk/navaids": "^0.3.1",
-        "@squawk/procedure-data": "^0.5.1",
-        "@squawk/procedures": "^0.4.1",
+        "@squawk/airport-data": "^0.6.1",
+        "@squawk/airports": "^0.5.1",
+        "@squawk/airway-data": "^0.4.2",
+        "@squawk/airways": "^0.3.2",
+        "@squawk/fix-data": "^0.5.2",
+        "@squawk/fixes": "^0.2.2",
+        "@squawk/navaid-data": "^0.5.2",
+        "@squawk/navaids": "^0.3.2",
+        "@squawk/procedure-data": "^0.5.2",
+        "@squawk/procedures": "^0.4.2",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4745,10 +4745,10 @@
     },
     "packages/geo": {
       "name": "@squawk/geo",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0",
+        "@squawk/types": "^0.7.0",
         "@squawk/units": "^0.4.0"
       },
       "devDependencies": {
@@ -4760,10 +4760,10 @@
     },
     "packages/icao-registry": {
       "name": "@squawk/icao-registry",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0",
+        "@squawk/types": "^0.7.0",
         "adm-zip": "^0.5.17"
       },
       "devDependencies": {
@@ -4776,10 +4776,10 @@
     },
     "packages/icao-registry-data": {
       "name": "@squawk/icao-registry-data",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4790,30 +4790,30 @@
     },
     "packages/mcp": {
       "name": "@squawk/mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@squawk/airport-data": "^0.6.0",
-        "@squawk/airports": "^0.5.0",
-        "@squawk/airspace": "^0.5.1",
-        "@squawk/airspace-data": "^0.3.2",
-        "@squawk/airway-data": "^0.4.1",
-        "@squawk/airways": "^0.3.1",
-        "@squawk/fix-data": "^0.5.1",
-        "@squawk/fixes": "^0.2.1",
+        "@squawk/airport-data": "^0.6.1",
+        "@squawk/airports": "^0.5.1",
+        "@squawk/airspace": "^0.6.0",
+        "@squawk/airspace-data": "^0.4.0",
+        "@squawk/airway-data": "^0.4.2",
+        "@squawk/airways": "^0.3.2",
+        "@squawk/fix-data": "^0.5.2",
+        "@squawk/fixes": "^0.2.2",
         "@squawk/flight-math": "^0.5.1",
-        "@squawk/flightplan": "^0.4.1",
-        "@squawk/geo": "^0.3.1",
-        "@squawk/icao-registry": "^0.3.1",
-        "@squawk/icao-registry-data": "^0.4.1",
-        "@squawk/navaid-data": "^0.5.1",
-        "@squawk/navaids": "^0.3.1",
-        "@squawk/notams": "^0.3.1",
-        "@squawk/procedure-data": "^0.5.1",
-        "@squawk/procedures": "^0.4.1",
-        "@squawk/types": "^0.6.0",
-        "@squawk/weather": "^0.5.0",
+        "@squawk/flightplan": "^0.4.2",
+        "@squawk/geo": "^0.3.2",
+        "@squawk/icao-registry": "^0.3.2",
+        "@squawk/icao-registry-data": "^0.4.2",
+        "@squawk/navaid-data": "^0.5.2",
+        "@squawk/navaids": "^0.3.2",
+        "@squawk/notams": "^0.3.2",
+        "@squawk/procedure-data": "^0.5.2",
+        "@squawk/procedures": "^0.4.2",
+        "@squawk/types": "^0.7.0",
+        "@squawk/weather": "^0.5.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -4828,10 +4828,10 @@
     },
     "packages/navaid-data": {
       "name": "@squawk/navaid-data",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4842,14 +4842,14 @@
     },
     "packages/navaids": {
       "name": "@squawk/navaids",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/geo": "^0.3.1",
-        "@squawk/types": "^0.6.0"
+        "@squawk/geo": "^0.3.2",
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/navaid-data": "^0.5.1",
+        "@squawk/navaid-data": "^0.5.2",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4858,10 +4858,10 @@
     },
     "packages/notams": {
       "name": "@squawk/notams",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "engines": {
         "node": ">=22"
@@ -4869,10 +4869,10 @@
     },
     "packages/procedure-data": {
       "name": "@squawk/procedure-data",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"
@@ -4883,13 +4883,13 @@
     },
     "packages/procedures": {
       "name": "@squawk/procedures",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
-        "@squawk/procedure-data": "^0.5.1",
+        "@squawk/procedure-data": "^0.5.2",
         "@types/node": "^25.6.0"
       },
       "engines": {
@@ -4898,7 +4898,7 @@
     },
     "packages/types": {
       "name": "@squawk/types",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.16"
@@ -4923,10 +4923,10 @@
     },
     "packages/weather": {
       "name": "@squawk/weather",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@squawk/types": "^0.6.0"
+        "@squawk/types": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:data": "node scripts/build-data.js",
     "clean": "node scripts/clean.js",
     "publish": "changeset publish",
+    "version-packages": "changeset version && npm install --package-lock-only",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
Add a version-packages npm script that runs `changeset version` followed by `npm install --package-lock-only`, and wire it into the changesets/action step. This keeps the committed lockfile in sync with bumped package.json files at every release. Also includes a one-time resync of the existing drift on main.