### PR TITLE
Centralize atlas chart colors and add mobile-responsive UX

### DIFF
--- a/apps/atlas/src/index.css
+++ b/apps/atlas/src/index.css
@@ -1,5 +1,18 @@
 @import 'tailwindcss';
 
+/*
+ * Atlas-specific Tailwind theme extensions. Each `--spacing-*` entry
+ * extends Tailwind's spacing scale and is reachable via every spacing
+ * utility (`w-*`, `h-*`, `p-*`, `m-*`, `min-w-*`, etc.). Add a token
+ * here when a fixed dimension is referenced from more than one place
+ * or needs a semantic name; one-off dimensions stay inline as rem
+ * arbitrary values (e.g. `min-w-[12.5rem]`).
+ */
+@theme {
+  /* Width of the desktop entity inspector overlay (360px @ 16px root). Mirrored by INSPECTOR_OVERLAY_DESKTOP_WIDTH_PX in use-chip-hover-pan.ts for MapLibre canvas math. */
+  --spacing-inspector: 22.5rem;
+}
+
 html,
 body,
 #root {

--- a/apps/atlas/src/modes/chart/chart-loading-indicator.tsx
+++ b/apps/atlas/src/modes/chart/chart-loading-indicator.tsx
@@ -157,7 +157,7 @@ export function ChartLoadingIndicator(): ReactElement | null {
           <button
             type="button"
             onClick={() => window.location.reload()}
-            className="mt-3 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-800"
+            className="mt-3 rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white hover:bg-slate-800 md:py-1.5"
           >
             Reload
           </button>

--- a/apps/atlas/src/modes/chart/disambiguation-popover.tsx
+++ b/apps/atlas/src/modes/chart/disambiguation-popover.tsx
@@ -14,6 +14,7 @@ import {
 import { AIRWAYS_LAYER_ID } from './layers/airways-layer.tsx';
 import { FIXES_LAYER_ID } from './layers/fixes-layer.tsx';
 import { NAVAIDS_LAYER_ID } from './layers/navaids-layer.tsx';
+import { useCanHover } from '../../shared/styles/use-can-hover.ts';
 import { formatChipLabel, selectedFromFeature } from './click-to-select.ts';
 import type { InspectableFeature } from './click-to-select.ts';
 import { useSetHoveredChipSelection } from './highlight-context.ts';
@@ -89,6 +90,7 @@ export function DisambiguationPopover({
   const map = useMap();
   const mapRef = map.current ?? map.default;
   const setHoveredChipSelection = useSetHoveredChipSelection();
+  const canHover = useCanHover();
 
   // Build the visible entry list. Drops features whose layer cannot
   // produce a selection (e.g. an airport feature missing `faaId`) and
@@ -176,7 +178,7 @@ export function DisambiguationPopover({
       clampKey={entries.length}
       role="menu"
       aria-label="Select a feature"
-      className="absolute z-30 flex max-h-[70vh] min-w-[200px] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg"
+      className="absolute z-30 flex max-h-[70vh] min-w-[12.5rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg"
     >
       <p className="flex shrink-0 items-baseline justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-slate-600 uppercase">
         <span>Select a feature</span>
@@ -189,11 +191,13 @@ export function DisambiguationPopover({
               type="button"
               role="menuitem"
               onClick={(): void => onSelect(entry.selection)}
-              onMouseEnter={(): void => setHoveredChipSelection(entry.selection)}
-              onMouseLeave={(): void => setHoveredChipSelection(undefined)}
+              {...(canHover && {
+                onMouseEnter: (): void => setHoveredChipSelection(entry.selection),
+                onMouseLeave: (): void => setHoveredChipSelection(undefined),
+              })}
               onFocus={(): void => setHoveredChipSelection(entry.selection)}
               onBlur={(): void => setHoveredChipSelection(undefined)}
-              className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm text-slate-700 hover:bg-indigo-50 hover:text-indigo-700 focus:bg-indigo-50 focus:text-indigo-700 focus:outline-none"
+              className="flex w-full items-baseline gap-2 px-3 py-3 text-left text-sm text-slate-700 hover:bg-indigo-50 hover:text-indigo-700 focus:bg-indigo-50 focus:text-indigo-700 focus:outline-none md:py-1.5"
             >
               <span className="w-14 shrink-0 text-[10px] font-semibold tracking-wide text-slate-500 uppercase">
                 {entry.type}

--- a/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
@@ -61,12 +61,14 @@ vi.mock('@radix-ui/react-dropdown-menu', () => {
     children,
     checked,
     onCheckedChange,
+    onKeyDown,
     className,
   }: {
     children: ReactNode;
     checked: boolean;
     onCheckedChange: (next: boolean) => void;
     onSelect?: (event: Event) => void;
+    onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
     className?: string;
   }): ReactNode {
     const activate = (): void => onCheckedChange(!checked);
@@ -78,6 +80,13 @@ vi.mock('@radix-ui/react-dropdown-menu', () => {
         className={className}
         onClick={activate}
         onKeyDown={(event) => {
+          // Run the consumer's handler first so it can preventDefault on
+          // arrow keys (the unified parent row uses ArrowRight/Left for
+          // expand/collapse before the menu's space/enter activation).
+          onKeyDown?.(event);
+          if (event.defaultPrevented) {
+            return;
+          }
           if (event.key === ' ' || event.key === 'Enter') {
             event.preventDefault();
             activate();
@@ -159,13 +168,9 @@ function makePrev(overrides: Partial<ChartSearch> = {}): ChartSearch {
   };
 }
 
-/** Resolves the parent menuitem (or menuitemcheckbox) for a given layer label. */
+/** Resolves the parent row for a given layer label. All parent rows are menuitemcheckbox in the unified design. */
 function getParentRow(label: RegExp | string): HTMLElement {
-  const items = screen.getAllByRole(
-    /airways|airspace/i.test(typeof label === 'string' ? label : label.source)
-      ? 'menuitem'
-      : 'menuitemcheckbox',
-  );
+  const items = screen.getAllByRole('menuitemcheckbox');
   const text = typeof label === 'string' ? label.toLowerCase() : label.source.toLowerCase();
   const match = items.find((el) => el.textContent?.toLowerCase().includes(text));
   if (match === undefined) {
@@ -174,16 +179,18 @@ function getParentRow(label: RegExp | string): HTMLElement {
   return match;
 }
 
-/** Click the row body of an expandable parent (Airways / Airspace) to toggle expansion. */
+/** Click the chevron button inside an expandable parent row to toggle expansion. */
 function expandLayer(layer: 'airways' | 'airspace'): void {
-  fireEvent.click(getParentRow(layer));
+  const row = getParentRow(layer);
+  const chevron = within(row).getByRole('button', {
+    name: new RegExp(`(expand|collapse) ${layer} sub-list`, 'i'),
+  });
+  fireEvent.click(chevron);
 }
 
-/** Click the inner parent checkbox button on an expandable layer row. */
-function clickParentCheckbox(layer: 'airways' | 'airspace'): void {
-  const row = getParentRow(layer);
-  const checkbox = within(row).getByRole('checkbox');
-  fireEvent.click(checkbox);
+/** Click the parent row body itself to toggle the layer's checked state. */
+function clickParentLayer(layer: 'airways' | 'airspace' | 'airports' | 'navaids' | 'fixes'): void {
+  fireEvent.click(getParentRow(layer));
 }
 
 describe('LayerToggle', () => {
@@ -210,15 +217,12 @@ describe('LayerToggle', () => {
     );
   });
 
-  it('renders the expandable parent rows as menuitem with an inner checkbox reflecting the URL', () => {
+  it('renders the expandable parent rows as menuitemcheckbox reflecting the URL', () => {
     useSearchMock.mockReturnValue(makeSearch({ layers: ['airports'] }));
     render(<LayerToggle />);
 
-    const airwaysRow = screen.getByRole('menuitem', { name: /airways/i });
-    expect(within(airwaysRow).getByRole('checkbox')).toHaveAttribute('aria-checked', 'false');
-
-    const airspaceRow = screen.getByRole('menuitem', { name: /airspace/i });
-    expect(within(airspaceRow).getByRole('checkbox')).toHaveAttribute('aria-checked', 'false');
+    expect(getParentRow('airways')).toHaveAttribute('aria-checked', 'false');
+    expect(getParentRow('airspace')).toHaveAttribute('aria-checked', 'false');
   });
 
   it('removes a simple layer from the URL when its row is clicked', () => {
@@ -230,21 +234,21 @@ describe('LayerToggle', () => {
     expect(next.layers).toEqual(['airports', 'navaids', 'airways', 'airspace']);
   });
 
-  it('toggles an expandable parent layer via the inner checkbox without expanding the row', () => {
+  it('toggles an expandable parent layer when the row is clicked, without expanding it', () => {
     render(<LayerToggle />);
-    clickParentCheckbox('airways');
+    clickParentLayer('airways');
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
     const next = applyLatestSearchUpdate(makePrev());
     expect(next.layers).toEqual(['airports', 'navaids', 'fixes', 'airspace']);
-    // Expansion state is component-local - clicking the checkbox should not
-    // have expanded the row, so sub-rows should not be in the DOM.
+    // Row click toggles the layer; the chevron is the separate
+    // expansion affordance, so sub-rows should not have appeared.
     expect(
       screen.queryByRole('menuitemcheckbox', { name: /low altitude/i }),
     ).not.toBeInTheDocument();
   });
 
-  it('expands the row when its body is clicked, without toggling the parent', () => {
+  it('expands the row when the chevron is clicked, without toggling the parent', () => {
     render(<LayerToggle />);
     expandLayer('airways');
 
@@ -256,7 +260,7 @@ describe('LayerToggle', () => {
     ).toBeInTheDocument();
   });
 
-  it('hides sub-rows again when the row is clicked a second time', () => {
+  it('hides sub-rows again when the chevron is clicked a second time', () => {
     render(<LayerToggle />);
     expandLayer('airspace');
     expect(screen.getByRole('menuitemcheckbox', { name: /class b/i })).toBeInTheDocument();
@@ -265,12 +269,12 @@ describe('LayerToggle', () => {
     expect(screen.queryByRole('menuitemcheckbox', { name: /class b/i })).not.toBeInTheDocument();
   });
 
-  it('keeps sub-rows visible when the parent checkbox is toggled (expansion state preserved)', () => {
+  it('keeps sub-rows visible when the parent layer is toggled (expansion state preserved)', () => {
     render(<LayerToggle />);
     expandLayer('airspace');
     expect(screen.getByRole('menuitemcheckbox', { name: /class b/i })).toBeInTheDocument();
 
-    clickParentCheckbox('airspace');
+    clickParentLayer('airspace');
     expect(screen.getByRole('menuitemcheckbox', { name: /class b/i })).toBeInTheDocument();
   });
 
@@ -280,11 +284,11 @@ describe('LayerToggle', () => {
     );
     render(<LayerToggle />);
 
-    const airwaysRow = screen.getByRole('menuitem', { name: /airways/i });
+    const airwaysRow = getParentRow('airways');
     expect(within(airwaysRow).getByText('1/3')).toBeInTheDocument();
     expect(within(airwaysRow).getByLabelText('1 of 3 enabled')).toBeInTheDocument();
 
-    const airspaceRow = screen.getByRole('menuitem', { name: /airspace/i });
+    const airspaceRow = getParentRow('airspace');
     expect(within(airspaceRow).getByText('2/11')).toBeInTheDocument();
     expect(within(airspaceRow).getByLabelText('2 of 11 enabled')).toBeInTheDocument();
   });
@@ -425,7 +429,7 @@ describe('LayerToggle', () => {
       }),
     );
     render(<LayerToggle />);
-    clickParentCheckbox('airways');
+    clickParentLayer('airways');
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
     const next = applyLatestSearchUpdate(
@@ -446,7 +450,7 @@ describe('LayerToggle', () => {
       }),
     );
     render(<LayerToggle />);
-    clickParentCheckbox('airways');
+    clickParentLayer('airways');
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
     const next = applyLatestSearchUpdate(
@@ -480,5 +484,23 @@ describe('LayerToggle', () => {
     expect(next.airwayCategories).toEqual(['LOW']);
     // Parent stays off because the sub-array did not transition out of empty.
     expect(next.layers).toEqual(['airports', 'navaids', 'fixes', 'airspace']);
+  });
+
+  it('expands on ArrowRight and collapses on ArrowLeft (keyboard tree-style nav)', () => {
+    render(<LayerToggle />);
+    const airwaysRow = getParentRow('airways');
+
+    // ArrowRight on a collapsed expandable row expands it without
+    // toggling the parent layer.
+    fireEvent.keyDown(airwaysRow, { key: 'ArrowRight' });
+    expect(screen.getByRole('menuitemcheckbox', { name: /low altitude/i })).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    // ArrowLeft on an expanded row collapses it.
+    fireEvent.keyDown(airwaysRow, { key: 'ArrowLeft' });
+    expect(
+      screen.queryByRole('menuitemcheckbox', { name: /low altitude/i }),
+    ).not.toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/atlas/src/modes/chart/layer-toggle.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useState } from 'react';
-import type { MouseEvent, PointerEvent, ReactElement } from 'react';
+import type { KeyboardEvent, MouseEvent, PointerEvent, ReactElement } from 'react';
 import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { AIRSPACE_CLASSES, AIRWAY_CATEGORIES, CHART_ROUTE_PATH, LAYER_IDS } from './url-state.ts';
@@ -211,7 +211,7 @@ export function LayerToggle(): ReactElement {
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger className="absolute right-3 top-3 z-10 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-md hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400">
+      <DropdownMenu.Trigger className="absolute right-3 top-3 z-10 rounded-md border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-slate-700 shadow-md hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:py-1.5">
         Layers
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
@@ -296,7 +296,7 @@ function SimpleParentRow({ label, checked, onCheckedChange }: SimpleParentRowPro
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="flex cursor-default items-center gap-2 rounded px-2 py-1.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100"
+      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -327,11 +327,16 @@ interface ExpandableParentRowProps {
 }
 
 /**
- * Row for a layer with sub-types. Split-action layout: the row itself is a
- * Radix `Item` whose `onSelect` toggles the inline expansion, and a small
- * checkbox button at the left toggles the parent layer independently. The
- * checkbox stops pointer + click propagation so toggling it does not also
- * expand the row. Renders a "X/Y" chip and a chevron at the right.
+ * Row for a layer with sub-types. Unified click semantics: the row itself
+ * is a Radix `CheckboxItem` whose `onCheckedChange` toggles the parent
+ * layer (identical to {@link SimpleParentRow}), and a dedicated chevron
+ * button at the right toggles the inline expansion. Stopping pointer
+ * propagation on the chevron prevents the parent CheckboxItem from also
+ * firing its `onCheckedChange` from the same click. Keyboard users
+ * navigate to the row with arrow keys; ArrowRight expands and ArrowLeft
+ * collapses, mirroring the standard tree-style menu pattern. The chevron
+ * button is intentionally non-tabbable (`tabIndex=-1`) so the keyboard
+ * focus chain remains the menu items, not their internal sub-controls.
  */
 function ExpandableParentRow({
   label,
@@ -342,60 +347,79 @@ function ExpandableParentRow({
   enabledCount,
   totalCount,
 }: ExpandableParentRowProps): ReactElement {
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === 'ArrowRight' && !expanded) {
+      event.preventDefault();
+      onToggleExpanded();
+    } else if (event.key === 'ArrowLeft' && expanded) {
+      event.preventDefault();
+      onToggleExpanded();
+    }
+  };
   return (
-    <DropdownMenu.Item
-      onSelect={(event) => {
-        event.preventDefault();
-        onToggleExpanded();
-      }}
-      className="flex cursor-default items-center gap-2 rounded px-2 py-1.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100"
+    <DropdownMenu.CheckboxItem
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      onSelect={(event) => event.preventDefault()}
+      onKeyDown={handleKeyDown}
+      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
     >
-      <ParentCheckbox label={label} checked={checked} onCheckedChange={onCheckedChange} />
+      <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
+        <DropdownMenu.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenu.ItemIndicator>
+      </span>
       <span className="flex-1">{label}</span>
       <SubCountChip enabled={enabledCount} total={totalCount} dimmed={!checked} />
-      <ChevronIcon expanded={expanded} />
-    </DropdownMenu.Item>
+      <ExpandToggleButton label={label} expanded={expanded} onToggleExpanded={onToggleExpanded} />
+    </DropdownMenu.CheckboxItem>
   );
 }
 
-/** Props for {@link ParentCheckbox}. */
-interface ParentCheckboxProps {
+/** Props for {@link ExpandToggleButton}. */
+interface ExpandToggleButtonProps {
   /** Layer label, used for the accessible name. */
   label: string;
-  /** Whether the parent layer is currently enabled. */
-  checked: boolean;
-  /** Called with the new checked state when the checkbox is toggled. */
-  onCheckedChange: (checked: boolean) => void;
+  /** Whether the inline sub-list is currently expanded. */
+  expanded: boolean;
+  /** Called when the chevron is clicked. */
+  onToggleExpanded: () => void;
 }
 
 /**
- * Small checkbox button used inside an {@link ExpandableParentRow}. Stops
- * pointer + click propagation so its click does not also fire the row's
- * `onSelect`. Renders the same checkmark glyph as the simple parent rows
- * inside a slot of the same width, so all parent rows align vertically.
+ * Dedicated chevron button rendered inside an {@link ExpandableParentRow}
+ * to toggle the inline sub-list expansion. Stops pointer + click
+ * propagation so its click does NOT also flip the parent CheckboxItem's
+ * checked state (which would toggle the layer at the same time as
+ * expanding). Sized at 44px on mobile (touch target) and 28px on desktop;
+ * `tabIndex=-1` keeps it out of the keyboard focus chain so arrow-key
+ * menu navigation lands on the row, not separately on the chevron.
  */
-function ParentCheckbox({ label, checked, onCheckedChange }: ParentCheckboxProps): ReactElement {
+function ExpandToggleButton({
+  label,
+  expanded,
+  onToggleExpanded,
+}: ExpandToggleButtonProps): ReactElement {
   const stopPointer = (event: PointerEvent<HTMLButtonElement>): void => {
     event.stopPropagation();
   };
   const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
     event.stopPropagation();
     event.preventDefault();
-    onCheckedChange(!checked);
+    onToggleExpanded();
   };
   return (
     <button
       type="button"
-      role="checkbox"
-      aria-checked={checked}
-      aria-label={`Toggle ${label} layer`}
+      aria-label={`${expanded ? 'Collapse' : 'Expand'} ${label} sub-list`}
+      aria-expanded={expanded}
       tabIndex={-1}
       onClick={handleClick}
       onPointerDown={stopPointer}
       onPointerUp={stopPointer}
-      className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:border-slate-400"
+      className="-mr-1 flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-200 hover:text-slate-700 md:h-7 md:w-7"
     >
-      {checked ? <CheckIcon /> : null}
+      <ChevronIcon expanded={expanded} />
     </button>
   );
 }
@@ -421,7 +445,7 @@ function SubRow({ label, checked, onCheckedChange }: SubRowProps): ReactElement 
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="flex cursor-default items-center gap-2 rounded py-1.5 pl-8 pr-2 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100"
+      className="flex cursor-default items-center gap-2 rounded py-2.5 pl-8 pr-2 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>

--- a/apps/atlas/src/modes/chart/layers/airports-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airports-layer.tsx
@@ -6,6 +6,11 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Airport } from '@squawk/types';
 import { useAirportDataset } from '../../../shared/data/airport-dataset.ts';
+import {
+  CHART_AIRPORT_COLORS,
+  CHART_HIGHLIGHT_COLORS,
+  CHART_SYMBOL_STROKE,
+} from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 
 /**
@@ -96,8 +101,8 @@ const AIRPORTS_HIGHLIGHT_LAYER_BASE: LayerProps = {
   type: 'circle',
   paint: {
     'circle-radius': 9,
-    'circle-color': '#fde047',
-    'circle-stroke-color': '#0f172a',
+    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
+    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
     'circle-stroke-width': 2,
   },
 };
@@ -128,8 +133,13 @@ const AIRPORTS_LAYER_PROPS: LayerProps = {
       16,
       10,
     ],
-    'circle-color': ['case', ['>=', ['get', 'longestRunwayFt'], 8000], '#1d4ed8', '#0f172a'],
-    'circle-stroke-color': '#ffffff',
+    'circle-color': [
+      'case',
+      ['>=', ['get', 'longestRunwayFt'], 8000],
+      CHART_AIRPORT_COLORS.major,
+      CHART_AIRPORT_COLORS.minor,
+    ],
+    'circle-stroke-color': CHART_SYMBOL_STROKE,
     'circle-stroke-width': 1,
   },
 };

--- a/apps/atlas/src/modes/chart/layers/airspace-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airspace-layer.tsx
@@ -8,6 +8,11 @@ import type { Feature, FeatureCollection } from 'geojson';
 import { polygonGeoJson } from '@squawk/geo';
 import type { AirspaceType } from '@squawk/types';
 import { useAirspaceDataset } from '../../../shared/data/airspace-dataset.ts';
+import {
+  CHART_AIRSPACE_BADGE_COLORS,
+  CHART_AIRSPACE_COLORS,
+  CHART_HIGHLIGHT_COLORS,
+} from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef, useHoveredFeatureIndex } from '../highlight-context.ts';
 import { AIRSPACE_CLASS_TYPES, CHART_ROUTE_PATH } from '../url-state.ts';
 
@@ -161,7 +166,7 @@ const AIRSPACE_HIGHLIGHT_LAYER_BASE: LayerProps = {
     'line-join': 'round',
   },
   paint: {
-    'line-color': '#fde047',
+    'line-color': CHART_HIGHLIGHT_COLORS.primary,
     'line-width': 3,
     'line-opacity': 1,
   },
@@ -205,7 +210,7 @@ const AIRSPACE_FEATURE_FOCUS_LAYER_BASE: LayerProps = {
     'line-join': 'round',
   },
   paint: {
-    'line-color': '#fef9c3',
+    'line-color': CHART_HIGHLIGHT_COLORS.focusOutline,
     'line-width': 5,
     'line-opacity': 1,
   },
@@ -238,8 +243,8 @@ const AIRSPACE_FEATURE_BADGE_LAYER_BASE: LayerProps = {
     'text-ignore-placement': true,
   },
   paint: {
-    'text-color': '#fef08a',
-    'text-halo-color': '#0f172a',
+    'text-color': CHART_AIRSPACE_BADGE_COLORS.text,
+    'text-halo-color': CHART_AIRSPACE_BADGE_COLORS.halo,
     'text-halo-width': 2.5,
   },
 };
@@ -257,28 +262,28 @@ const TYPE_COLOR_EXPRESSION = [
   'match',
   ['get', 'type'],
   'CLASS_B',
-  '#1e3a8a',
+  CHART_AIRSPACE_COLORS.classB,
   'CLASS_C',
-  '#be185d',
+  CHART_AIRSPACE_COLORS.classC,
   'CLASS_D',
-  '#2563eb',
+  CHART_AIRSPACE_COLORS.classD,
   ['CLASS_E2', 'CLASS_E3', 'CLASS_E4', 'CLASS_E5', 'CLASS_E6', 'CLASS_E7'],
-  '#ec4899',
+  CHART_AIRSPACE_COLORS.classE,
   'MOA',
-  '#d97706',
+  CHART_AIRSPACE_COLORS.moa,
   'RESTRICTED',
-  '#dc2626',
+  CHART_AIRSPACE_COLORS.restricted,
   'PROHIBITED',
-  '#991b1b',
+  CHART_AIRSPACE_COLORS.prohibited,
   'WARNING',
-  '#f97316',
+  CHART_AIRSPACE_COLORS.warning,
   'ALERT',
-  '#facc15',
+  CHART_AIRSPACE_COLORS.alert,
   'NSA',
-  '#6b7280',
+  CHART_AIRSPACE_COLORS.nsa,
   'ARTCC',
-  '#94a3b8',
-  '#64748b',
+  CHART_AIRSPACE_COLORS.artcc,
+  CHART_AIRSPACE_COLORS.fallback,
 ] satisfies ExpressionSpecification;
 
 /**
@@ -580,7 +585,7 @@ function createHatchPatternImage():
   if (ctx === null) {
     return undefined;
   }
-  ctx.strokeStyle = '#fde047';
+  ctx.strokeStyle = CHART_HIGHLIGHT_COLORS.primary;
   ctx.lineWidth = 1.5;
   ctx.lineCap = 'square';
   // Three diagonal segments so the pattern tiles seamlessly across

--- a/apps/atlas/src/modes/chart/layers/airways-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airways-layer.tsx
@@ -7,6 +7,10 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, MultiLineString } from 'geojson';
 import type { Airway, AirwayType } from '@squawk/types';
 import { useAirwayDataset } from '../../../shared/data/airway-dataset.ts';
+import {
+  CHART_AIRWAY_COLORS,
+  CHART_HIGHLIGHT_COLORS,
+} from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { AIRWAY_CATEGORY_TYPES, CHART_ROUTE_PATH } from '../url-state.ts';
 import { buildSegments } from './airway-segments.ts';
@@ -59,7 +63,7 @@ const AIRWAYS_HIGHLIGHT_LAYER_BASE: LayerProps = {
     'line-join': 'round',
   },
   paint: {
-    'line-color': '#fde047',
+    'line-color': CHART_HIGHLIGHT_COLORS.primary,
     'line-width': 4,
     'line-opacity': 0.95,
   },
@@ -115,10 +119,10 @@ const AIRWAYS_LAYER_BASE: LayerProps = {
       'match',
       ['get', 'type'],
       ['VICTOR', 'RNAV_T'],
-      '#475569',
+      CHART_AIRWAY_COLORS.low,
       ['JET', 'RNAV_Q'],
-      '#4338ca',
-      '#94a3b8',
+      CHART_AIRWAY_COLORS.high,
+      CHART_AIRWAY_COLORS.regional,
     ],
     'line-width': ['interpolate', ['linear'], ['zoom'], 4, 1, 7, 1.6, 10, 2.6],
     'line-opacity': 0.45,

--- a/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
@@ -6,6 +6,11 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Fix, FixUseCode } from '@squawk/types';
 import { useFixDataset } from '../../../shared/data/fix-dataset.ts';
+import {
+  CHART_FIX_COLOR,
+  CHART_HIGHLIGHT_COLORS,
+  CHART_SYMBOL_STROKE,
+} from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 
 /**
@@ -52,8 +57,8 @@ const FIXES_HIGHLIGHT_LAYER_BASE: LayerProps = {
   type: 'circle',
   paint: {
     'circle-radius': 9,
-    'circle-color': '#fde047',
-    'circle-stroke-color': '#0f172a',
+    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
+    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
     'circle-stroke-width': 2,
   },
 };
@@ -123,8 +128,8 @@ const FIXES_LAYER_PROPS: LayerProps = {
       16,
       8,
     ],
-    'circle-color': '#ea580c',
-    'circle-stroke-color': '#ffffff',
+    'circle-color': CHART_FIX_COLOR,
+    'circle-stroke-color': CHART_SYMBOL_STROKE,
     'circle-stroke-width': 0.75,
   },
 };

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
@@ -6,6 +6,11 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Navaid, NavaidType } from '@squawk/types';
 import { useNavaidDataset } from '../../../shared/data/navaid-dataset.ts';
+import {
+  CHART_HIGHLIGHT_COLORS,
+  CHART_NAVAID_COLOR,
+  CHART_SYMBOL_STROKE,
+} from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 
 /**
@@ -53,8 +58,8 @@ const NAVAIDS_HIGHLIGHT_LAYER_BASE: LayerProps = {
   type: 'circle',
   paint: {
     'circle-radius': 9,
-    'circle-color': '#fde047',
-    'circle-stroke-color': '#0f172a',
+    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
+    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
     'circle-stroke-width': 2,
   },
 };
@@ -129,8 +134,8 @@ const NAVAIDS_LAYER_PROPS: LayerProps = {
       16,
       8,
     ],
-    'circle-color': '#7c3aed',
-    'circle-stroke-color': '#ffffff',
+    'circle-color': CHART_NAVAID_COLOR,
+    'circle-stroke-color': CHART_SYMBOL_STROKE,
     'circle-stroke-width': 1,
   },
 };

--- a/apps/atlas/src/shared/inspector/inspector.spec.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.spec.tsx
@@ -853,4 +853,57 @@ describe('EntityInspector', () => {
     fireEvent.mouseLeave(chip);
     expect(easeToMock).not.toHaveBeenCalled();
   });
+
+  it('pans to the chip target on commit click and calls navigate with the new selection', () => {
+    const easeToMock = vi.fn();
+    // project returns a centered point so isPointOutsideComfortableArea
+    // is false during hover - this isolates the pan-on-commit test from
+    // any preview-pan behavior. Even with the chip target onscreen,
+    // commit should pan because committing is a deliberate selection,
+    // not a preview hover.
+    useMapMock.mockReturnValue({
+      default: {
+        getMap: () => ({
+          easeTo: easeToMock,
+          project: vi.fn().mockReturnValue({ x: 400, y: 400 }),
+          getCanvas: vi.fn().mockReturnValue({ clientWidth: 1280, clientHeight: 800 }),
+          getCenter: vi.fn().mockReturnValue({ lng: -71, lat: 42 }),
+          getBounds: vi.fn().mockReturnValue({
+            getWest: () => -180,
+            getEast: () => 180,
+            getSouth: () => -90,
+            getNorth: () => 90,
+          }),
+          on: vi.fn(),
+          off: vi.fn(),
+        }),
+      },
+    });
+    useSearchMock.mockReturnValue(search({ selected: 'airport:BOS' }));
+    setupResolutions({
+      'airport:BOS': airportResolution,
+      'navaid:BOS': navaidResolution,
+    });
+    render(
+      <EntityInspector siblings={[buildSiblingFeature(NAVAIDS_LAYER_ID, { identifier: 'BOS' })]} />,
+    );
+    expandSiblingChips();
+    const chip = screen.getByRole('button', { name: 'BOS' });
+
+    fireEvent.click(chip);
+
+    // Pan-on-commit should fire with the navaid's centroid and the
+    // standard inspector-aware offset.
+    expect(easeToMock).toHaveBeenCalledTimes(1);
+    expect(easeToMock.mock.calls[0]?.[0]).toMatchObject({
+      center: [sampleNavaid.lon, sampleNavaid.lat],
+      offset: [-180, 0],
+    });
+    // And the URL navigation should still fire.
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0]?.[0]).toMatchObject({
+      search: expect.any(Function),
+      replace: true,
+    });
+  });
 });

--- a/apps/atlas/src/shared/inspector/inspector.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.tsx
@@ -12,6 +12,7 @@ import {
 import type { InspectableFeature } from '../../modes/chart/click-to-select.ts';
 import { AIRSPACE_CLASS_FOR_TYPE, CHART_ROUTE_PATH } from '../../modes/chart/url-state.ts';
 import type { AirspaceClass } from '../../modes/chart/url-state.ts';
+import { useCanHover } from '../styles/use-can-hover.ts';
 import { isAirspacePolygonFeature } from './airspace-feature.ts';
 import { ENTITY_TYPES, parseSelected } from './entity.ts';
 import type { EntityType } from './entity.ts';
@@ -71,10 +72,16 @@ export interface EntityInspectorProps {
  * selected; renders a slim loading or not-found header when the URL points
  * at an unloaded or stale id; otherwise dispatches to a per-type renderer.
  *
- * The panel is positioned `absolute` along the right edge of the chart
- * area (`top-0 right-0 bottom-0 w-[360px]`). It overlaps the layer-toggle
- * dropdown when both are open; the close affordance is the X in the
- * panel header.
+ * Layout is responsive: at the Tailwind `md:` breakpoint (>= 768px)
+ * the panel sits `absolute` along the right edge of the chart area
+ * (`top-0 right-0 bottom-0 w-inspector`, with the `inspector` spacing
+ * token declared in `src/index.css`). Below that breakpoint it
+ * collapses into a bottom sheet (`right-0 bottom-0 left-0
+ * max-h-[60vh]`) so the map stays visible above on phones. The
+ * chip-hover pan and recenter offset in `use-chip-hover-pan.ts` follow
+ * the same breakpoint and shift the camera focal point along whichever
+ * axis is occluded. The panel overlaps the layer-toggle dropdown when
+ * both are open; the close affordance is the X in the panel header.
  *
  * Stacked features at the click point: when the user clicks a spot where
  * multiple features overlap (Class B inside ARTCC, an airport sitting on
@@ -123,13 +130,14 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
   // bounce-fix freeze, the dragstart subscription, and the
   // selection-change cleanup; the inspector wires its outputs into
   // the chip strip, the recenter button, and the chip useMemo.
-  const { handleChipHover, handleRecenter, chipViewportBounds, resetSession } = useChipHoverPan({
-    selected,
-    mapRef,
-    datasets,
-    viewportBounds,
-    state,
-  });
+  const { handleChipHover, handleChipCommit, handleRecenter, chipViewportBounds, resetSession } =
+    useChipHoverPan({
+      selected,
+      mapRef,
+      datasets,
+      viewportBounds,
+      state,
+    });
 
   const handleClose = useCallback((): void => {
     resetSession();
@@ -141,16 +149,19 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
 
   const handleSwitchSelected = useCallback(
     (next: string): void => {
-      // Chip click commits: drop any in-flight hover session so the
-      // unhover restore does NOT yank the user back to a position
-      // that no longer matches the new selection.
-      resetSession();
+      // Pan to the picked chip's feature first, then commit the URL.
+      // `handleChipCommit` clears any in-flight hover session so the
+      // unhover-restore does NOT yank the user back to a position that
+      // no longer matches the new selection. The pan starts immediately
+      // and continues through the URL change so the camera ends up at
+      // the new feature regardless of input device.
+      handleChipCommit(next);
       void navigate({
         search: (prev) => ({ ...prev, selected: next }),
         replace: true,
       });
     },
-    [navigate, resetSession],
+    [navigate, handleChipCommit],
   );
 
   // Build the chip list. Two sources are merged, with same-pixel chips
@@ -238,7 +249,7 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
 
   return (
     <aside
-      className="absolute top-0 right-0 bottom-0 z-20 w-[360px] overflow-y-auto border-l border-slate-200 bg-white shadow-lg"
+      className="absolute right-0 bottom-0 left-0 z-20 max-h-[60vh] overflow-y-auto rounded-t-xl border-t border-slate-200 bg-white shadow-lg md:top-0 md:left-auto md:max-h-none md:w-inspector md:rounded-none md:border-t-0 md:border-l"
       aria-label="Entity inspector"
     >
       <InspectorHeader
@@ -279,9 +290,14 @@ const CHIP_GROUP_LABELS: Record<EntityType, string> = {
  * Airways, Airspace) so a click into a busy area is readable instead
  * of an unsorted wall of buttons.
  *
- * Each chip is a `<button>` so it is keyboard-focusable; hover and
+ * Each chip is a `<button>` so it is keyboard-focusable. On devices
+ * with a real hover gesture (mouse / trackpad) chip hover and keyboard
  * focus call `onHover` so chart-mode can preview the highlight on the
- * map before the user commits with a click.
+ * map before the user commits with a click. On `(hover: none)` devices
+ * (touch-only phones / tablets) the mouse-event preview is gated off
+ * to avoid synthesized-event flicker on tap; focus events still drive
+ * `onHover` so a connected keyboard or screen reader keeps the same
+ * affordance.
  */
 function SiblingChips({
   chips,
@@ -291,13 +307,15 @@ function SiblingChips({
   chips: readonly Chip[];
   onSelect: (selection: string) => void;
   /**
-   * Called on chip hover-enter (with the chip's selection) and on
-   * hover-leave / blur (with `undefined`). Used by chart-mode to
-   * temporarily highlight that chip's feature on the map so the user
-   * can confirm which entity a chip refers to before clicking.
+   * Called when a chip is hover-entered or focused (with the chip's
+   * selection) and when it is hover-left or blurred (with `undefined`).
+   * Used by chart-mode to temporarily highlight that chip's feature on
+   * the map so the user can confirm which entity a chip refers to
+   * before clicking.
    */
   onHover: (selection: string | undefined) => void;
 }): ReactElement {
+  const canHover = useCanHover();
   const [expanded, setExpanded] = useState(false);
   // Group chips by entity type, in canonical ENTITY_TYPES order, and
   // drop empty groups. The result is recomputed only when the chip
@@ -327,7 +345,7 @@ function SiblingChips({
         type="button"
         onClick={(): void => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-1.5 px-4 py-2 text-left text-xs font-semibold tracking-wide text-indigo-700 uppercase hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-400"
+        className="flex w-full items-center gap-1.5 px-4 py-3 text-left text-xs font-semibold tracking-wide text-indigo-700 uppercase hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-400 md:py-2"
       >
         <SwitchIcon />
         <span className="flex-1">{headerText}</span>
@@ -346,11 +364,13 @@ function SiblingChips({
                     key={chip.selection}
                     type="button"
                     onClick={(): void => onSelect(chip.selection)}
-                    onMouseEnter={(): void => onHover(chip.selection)}
-                    onMouseLeave={(): void => onHover(undefined)}
+                    {...(canHover && {
+                      onMouseEnter: (): void => onHover(chip.selection),
+                      onMouseLeave: (): void => onHover(undefined),
+                    })}
                     onFocus={(): void => onHover(chip.selection)}
                     onBlur={(): void => onHover(undefined)}
-                    className="rounded-full border border-indigo-300 bg-white px-2.5 py-1 text-xs font-medium text-indigo-700 shadow-sm hover:border-indigo-400 hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                    className="rounded-full border border-indigo-300 bg-white px-3 py-2 text-xs font-medium text-indigo-700 shadow-sm hover:border-indigo-400 hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 md:px-2.5 md:py-1"
                   >
                     {chip.label}
                   </button>
@@ -634,7 +654,7 @@ function InspectorHeader({
             onClick={onRecenter}
             aria-label="Recenter on this feature"
             title="Recenter on this feature"
-            className="flex h-7 w-7 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+            className="flex h-11 w-11 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7"
           >
             <RecenterIcon />
           </button>
@@ -643,7 +663,7 @@ function InspectorHeader({
           type="button"
           onClick={onClose}
           aria-label="Close inspector"
-          className="flex h-7 w-7 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+          className="flex h-11 w-11 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7"
         >
           <CloseIcon />
         </button>

--- a/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
+++ b/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
@@ -8,14 +8,52 @@ import { bboxFromWaypoints, combinedBboxFromAirspaceFeatures } from './geometry.
 import type { BoundingBox } from './geometry.ts';
 
 /**
- * Width in pixels of the inspector overlay that the entity inspector
- * paints on the right edge of the chart-mode map. The chip-hover pan
- * and the recenter button both shift the camera focal point left by
- * half this width so the target feature lands in the un-occluded
- * portion of the map. Mirrors the `w-[360px]` Tailwind class on the
- * inspector aside in `inspector.tsx`; keep both in sync.
+ * Width in pixels of the inspector overlay when it renders as the
+ * desktop right-edge panel. Mirrors the `--spacing-inspector` token
+ * (22.5rem = 360px @ 16px root) declared in `src/index.css` and
+ * consumed via `w-inspector` on the inspector aside in
+ * `inspector.tsx`; keep both in sync. Stays as a plain pixel constant
+ * rather than a rem value because every consumer feeds it to a
+ * MapLibre canvas-pixel API (`map.easeTo({ offset })`,
+ * `map.project()`).
  */
-export const INSPECTOR_OVERLAY_WIDTH_PX = 360;
+export const INSPECTOR_OVERLAY_DESKTOP_WIDTH_PX = 360;
+
+/**
+ * Tailwind `md:` breakpoint in pixels. The inspector renders as a
+ * bottom sheet below this width and as a right-edge panel at or above
+ * it, mirroring the `md:` overrides on the inspector aside. Keep in
+ * sync with Tailwind v4's default `md` breakpoint (currently 48rem =
+ * 768px); if either changes, update both.
+ */
+const INSPECTOR_DESKTOP_BREAKPOINT_PX = 768;
+
+/**
+ * Fraction of viewport height the inspector occupies as a mobile
+ * bottom sheet. Mirrors the `max-h-[60vh]` clamp on the inspector
+ * aside; the chip-hover pan keeps the selected feature visible above
+ * this band.
+ */
+const INSPECTOR_MOBILE_HEIGHT_FRACTION = 0.6;
+
+/**
+ * Returns the inspector's chart-occlusion footprint for the current
+ * viewport in canvas pixels. On desktop (>= the `md:` breakpoint) the
+ * inspector occupies the right edge so the camera offset shifts the
+ * focal point leftward (`x` non-zero). Below the breakpoint the
+ * inspector is a bottom sheet so the offset shifts upward (`y`
+ * non-zero) instead. Read at the time of pan so the camera follows
+ * resize / orientation changes without cached stale geometry.
+ */
+function getInspectorOcclusionPx(): { x: number; y: number } {
+  if (typeof window === 'undefined') {
+    return { x: 0, y: 0 };
+  }
+  if (window.innerWidth >= INSPECTOR_DESKTOP_BREAKPOINT_PX) {
+    return { x: INSPECTOR_OVERLAY_DESKTOP_WIDTH_PX, y: 0 };
+  }
+  return { x: 0, y: Math.round(window.innerHeight * INSPECTOR_MOBILE_HEIGHT_FRACTION) };
+}
 
 /**
  * Camera ease duration for chip-hover pan and recenter actions, in
@@ -59,10 +97,11 @@ export interface UseChipHoverPanArgs {
 
 /**
  * Public API of the chip-hover pan hook. The inspector wires
- * `handleChipHover` to the sibling chip strip's onHover, exposes
- * `handleRecenter` as the recenter button's onClick, derives the chip
- * `useMemo`'s viewport input from `chipViewportBounds`, and calls
- * `resetSession` from its close / chip-click commit paths.
+ * `handleChipHover` to the sibling chip strip's onHover, calls
+ * `handleChipCommit` from its chip-click commit path,
+ * exposes `handleRecenter` as the recenter button's onClick, derives
+ * the chip `useMemo`'s viewport input from `chipViewportBounds`, and
+ * calls `resetSession` from its close handler.
  */
 export interface UseChipHoverPanResult {
   /**
@@ -75,6 +114,17 @@ export interface UseChipHoverPanResult {
    * recapture mid-restore.
    */
   handleChipHover: (selection: string | undefined) => void;
+  /**
+   * Pan + commit handler for chip clicks. Eases the camera so the
+   * picked chip's feature lands in the un-occluded portion of the
+   * map and clears any in-flight hover session so the unhover-restore
+   * does not yank the user back to a position that no longer matches
+   * the new selection. Caller is still responsible for the URL
+   * navigation that commits the selection. Pans regardless of input
+   * device (mouse hover-then-click and touch tap both end up at the
+   * picked feature).
+   */
+  handleChipCommit: (selection: string) => void;
   /**
    * Eases the camera so the currently-resolved entity lands in the
    * un-occluded portion of the map. No-op when the entity has no
@@ -91,9 +141,9 @@ export interface UseChipHoverPanResult {
   chipViewportBounds: BoundingBox | undefined;
   /**
    * Clears the captured pre-pan center and viewport snapshot. The
-   * inspector's close handler and chip-click commit handler both
-   * call this so the camera does not snap back after the user has
-   * committed to a new view.
+   * inspector's close handler calls this so the camera does not snap
+   * back after the user has dismissed the panel. Chip-click commits
+   * go through `handleChipCommit`, which calls this internally.
    */
   resetSession: () => void;
 }
@@ -227,9 +277,31 @@ export function useChipHoverPan(args: UseChipHoverPanArgs): UseChipHoverPanResul
     panToFeatureWithInspectorOffset(target, map);
   }, [state, mapRef, resetSession]);
 
+  const handleChipCommit = useCallback(
+    (selection: string): void => {
+      // Commit ends any preview phase: clear the hover-chip highlight
+      // and the pre-pan capture so the unhover-restore does not yank
+      // the user back to a position that no longer matches the new
+      // selection. Touch devices never enter a hover preview phase, so
+      // the clears are no-ops there but harmless.
+      setHoveredChipSelection(undefined);
+      resetSession();
+      const map = getMapInstance(mapRef);
+      if (map === undefined) {
+        return;
+      }
+      const target = chipCentroid(selection, datasets);
+      if (target === undefined) {
+        return;
+      }
+      panToFeatureWithInspectorOffset(target, map);
+    },
+    [setHoveredChipSelection, resetSession, mapRef, datasets],
+  );
+
   const chipViewportBounds = hoverViewportFreeze ?? viewportBounds;
 
-  return { handleChipHover, handleRecenter, chipViewportBounds, resetSession };
+  return { handleChipHover, handleChipCommit, handleRecenter, chipViewportBounds, resetSession };
 }
 
 /**
@@ -287,15 +359,16 @@ function chipCentroid(
 /**
  * Returns true when a map-coordinate point lies outside the
  * comfortable viewing area, gating the chip-hover pan. The
- * comfortable area is the canvas minus the inspector overlay on the
- * right, with a {@link PAN_EDGE_MARGIN_PX} buffer around every other
- * edge. Returns true for:
+ * comfortable area is the canvas minus whichever edge the inspector
+ * occludes (right on desktop, bottom on mobile), with a
+ * {@link PAN_EDGE_MARGIN_PX} buffer around every other edge. Returns
+ * true for:
  *
  * - Fully offscreen points (negative coords or beyond canvas size).
- * - Points within `PAN_EDGE_MARGIN_PX` of the top, bottom, or left
- *   edges - they would render barely visible and easy to miss.
- * - Points within the right `INSPECTOR_OVERLAY_WIDTH_PX` strip
- *   (occluded by the inspector) plus the same margin.
+ * - Points within `PAN_EDGE_MARGIN_PX` of any non-occluded edge -
+ *   they would render barely visible and easy to miss.
+ * - Points within the inspector-occluded strip (right on desktop,
+ *   bottom on mobile) plus the same margin.
  *
  * Features comfortably inside this area are skipped from panning so
  * the camera does not jolt for chip-hovers on already-visible
@@ -309,29 +382,40 @@ function isPointOutsideComfortableArea(
   const canvas = map.getCanvas();
   const w = canvas.clientWidth;
   const h = canvas.clientHeight;
-  const usableRightEdge = w - INSPECTOR_OVERLAY_WIDTH_PX - PAN_EDGE_MARGIN_PX;
+  const occlusion = getInspectorOcclusionPx();
+  const usableRightEdge = w - occlusion.x - PAN_EDGE_MARGIN_PX;
+  const usableBottomEdge = h - occlusion.y - PAN_EDGE_MARGIN_PX;
   return (
     point.x < PAN_EDGE_MARGIN_PX ||
     point.x > usableRightEdge ||
     point.y < PAN_EDGE_MARGIN_PX ||
-    point.y > h - PAN_EDGE_MARGIN_PX
+    point.y > usableBottomEdge
   );
 }
 
 /**
  * Eases the camera so a target lng/lat lands at the center of the
  * un-occluded portion of the map (geometric center minus half the
- * inspector overlay's width). The negative x-offset shifts the camera
- * focal point left so the target appears in the visible left strip
- * rather than directly under the right-side panel.
+ * inspector overlay's footprint). On desktop the negative x-offset
+ * shifts the focal point left so the target appears in the visible
+ * left strip rather than directly under the right-side panel; on
+ * mobile the negative y-offset shifts the focal point up so the
+ * target appears in the visible top strip above the bottom sheet.
  */
 function panToFeatureWithInspectorOffset(
   lngLat: { lng: number; lat: number },
   map: MaplibreMap,
 ): void {
+  const occlusion = getInspectorOcclusionPx();
+  // Guard against negative zero on the un-occluded axis: dividing 0 by
+  // 2 and negating yields `-0`, which trips strict object-equality
+  // assertions and is technically distinct from `+0` even though
+  // MapLibre treats them identically.
+  const offsetX = occlusion.x === 0 ? 0 : -(occlusion.x / 2);
+  const offsetY = occlusion.y === 0 ? 0 : -(occlusion.y / 2);
   map.easeTo({
     center: [lngLat.lng, lngLat.lat],
-    offset: [-INSPECTOR_OVERLAY_WIDTH_PX / 2, 0],
+    offset: [offsetX, offsetY],
     duration: PAN_DURATION_MS,
   });
 }

--- a/apps/atlas/src/shared/map/zoom-controls.tsx
+++ b/apps/atlas/src/shared/map/zoom-controls.tsx
@@ -187,7 +187,7 @@ export function ZoomControls(): ReactElement {
  * stack - keeping the control geometry stable at the bounds.
  */
 const CONTROL_BUTTON_CLASS =
-  'flex h-8 w-8 items-center justify-center text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white';
+  'flex h-11 w-11 items-center justify-center text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white md:h-8 md:w-8';
 
 /** Inline plus glyph for the zoom-in button. */
 function PlusIcon(): ReactElement {

--- a/apps/atlas/src/shared/styles/chart-colors.ts
+++ b/apps/atlas/src/shared/styles/chart-colors.ts
@@ -1,0 +1,105 @@
+/**
+ * Centralized color tokens for chart-mode MapLibre layers.
+ *
+ * MapLibre `paint` and `layout` properties take literal color strings -
+ * they cannot read CSS custom properties at runtime - so chart palette
+ * tokens live here as a TypeScript module and are imported by each
+ * layer file. UI chrome (panels, buttons, text) continues to use
+ * Tailwind utilities directly; only chart-domain colors flow through
+ * this module.
+ *
+ * Add a new token here whenever a layer would otherwise inline a hex
+ * literal. Reuse an existing token when the color is already named for
+ * the same semantic purpose.
+ */
+
+/**
+ * Selection / hover highlight colors used uniformly across every chart
+ * layer (airports, fixes, navaids, airways, airspace). Reusing a single
+ * highlight palette keeps the active-feature affordance recognizable
+ * regardless of which layer the feature came from.
+ */
+export const CHART_HIGHLIGHT_COLORS = {
+  /** Primary highlight fill / stroke (yellow). */
+  primary: '#fde047',
+  /** Dark stroke paired with the primary highlight on point symbols. */
+  stroke: '#0f172a',
+  /** Lighter outline used for the per-feature focus ring on multi-feature airspace groupings. */
+  focusOutline: '#fef9c3',
+} as const;
+
+/**
+ * Default white stroke around point symbols (airports, fixes, navaids).
+ * Sits between the symbol fill and the basemap so the marker reads as a
+ * coin rather than blending into chart background tiles.
+ */
+export const CHART_SYMBOL_STROKE = '#ffffff';
+
+/** Airport circle fill colors keyed by longest-runway tier. */
+export const CHART_AIRPORT_COLORS = {
+  /** Major airport (longest runway >= 8000 ft) - blue. */
+  major: '#1d4ed8',
+  /** Minor airport - dark slate. */
+  minor: '#0f172a',
+} as const;
+
+/** Fix (waypoint) point symbol fill color (amber). */
+export const CHART_FIX_COLOR = '#ea580c';
+
+/** Navaid point symbol fill color (purple). */
+export const CHART_NAVAID_COLOR = '#7c3aed';
+
+/** Airway line colors keyed by altitude band. */
+export const CHART_AIRWAY_COLORS = {
+  /** Low-altitude airways (VICTOR / RNAV_T) - slate. */
+  low: '#475569',
+  /** High-altitude airways (JET / RNAV_Q) - indigo. */
+  high: '#4338ca',
+  /** Regional / oceanic airways - muted slate. */
+  regional: '#94a3b8',
+} as const;
+
+/**
+ * Airspace polygon fill / outline palette keyed by airspace class. Class
+ * E variants (E2-E7) all share `classE`, mirroring how sectional charts
+ * use a single magenta family for every Class E subtype. `fallback` is
+ * the default for any unrecognized future `AirspaceType` value.
+ */
+export const CHART_AIRSPACE_COLORS = {
+  /** Class B terminal airspace (blue-900). */
+  classB: '#1e3a8a',
+  /** Class C terminal airspace (rose-900). */
+  classC: '#be185d',
+  /** Class D terminal airspace (blue-600). */
+  classD: '#2563eb',
+  /** Class E surface airspace and all E2-E7 subtypes (pink-600). */
+  classE: '#ec4899',
+  /** Military Operations Area (amber-600). */
+  moa: '#d97706',
+  /** Restricted area (red-600). */
+  restricted: '#dc2626',
+  /** Prohibited area (red-900). */
+  prohibited: '#991b1b',
+  /** Warning area (orange-600). */
+  warning: '#f97316',
+  /** Alert area (yellow-400). */
+  alert: '#facc15',
+  /** National Security Area (gray-500). */
+  nsa: '#6b7280',
+  /** ARTCC boundary (slate-400). */
+  artcc: '#94a3b8',
+  /** Catch-all for unrecognized airspace types (slate-500). */
+  fallback: '#64748b',
+} as const;
+
+/**
+ * Airspace per-feature badge label colors. The badge is the small
+ * centroid label ("1", "2", "LOW", "HIGH") that disambiguates polygons
+ * inside a multi-feature airspace grouping.
+ */
+export const CHART_AIRSPACE_BADGE_COLORS = {
+  /** Badge text color (light yellow). */
+  text: '#fef08a',
+  /** Halo color drawn around badge text for legibility against any basemap or fill. */
+  halo: '#0f172a',
+} as const;

--- a/apps/atlas/src/shared/styles/use-can-hover.ts
+++ b/apps/atlas/src/shared/styles/use-can-hover.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * CSS media query that resolves true when the primary input device can
+ * hover - mouse / trackpad on a desktop or laptop. Resolves false on
+ * touch-only devices like phones and most tablets, even though those
+ * devices synthesize `mouseenter` events from a tap. Used to gate
+ * hover-preview affordances (chip-hover camera pan, popover-item
+ * highlight on hover) so they do not fire from synthesized touch
+ * events.
+ */
+const HOVER_QUERY = '(hover: hover)';
+
+/**
+ * Returns whether the user's primary input device supports a real
+ * hover gesture. Subscribes to `change` events on the underlying
+ * `MediaQueryList` so the value updates if the user attaches or
+ * detaches a mouse mid-session (rare on phones, common on
+ * iPad-with-trackpad and Surface tablets).
+ *
+ * Use this to conditionally attach `onMouseEnter` / `onMouseLeave`
+ * handlers - omit them on `(hover: none)` so synthesized mouse events
+ * from taps do not trigger preview-and-restore artifacts. Keep
+ * `onFocus` / `onBlur` attached regardless so keyboard navigation
+ * still drives the same affordance on any device.
+ */
+export function useCanHover(): boolean {
+  const [canHover, setCanHover] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia(HOVER_QUERY).matches;
+  });
+  useEffect((): (() => void) | undefined => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const mq = window.matchMedia(HOVER_QUERY);
+    function handleChange(event: MediaQueryListEvent): void {
+      setCanHover(event.matches);
+    }
+    mq.addEventListener('change', handleChange);
+    return (): void => {
+      mq.removeEventListener('change', handleChange);
+    };
+  }, []);
+  return canHover;
+}

--- a/apps/atlas/src/shell/mode-switcher.tsx
+++ b/apps/atlas/src/shell/mode-switcher.tsx
@@ -46,8 +46,8 @@ function ModeLink({ to, children }: ModeLinkProps): ReactElement {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const active = pathname === to || pathname.startsWith(`${to}/`);
   const className = active
-    ? 'rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-white'
-    : 'rounded-md px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100';
+    ? 'inline-flex items-center rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white md:py-1.5'
+    : 'inline-flex items-center rounded-md px-3 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-100 md:py-1.5';
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {

--- a/apps/atlas/src/test-setup.ts
+++ b/apps/atlas/src/test-setup.ts
@@ -8,9 +8,30 @@
  * not enable test-framework globals by default, so RTL's auto-cleanup
  * cannot register itself and components from prior tests would otherwise
  * accumulate in the document.
+ *
+ * Provides a minimal `window.matchMedia` shim for jsdom, which omits the
+ * API entirely. Defaults every query to `matches: true` so hooks like
+ * `useCanHover` (which inspects `(hover: hover)`) treat the test
+ * environment as a desktop with a real hover gesture - matching the
+ * default UX that hover-dependent specs were originally written
+ * against. Tests that need to exercise the touch / no-hover path can
+ * override this per-suite by stubbing `window.matchMedia`.
  */
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addListener: (): void => {},
+    removeListener: (): void => {},
+    addEventListener: (): void => {},
+    removeEventListener: (): void => {},
+    dispatchEvent: (): boolean => false,
+  });
+}
 
 afterEach(cleanup);


### PR DESCRIPTION
Replace inline hex literals with semantic chart-color tokens, pivot the inspector to a mobile bottom sheet with 44px touch targets, and gate hover-preview affordances on `(hover: hover)` so touch taps commit cleanly without synthesized-event flicker.