### PR TITLE
Improve atlas chart rendering and inspector hover affordances

### DIFF
--- a/apps/atlas/src/modes/chart/chart-mode.tsx
+++ b/apps/atlas/src/modes/chart/chart-mode.tsx
@@ -17,7 +17,7 @@ import { ChartViewResetListener } from './view-reset-listener.tsx';
 import { LayerToggle } from './layer-toggle.tsx';
 import { AirportsLayer } from './layers/airports-layer.tsx';
 import { AirspaceFeatureOverlayLayers, AirspaceLayer } from './layers/airspace-layer.tsx';
-import { AirwaysLayer } from './layers/airways-layer.tsx';
+import { AirwayLegFocusLayer, AirwaysLayer } from './layers/airways-layer.tsx';
 import { FixesLayer } from './layers/fixes-layer.tsx';
 import { NavaidsLayer } from './layers/navaids-layer.tsx';
 import { CHART_ROUTE_PATH } from './url-state.ts';
@@ -82,6 +82,15 @@ export function ChartMode(): ReactElement {
   // mouseLeave; component-local because the hover state should not survive
   // refreshes or be shareable via URL.
   const [hoveredFeatureIndex, setHoveredFeatureIndex] = useState<number | undefined>(undefined);
+  // Index of the airway waypoint row that's currently hovered in the
+  // inspector, used by the airway focus layer to brighten the
+  // matching waypoint dot (and, when index > 0, its incoming leg) and
+  // by the row-hover-pan hook to ease the camera if that area is
+  // offscreen. Cleared on mouseLeave; component-local for the same
+  // reasons as `hoveredFeatureIndex`.
+  const [hoveredAirwayWaypointIndex, setHoveredAirwayWaypointIndex] = useState<number | undefined>(
+    undefined,
+  );
   // Snapshot of the most recent click that the click classifier ruled
   // ambiguous (e.g. an airway intersection or two close VORs at the
   // same pixel). Drives the disambiguation popover - when set, the
@@ -203,6 +212,8 @@ export function ChartMode(): ReactElement {
         setHoveredChipSelection={setHoveredChipSelection}
         hoveredFeatureIndex={hoveredFeatureIndex}
         setHoveredFeatureIndex={setHoveredFeatureIndex}
+        hoveredAirwayWaypointIndex={hoveredAirwayWaypointIndex}
+        setHoveredAirwayWaypointIndex={setHoveredAirwayWaypointIndex}
       >
         <MapCanvas
           lat={lat}
@@ -226,6 +237,14 @@ export function ChartMode(): ReactElement {
             symbols and get visually clipped.
           */}
           {layers.includes('airspace') ? <AirspaceFeatureOverlayLayers /> : null}
+          {/*
+            Airway-leg focus mounts after the airspace overlay so a
+            hovered leg's brighter stroke sits above every base layer
+            and above the airspace feature focus / badge stack. The
+            component returns null whenever the active selection is
+            not an airway, so it costs nothing for non-airway views.
+          */}
+          {layers.includes('airways') ? <AirwayLegFocusLayer /> : null}
         </MapCanvas>
         <InspectableHoverCursor />
         <ChartViewResetListener />

--- a/apps/atlas/src/modes/chart/disambiguation-popover.spec.tsx
+++ b/apps/atlas/src/modes/chart/disambiguation-popover.spec.tsx
@@ -51,6 +51,8 @@ function withProvider(
         setHoveredChipSelection={setHoveredChipSelection}
         hoveredFeatureIndex={undefined}
         setHoveredFeatureIndex={vi.fn()}
+        hoveredAirwayWaypointIndex={undefined}
+        setHoveredAirwayWaypointIndex={vi.fn()}
       >
         {children}
       </HighlightProvider>
@@ -413,6 +415,81 @@ describe('DisambiguationPopover', () => {
     expect(handler).toBeDefined();
     handler?.();
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('orders airspace rows by altitude descending and keeps non-airspace rows ahead of them', () => {
+    // MapLibre's z-order returns points/lines before polygons, so a
+    // realistic candidate list looks like [airport, low MOA, high MOA].
+    // After the popover's sort, the airport stays first (it has no
+    // altitude key) and the airspace rows reorder to high-then-low so
+    // the popover reads top-down by altitude.
+    const airport = buildFeature(AIRPORTS_LAYER_ID, { faaId: 'BOS' });
+    const moaLow = buildFeature(AIRSPACE_FILL_LAYER_ID, {
+      type: 'MOA',
+      identifier: 'MEUREKAL',
+      __atlasFloorFt: 0,
+      __atlasFloorRef: 'SFC',
+      __atlasCeilingFt: 10000,
+      __atlasCeilingRef: 'MSL',
+    });
+    const moaHigh = buildFeature(AIRSPACE_FILL_LAYER_ID, {
+      type: 'MOA',
+      identifier: 'MEUREKAH',
+      __atlasFloorFt: 11000,
+      __atlasFloorRef: 'MSL',
+      __atlasCeilingFt: 18000,
+      __atlasCeilingRef: 'MSL',
+    });
+    render(
+      <DisambiguationPopover
+        screen={{ x: 0, y: 0 }}
+        candidates={[airport, moaLow, moaHigh]}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      { wrapper: withProvider(vi.fn()) },
+    );
+
+    const rows = screen.getAllByRole('menuitem');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('BOS');
+    expect(rows[1]).toHaveTextContent('MEUREKAH');
+    expect(rows[2]).toHaveTextContent('MEUREKAL');
+  });
+
+  it('breaks airspace ties by floor descending so concentric Class B rings read outer-first', () => {
+    // Inner ring (10k/SFC) and outer ring (10k/3000 MSL) share a
+    // ceiling. The outer ring's higher floor should put it first when
+    // ceilings tie, matching the chart "altitude band, top down" model.
+    const innerRing = buildFeature(AIRSPACE_FILL_LAYER_ID, {
+      type: 'CLASS_B',
+      identifier: 'JFK-INNER',
+      __atlasFloorFt: 0,
+      __atlasFloorRef: 'SFC',
+      __atlasCeilingFt: 10000,
+      __atlasCeilingRef: 'MSL',
+    });
+    const outerRing = buildFeature(AIRSPACE_FILL_LAYER_ID, {
+      type: 'CLASS_B',
+      identifier: 'JFK-OUTER',
+      __atlasFloorFt: 3000,
+      __atlasFloorRef: 'MSL',
+      __atlasCeilingFt: 10000,
+      __atlasCeilingRef: 'MSL',
+    });
+    render(
+      <DisambiguationPopover
+        screen={{ x: 0, y: 0 }}
+        candidates={[innerRing, outerRing]}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      { wrapper: withProvider(vi.fn()) },
+    );
+
+    const rows = screen.getAllByRole('menuitem');
+    expect(rows[0]).toHaveTextContent('JFK-OUTER');
+    expect(rows[1]).toHaveTextContent('JFK-INNER');
   });
 
   it('renders an altitude subtitle for airspace rows that distinguishes vertically-stacked features', () => {

--- a/apps/atlas/src/modes/chart/disambiguation-popover.tsx
+++ b/apps/atlas/src/modes/chart/disambiguation-popover.tsx
@@ -15,6 +15,8 @@ import { AIRWAYS_LAYER_ID } from './layers/airways-layer.tsx';
 import { FIXES_LAYER_ID } from './layers/fixes-layer.tsx';
 import { NAVAIDS_LAYER_ID } from './layers/navaids-layer.tsx';
 import { useCanHover } from '../../shared/styles/use-can-hover.ts';
+import { compareAirspaceByAltitudeDesc } from '../../shared/inspector/airspace-feature.ts';
+import type { AirspaceAltitudeKey } from '../../shared/inspector/airspace-feature.ts';
 import { formatChipLabel, selectedFromFeature } from './click-to-select.ts';
 import type { InspectableFeature } from './click-to-select.ts';
 import { useSetHoveredChipSelection } from './highlight-context.ts';
@@ -101,9 +103,19 @@ export function DisambiguationPopover({
   // "11k-18k" or "SFC-10k") so two MOA components or ARTCC strata that
   // share an identical lateral polygon - and therefore an identical map
   // highlight - remain visually distinguishable in the list.
+  //
+  // Airspace rows are then sorted by altitude descending (highest
+  // ceiling first, floor as tie-break) so a stack of vertically-layered
+  // airspaces (Class B + ARTCC + Class E5; MOA HIGH + MOA LOW) reads
+  // top-down. Non-airspace rows keep their MapLibre z-order position
+  // since they have no altitude to sort against; in practice
+  // queryRenderedFeatures returns them ahead of airspace anyway, so
+  // the visible result is "points/lines first, then airspace by
+  // altitude".
   const entries = useMemo<readonly PopoverEntry[]>(() => {
     const seen = new Set<string>();
-    const result: PopoverEntry[] = [];
+    const nonAirspace: PopoverEntry[] = [];
+    const airspace: { entry: PopoverEntry; key: AirspaceAltitudeKey }[] = [];
     for (const feature of candidates) {
       const selection = selectedFromFeature(feature);
       if (selection === undefined) {
@@ -118,14 +130,21 @@ export function DisambiguationPopover({
       }
       seen.add(selection);
       const subtitle = subtitleForFeature(feature);
-      result.push({
+      const entry: PopoverEntry = {
         selection,
         type,
         label: formatChipLabel(feature),
         ...(subtitle !== undefined && { subtitle }),
-      });
+      };
+      const altitudeKey = readAirspaceAltitudeKey(feature);
+      if (altitudeKey === undefined) {
+        nonAirspace.push(entry);
+      } else {
+        airspace.push({ entry, key: altitudeKey });
+      }
     }
-    return result;
+    airspace.sort((a, b) => compareAirspaceByAltitudeDesc(a.key, b.key));
+    return [...nonAirspace, ...airspace.map((it) => it.entry)];
   }, [candidates]);
 
   useEffect((): (() => void) => {
@@ -413,4 +432,28 @@ function readBoundPrimitives(
     return undefined;
   }
   return { valueFt, reference };
+}
+
+/**
+ * Reads an {@link AirspaceAltitudeKey} from an airspace feature's
+ * synthetic floor/ceiling primitive properties, used to drive the
+ * altitude-descending sort. Returns `undefined` for non-airspace
+ * features and for airspace features whose primitives are missing
+ * - those rows fall through to the non-airspace bucket and keep
+ * their natural MapLibre z-order position.
+ */
+function readAirspaceAltitudeKey(feature: InspectableFeature): AirspaceAltitudeKey | undefined {
+  if (feature.layer.id !== AIRSPACE_FILL_LAYER_ID && feature.layer.id !== AIRSPACE_LINE_LAYER_ID) {
+    return undefined;
+  }
+  const props = feature.properties;
+  if (props === null) {
+    return undefined;
+  }
+  const ceilingFt = props[AIRSPACE_CEILING_FT_PROPERTY];
+  const floorFt = props[AIRSPACE_FLOOR_FT_PROPERTY];
+  if (typeof ceilingFt !== 'number' || typeof floorFt !== 'number') {
+    return undefined;
+  }
+  return { ceilingFt, floorFt };
 }

--- a/apps/atlas/src/modes/chart/highlight-context.spec.tsx
+++ b/apps/atlas/src/modes/chart/highlight-context.spec.tsx
@@ -3,7 +3,9 @@ import { render, renderHook } from '@testing-library/react';
 import type { ReactElement, ReactNode } from 'react';
 import {
   useActiveHighlightRef,
+  useHoveredAirwayWaypointIndex,
   useHoveredFeatureIndex,
+  useSetHoveredAirwayWaypointIndex,
   useSetHoveredChipSelection,
   useSetHoveredFeatureIndex,
 } from './highlight-context.ts';
@@ -14,6 +16,8 @@ function wrap(
   setHoveredChipSelection: (selection: string | undefined) => void = vi.fn(),
   hoveredFeatureIndex: number | undefined = undefined,
   setHoveredFeatureIndex: (index: number | undefined) => void = vi.fn(),
+  hoveredAirwayWaypointIndex: number | undefined = undefined,
+  setHoveredAirwayWaypointIndex: (index: number | undefined) => void = vi.fn(),
 ): (props: { children: ReactNode }) => ReactElement {
   function Wrapper({ children }: { children: ReactNode }): ReactElement {
     return (
@@ -22,6 +26,8 @@ function wrap(
         setHoveredChipSelection={setHoveredChipSelection}
         hoveredFeatureIndex={hoveredFeatureIndex}
         setHoveredFeatureIndex={setHoveredFeatureIndex}
+        hoveredAirwayWaypointIndex={hoveredAirwayWaypointIndex}
+        setHoveredAirwayWaypointIndex={setHoveredAirwayWaypointIndex}
       >
         {children}
       </HighlightProvider>
@@ -95,11 +101,46 @@ describe('HighlightProvider rendering', () => {
         setHoveredChipSelection={() => {}}
         hoveredFeatureIndex={undefined}
         setHoveredFeatureIndex={() => {}}
+        hoveredAirwayWaypointIndex={undefined}
+        setHoveredAirwayWaypointIndex={() => {}}
       >
         <span>child content</span>
       </HighlightProvider>,
     );
     expect(getByText('child content')).toBeInTheDocument();
+  });
+});
+
+describe('useHoveredAirwayWaypointIndex', () => {
+  it('returns the provider-supplied waypoint index', () => {
+    const { result } = renderHook(() => useHoveredAirwayWaypointIndex(), {
+      wrapper: wrap(undefined, vi.fn(), undefined, vi.fn(), 3),
+    });
+    expect(result.current).toBe(3);
+  });
+
+  it('returns undefined when no provider is mounted', () => {
+    const { result } = renderHook(() => useHoveredAirwayWaypointIndex());
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useSetHoveredAirwayWaypointIndex', () => {
+  it('forwards the supplied setter', () => {
+    const setter = vi.fn();
+    const { result } = renderHook(() => useSetHoveredAirwayWaypointIndex(), {
+      wrapper: wrap(undefined, vi.fn(), undefined, vi.fn(), undefined, setter),
+    });
+    result.current(2);
+    expect(setter).toHaveBeenCalledWith(2);
+    result.current(undefined);
+    expect(setter).toHaveBeenCalledWith(undefined);
+  });
+
+  it('returns a no-op setter when no provider is mounted', () => {
+    const { result } = renderHook(() => useSetHoveredAirwayWaypointIndex());
+    expect(() => result.current(1)).not.toThrow();
+    expect(() => result.current(undefined)).not.toThrow();
   });
 });
 

--- a/apps/atlas/src/modes/chart/highlight-context.ts
+++ b/apps/atlas/src/modes/chart/highlight-context.ts
@@ -36,6 +36,26 @@ export interface HighlightContextValue {
    * to clear).
    */
   setHoveredFeatureIndex: (index: number | undefined) => void;
+  /**
+   * Index of the currently-hovered airway waypoint row within the
+   * active entity's `waypoints` array, or `undefined` when no row is
+   * hovered. The airway focus layer reads this to brighten the
+   * waypoint dot at `waypoints[i]` AND, when `i > 0`, the incoming
+   * leg from `waypoints[i - 1]` to `waypoints[i]`. Index `0` is the
+   * route's starting waypoint (no incoming leg, just the dot).
+   *
+   * Only meaningful for airway selections; ignored for other entity
+   * types.
+   */
+  hoveredAirwayWaypointIndex: number | undefined;
+  /**
+   * Sets the currently-hovered airway waypoint index. The airway
+   * inspector panel calls this on per-row mouseEnter / mouseLeave
+   * (with `undefined` to clear). Wired only on hover-capable devices
+   * via the inspector's existing `useCanHover()` gate so touch
+   * devices never fire it.
+   */
+  setHoveredAirwayWaypointIndex: (index: number | undefined) => void;
 }
 
 /**
@@ -87,6 +107,26 @@ export function useSetHoveredFeatureIndex(): (index: number | undefined) => void
   return ctx?.setHoveredFeatureIndex ?? noopFeatureIndexSetter;
 }
 
+/**
+ * Returns the index of the currently-hovered airway waypoint row
+ * within the active airway's `waypoints` array, or `undefined`.
+ * Consumed by the airway focus layer (which brightens the waypoint
+ * dot AND its incoming leg when index > 0) and by the row-hover-pan
+ * hook (which eases the camera if that area is offscreen).
+ */
+export function useHoveredAirwayWaypointIndex(): number | undefined {
+  return useContext(HighlightContext)?.hoveredAirwayWaypointIndex;
+}
+
+/**
+ * Returns the setter the airway inspector panel calls on per-row
+ * mouseEnter / mouseLeave. No-op when no provider is mounted.
+ */
+export function useSetHoveredAirwayWaypointIndex(): (index: number | undefined) => void {
+  const ctx = useContext(HighlightContext);
+  return ctx?.setHoveredAirwayWaypointIndex ?? noopWaypointIndexSetter;
+}
+
 /** Stable no-op setter used when the inspector renders without a provider. */
 function noopChipSelectionSetter(): void {
   // intentionally empty
@@ -94,5 +134,10 @@ function noopChipSelectionSetter(): void {
 
 /** Stable no-op feature-index setter used when no provider is mounted. */
 function noopFeatureIndexSetter(): void {
+  // intentionally empty
+}
+
+/** Stable no-op waypoint-index setter used when no provider is mounted. */
+function noopWaypointIndexSetter(): void {
   // intentionally empty
 }

--- a/apps/atlas/src/modes/chart/highlight-provider.tsx
+++ b/apps/atlas/src/modes/chart/highlight-provider.tsx
@@ -31,6 +31,18 @@ export interface HighlightProviderProps {
    * mouseEnter / mouseLeave.
    */
   setHoveredFeatureIndex: (index: number | undefined) => void;
+  /**
+   * Index of the currently-hovered airway waypoint row within the
+   * active airway's `waypoints` array, or `undefined` when no
+   * inspector row is hovered. Drives the airway focus layer (waypoint
+   * dot + incoming leg) and the row-hover-pan hook.
+   */
+  hoveredAirwayWaypointIndex: number | undefined;
+  /**
+   * Callback the airway inspector panel calls on per-row
+   * mouseEnter / mouseLeave (hover-capable devices only).
+   */
+  setHoveredAirwayWaypointIndex: (index: number | undefined) => void;
   /** Children that may consume the context via the exported hooks. */
   children: ReactNode;
 }
@@ -49,6 +61,8 @@ export function HighlightProvider({
   setHoveredChipSelection,
   hoveredFeatureIndex,
   setHoveredFeatureIndex,
+  hoveredAirwayWaypointIndex,
+  setHoveredAirwayWaypointIndex,
   children,
 }: HighlightProviderProps): ReactElement {
   const value = useMemo<HighlightContextValue>(
@@ -57,8 +71,17 @@ export function HighlightProvider({
       setHoveredChipSelection,
       hoveredFeatureIndex,
       setHoveredFeatureIndex,
+      hoveredAirwayWaypointIndex,
+      setHoveredAirwayWaypointIndex,
     }),
-    [activeHighlight, setHoveredChipSelection, hoveredFeatureIndex, setHoveredFeatureIndex],
+    [
+      activeHighlight,
+      setHoveredChipSelection,
+      hoveredFeatureIndex,
+      setHoveredFeatureIndex,
+      hoveredAirwayWaypointIndex,
+      setHoveredAirwayWaypointIndex,
+    ],
   );
   return <HighlightContext.Provider value={value}>{children}</HighlightContext.Provider>;
 }

--- a/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
@@ -14,7 +14,7 @@ interface NavigateArg {
 }
 
 /** Subset of the search shape the toggle reads via `route.useSearch()`. */
-type ToggleSearch = Pick<ChartSearch, 'layers' | 'airspaceClasses' | 'airwayCategories'>;
+type ToggleSearch = Pick<ChartSearch, 'layers' | 'airspaceClasses' | 'airwayCategories' | 'zoom'>;
 
 const { useSearchMock, navigateMock } = vi.hoisted(() => ({
   useSearchMock: vi.fn<() => ToggleSearch>(),
@@ -144,12 +144,19 @@ function applyLatestSearchUpdate(prev: ChartSearch): ChartSearch {
   return lastCall[0].search(prev);
 }
 
-/** Builds a complete `ToggleSearch` with the all-on defaults plus overrides. */
+/**
+ * Builds a complete `ToggleSearch` with the all-on defaults plus overrides.
+ * The default `zoom` is intentionally above every threshold in `LAYER_MIN_ZOOM`
+ * so existing tests (which do not care about the zoom-gated hint) see no
+ * extra "Zoom N+" badges in their rendered rows. Hint-specific tests override
+ * `zoom` to a value below the threshold they want to exercise.
+ */
 function makeSearch(overrides: Partial<ToggleSearch> = {}): ToggleSearch {
   return {
     layers: [...LAYER_IDS],
     airspaceClasses: [...AIRSPACE_CLASSES],
     airwayCategories: [...AIRWAY_CATEGORIES],
+    zoom: 10,
     ...overrides,
   };
 }
@@ -502,5 +509,68 @@ describe('LayerToggle', () => {
       screen.queryByRole('menuitemcheckbox', { name: /low altitude/i }),
     ).not.toBeInTheDocument();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  describe('zoom-gated hints', () => {
+    it('shows the hint on every gated row when current zoom is below all thresholds', () => {
+      // At zoom 4 (the chart-mode default), navaids (minzoom 5) and fixes
+      // (minzoom 7) are gated. Each row should advertise its own threshold
+      // so a user toggling that layer on knows when it will appear. Airways
+      // does not carry the hint here even though some of its features are
+      // zoom-gated internally - the layer always renders the major
+      // (HIGH-altitude) backbone, so toggling it on is never a "nothing
+      // happens" experience.
+      useSearchMock.mockReturnValue(makeSearch({ zoom: 4 }));
+      render(<LayerToggle />);
+
+      expect(within(getParentRow('fixes')).getByText('Zoom 7+')).toBeInTheDocument();
+      expect(within(getParentRow('navaids')).getByText('Zoom 5+')).toBeInTheDocument();
+      expect(within(getParentRow('airways')).queryByText(/Zoom \d+\+/)).toBeNull();
+    });
+
+    it('omits the hint for layers that have no minzoom regardless of current zoom', () => {
+      useSearchMock.mockReturnValue(makeSearch({ zoom: 4 }));
+      render(<LayerToggle />);
+
+      // airports, airspace, and airways have no entry in LAYER_MIN_ZOOM
+      // and must never carry the hint, even at the lowest zoom levels.
+      // (Airways gates non-major features internally; see the airways
+      // layer for the per-feature filter.)
+      expect(within(getParentRow('airports')).queryByText(/Zoom \d+\+/)).toBeNull();
+      expect(within(getParentRow('airspace')).queryByText(/Zoom \d+\+/)).toBeNull();
+      expect(within(getParentRow('airways')).queryByText(/Zoom \d+\+/)).toBeNull();
+    });
+
+    it('hides the hint once the current zoom has reached the layer threshold', () => {
+      // At zoom 5 the navaid gate has just opened (minzoom 5), so its
+      // hint disappears; fixes (minzoom 7) is still ahead. Airways
+      // never carries the hint at any zoom (gating is per-feature).
+      useSearchMock.mockReturnValue(makeSearch({ zoom: 5 }));
+      render(<LayerToggle />);
+
+      expect(within(getParentRow('navaids')).queryByText(/Zoom \d+\+/)).toBeNull();
+      expect(within(getParentRow('airways')).queryByText(/Zoom \d+\+/)).toBeNull();
+      expect(within(getParentRow('fixes')).getByText('Zoom 7+')).toBeInTheDocument();
+    });
+
+    it('hides the hint on every row when current zoom is above all thresholds', () => {
+      useSearchMock.mockReturnValue(makeSearch({ zoom: 12 }));
+      render(<LayerToggle />);
+
+      for (const id of ['airports', 'navaids', 'fixes', 'airways', 'airspace'] as const) {
+        expect(within(getParentRow(id)).queryByText(/Zoom \d+\+/)).toBeNull();
+      }
+    });
+
+    it('exposes the threshold to assistive tech via aria-label', () => {
+      useSearchMock.mockReturnValue(makeSearch({ zoom: 4 }));
+      render(<LayerToggle />);
+
+      // Screen readers benefit from the full sentence rather than the
+      // compact "Zoom 7+" glyph; aria-label is the canonical mechanism here.
+      expect(
+        within(getParentRow('fixes')).getByLabelText('Appears at zoom 7 and above'),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/apps/atlas/src/modes/chart/layer-toggle.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.tsx
@@ -2,7 +2,13 @@ import { Fragment, useCallback, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, PointerEvent, ReactElement } from 'react';
 import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { AIRSPACE_CLASSES, AIRWAY_CATEGORIES, CHART_ROUTE_PATH, LAYER_IDS } from './url-state.ts';
+import {
+  AIRSPACE_CLASSES,
+  AIRWAY_CATEGORIES,
+  CHART_ROUTE_PATH,
+  LAYER_IDS,
+  LAYER_MIN_ZOOM,
+} from './url-state.ts';
 import type { AirspaceClass, AirwayCategory, LayerId } from './url-state.ts';
 
 const route = getRouteApi(CHART_ROUTE_PATH);
@@ -85,7 +91,7 @@ const AIRWAY_CATEGORY_OPTIONS: readonly AirwayCategoryOption[] = [
  * users can flip several at once.
  */
 export function LayerToggle(): ReactElement {
-  const { layers, airspaceClasses, airwayCategories } = route.useSearch();
+  const { layers, airspaceClasses, airwayCategories, zoom } = route.useSearch();
   const navigate = useNavigate({ from: CHART_ROUTE_PATH });
   const [expanded, setExpanded] = useState<ReadonlySet<LayerId>>(() => new Set());
 
@@ -223,6 +229,12 @@ export function LayerToggle(): ReactElement {
           {LAYER_OPTIONS.map((option) => {
             const isExpandable = EXPANDABLE_LAYERS.has(option.id);
             const parentChecked = layers.includes(option.id);
+            // Resolve the layer's zoom-gating threshold from the central
+            // table and pass it through only when the current map zoom is
+            // below it. Above the threshold (or when the layer has no
+            // entry) the hint is suppressed by passing undefined.
+            const minZoom = LAYER_MIN_ZOOM[option.id];
+            const hintMinZoom = minZoom !== undefined && zoom < minZoom ? minZoom : undefined;
             return (
               <Fragment key={option.id}>
                 {isExpandable ? (
@@ -238,12 +250,14 @@ export function LayerToggle(): ReactElement {
                     totalCount={
                       option.id === 'airways' ? AIRWAY_CATEGORIES.length : AIRSPACE_CLASSES.length
                     }
+                    hintMinZoom={hintMinZoom}
                   />
                 ) : (
                   <SimpleParentRow
                     label={option.label}
                     checked={parentChecked}
                     onCheckedChange={(checked) => handleLayerChange(option.id, checked)}
+                    hintMinZoom={hintMinZoom}
                   />
                 )}
                 {option.id === 'airways' && expanded.has('airways')
@@ -283,6 +297,14 @@ interface SimpleParentRowProps {
   checked: boolean;
   /** Called with the new checked state when the row is toggled. */
   onCheckedChange: (checked: boolean) => void;
+  /**
+   * Minimum zoom at which this layer paints, when the current map zoom is
+   * below it. Drives the inline "appears at z N+" hint so a user toggling
+   * the layer on at low zoom understands why nothing has appeared. Absent
+   * means no hint (either the layer has no zoom gating, or the user is
+   * already above the threshold).
+   */
+  hintMinZoom: number | undefined;
 }
 
 /**
@@ -290,7 +312,12 @@ interface SimpleParentRowProps {
  * Radix `CheckboxItem` semantics, identical to today's behavior for the
  * three non-expandable layers.
  */
-function SimpleParentRow({ label, checked, onCheckedChange }: SimpleParentRowProps): ReactElement {
+function SimpleParentRow({
+  label,
+  checked,
+  onCheckedChange,
+  hintMinZoom,
+}: SimpleParentRowProps): ReactElement {
   return (
     <DropdownMenu.CheckboxItem
       checked={checked}
@@ -304,6 +331,7 @@ function SimpleParentRow({ label, checked, onCheckedChange }: SimpleParentRowPro
         </DropdownMenu.ItemIndicator>
       </span>
       <span className="flex-1">{label}</span>
+      {hintMinZoom !== undefined ? <ZoomGatedHint minZoom={hintMinZoom} /> : null}
     </DropdownMenu.CheckboxItem>
   );
 }
@@ -324,6 +352,14 @@ interface ExpandableParentRowProps {
   enabledCount: number;
   /** Total sub-classes / categories available, for the chip. */
   totalCount: number;
+  /**
+   * Minimum zoom at which this layer paints, when the current map zoom is
+   * below it. Drives the inline "appears at z N+" hint so a user toggling
+   * the layer on at low zoom understands why nothing has appeared. Absent
+   * means no hint (either the layer has no zoom gating, or the user is
+   * already above the threshold).
+   */
+  hintMinZoom: number | undefined;
 }
 
 /**
@@ -346,6 +382,7 @@ function ExpandableParentRow({
   onToggleExpanded,
   enabledCount,
   totalCount,
+  hintMinZoom,
 }: ExpandableParentRowProps): ReactElement {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === 'ArrowRight' && !expanded) {
@@ -370,6 +407,7 @@ function ExpandableParentRow({
         </DropdownMenu.ItemIndicator>
       </span>
       <span className="flex-1">{label}</span>
+      {hintMinZoom !== undefined ? <ZoomGatedHint minZoom={hintMinZoom} /> : null}
       <SubCountChip enabled={enabledCount} total={totalCount} dimmed={!checked} />
       <ExpandToggleButton label={label} expanded={expanded} onToggleExpanded={onToggleExpanded} />
     </DropdownMenu.CheckboxItem>
@@ -488,6 +526,32 @@ function SubCountChip({ enabled, total, dimmed }: SubCountChipProps): ReactEleme
       aria-label={`${enabled} of ${total} enabled`}
     >
       {enabled}/{total}
+    </span>
+  );
+}
+
+/** Props for {@link ZoomGatedHint}. */
+interface ZoomGatedHintProps {
+  /** Minimum zoom at which the gated layer paints. */
+  minZoom: number;
+}
+
+/**
+ * Inline "Zoom N+" indicator shown next to a layer row when the current
+ * map zoom is below the layer's `minzoom`. Tells the user the layer is
+ * on (or would be on) but is not painting yet because the camera is too
+ * far out. Reads the same threshold as the MapLibre `Layer` so the
+ * advertised number always matches the real cutoff. The `Zoom` prefix
+ * spells out the unit so the chip pairs cleanly with the current-zoom
+ * readout in the bottom-left zoom controls (also a numeric value).
+ */
+function ZoomGatedHint({ minZoom }: ZoomGatedHintProps): ReactElement {
+  return (
+    <span
+      className="inline-flex shrink-0 items-center rounded-sm border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-slate-500"
+      aria-label={`Appears at zoom ${minZoom} and above`}
+    >
+      Zoom {minZoom}+
     </span>
   );
 }

--- a/apps/atlas/src/modes/chart/layers/airports-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airports-layer.tsx
@@ -108,31 +108,50 @@ const AIRPORTS_HIGHLIGHT_LAYER_BASE: LayerProps = {
 };
 
 /**
- * MapLibre layer styling. Radius interpolates by zoom and is gated by
- * runway length, so large airports stay visible at low zoom while smaller
- * fields appear as the user zooms in. Color separates major airports
- * (longest runway >= 8000 ft) from the rest.
+ * Per-tier zoom thresholds. An airport is visible at the current zoom
+ * iff its tier's threshold is met. A `circle-radius: 0` paint stop is
+ * not enough on its own - MapLibre still draws the 1px white stroke
+ * around a zero-radius circle, leaving thousands of speck-sized
+ * artifacts at CONUS zoom. The visibility filter on the layer below
+ * skips those features entirely so they neither paint nor respond to
+ * `queryRenderedFeatures`.
+ */
+const AIRPORT_MID_TIER_MIN_ZOOM = 6;
+/** Visibility threshold for the 3000-4999 ft tier. */
+const AIRPORT_SMALL_TIER_MIN_ZOOM = 9;
+/** Visibility threshold for the < 3000 ft tier. */
+const AIRPORT_TINY_TIER_MIN_ZOOM = 12;
+
+/**
+ * MapLibre layer styling. Visibility is gated by runway length: only
+ * 8000-ft+ airports show at low zoom, mid-size fields appear at z6,
+ * smaller ones at z9, and the long tail at z12. Color separates major
+ * airports (longest runway >= 8000 ft) from the rest.
+ *
+ * Within a single zoom stop every visible airport renders at the same
+ * radius - the visibility filter controls *whether* an airport is
+ * visible, while the radius interpolation only controls how big the
+ * dot grows as the user zooms in. So when 5000-ft airports appear at
+ * z6 they pop in at the same dot size as the 8000-ft airports already
+ * on screen, rather than as tinier sub-class specks.
  */
 const AIRPORTS_LAYER_PROPS: LayerProps = {
   id: AIRPORTS_LAYER_ID,
   source: AIRPORTS_SOURCE_ID,
   type: 'circle',
-  paint: {
-    'circle-radius': [
-      'interpolate',
-      ['linear'],
-      ['zoom'],
-      4,
-      ['case', ['>=', ['get', 'longestRunwayFt'], 8000], 2.5, 0],
-      6,
-      ['case', ['>=', ['get', 'longestRunwayFt'], 5000], 3, 1],
-      9,
-      ['case', ['>=', ['get', 'longestRunwayFt'], 3000], 4, 2],
-      12,
-      5,
-      16,
-      10,
+  filter: [
+    'any',
+    ['>=', ['get', 'longestRunwayFt'], 8000],
+    ['all', ['>=', ['zoom'], AIRPORT_MID_TIER_MIN_ZOOM], ['>=', ['get', 'longestRunwayFt'], 5000]],
+    [
+      'all',
+      ['>=', ['zoom'], AIRPORT_SMALL_TIER_MIN_ZOOM],
+      ['>=', ['get', 'longestRunwayFt'], 3000],
     ],
+    ['>=', ['zoom'], AIRPORT_TINY_TIER_MIN_ZOOM],
+  ],
+  paint: {
+    'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 2.5, 6, 3, 9, 4, 12, 5, 16, 10],
     'circle-color': [
       'case',
       ['>=', ['get', 'longestRunwayFt'], 8000],

--- a/apps/atlas/src/modes/chart/layers/airways-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airways-layer.tsx
@@ -4,18 +4,58 @@ import { getRouteApi } from '@tanstack/react-router';
 import { Source, Layer } from '@vis.gl/react-maplibre';
 import type { LayerProps } from '@vis.gl/react-maplibre';
 import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
-import type { Feature, FeatureCollection, MultiLineString } from 'geojson';
+import type {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  LineString,
+  MultiLineString,
+  Point,
+} from 'geojson';
 import type { Airway, AirwayType } from '@squawk/types';
 import { useAirwayDataset } from '../../../shared/data/airway-dataset.ts';
 import {
   CHART_AIRWAY_COLORS,
   CHART_HIGHLIGHT_COLORS,
 } from '../../../shared/styles/chart-colors.ts';
-import { useActiveHighlightRef } from '../highlight-context.ts';
+import { useActiveHighlightRef, useHoveredAirwayWaypointIndex } from '../highlight-context.ts';
 import { AIRWAY_CATEGORY_TYPES, CHART_ROUTE_PATH } from '../url-state.ts';
 import { buildSegments } from './airway-segments.ts';
 
 const route = getRouteApi(CHART_ROUTE_PATH);
+
+/**
+ * Per-feature zoom threshold below which non-major airways stop
+ * rendering. The high-altitude `JET` / `RNAV_Q` backbone (the long
+ * cross-country routes) is exempt and stays visible at every zoom so
+ * users can read end-to-end on the CONUS view; everything else
+ * (V-routes, T-routes, oceanic, Alaska colored) only paints once the
+ * camera has zoomed in far enough that the dense web is legible.
+ *
+ * Implemented as a per-feature filter (not a layer-level `minzoom`)
+ * because the layer is no longer all-or-nothing - the major subset
+ * always paints.
+ */
+const MINOR_AIRWAY_MIN_ZOOM = 5;
+
+/**
+ * Filter sub-expression that resolves to `true` for any airway feature
+ * that should render at the current camera zoom. A feature passes if
+ * either it belongs to the major (HIGH-altitude) bucket, or the camera
+ * is already at or past {@link MINOR_AIRWAY_MIN_ZOOM}. Composed into
+ * both the base layer's category filter and the selection-highlight
+ * filter so the yellow halo inherits the same gating - no stray
+ * highlight floats over a hidden V-route at low zoom.
+ *
+ * MapLibre re-evaluates the `["zoom"]` expression as the camera
+ * moves, so features fade in / out smoothly without a re-render of
+ * the GeoJSON source.
+ */
+const ZOOM_AWARE_VISIBILITY: ExpressionSpecification = [
+  'any',
+  ['in', ['get', 'type'], ['literal', [...AIRWAY_CATEGORY_TYPES.HIGH]]],
+  ['>=', ['zoom'], MINOR_AIRWAY_MIN_ZOOM],
+];
 
 /**
  * Properties carried on each airway line feature in the GeoJSON source.
@@ -52,7 +92,11 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 /**
  * Highlight overlay for the currently-selected (or chip-hovered) airway.
  * Thicker stroke in dark slate over a wider yellow halo so the airway
- * still reads as a line (not a band) at any zoom.
+ * still reads as a line (not a band) at any zoom. The per-render
+ * filter combines the entity-match clause with
+ * {@link ZOOM_AWARE_VISIBILITY} so the halo follows the same fade-in
+ * rules as the base layer - selecting a hidden V-route at low zoom
+ * does not leave a yellow ring floating over nothing.
  */
 const AIRWAYS_HIGHLIGHT_LAYER_BASE: LayerProps = {
   id: AIRWAYS_HIGHLIGHT_LAYER_ID,
@@ -104,7 +148,9 @@ function toFeatureCollection(
  * symbology. Color is tiered by airway type: low-altitude V-routes and
  * RNAV T-routes in slate, high-altitude J-routes and RNAV Q-routes in
  * indigo, regional and oceanic routes in muted gray. The visibility filter
- * is built per-render from the active `airwayCategories` URL state.
+ * is built per-render from the active `airwayCategories` URL state plus
+ * {@link ZOOM_AWARE_VISIBILITY} so non-major airways are zoom-gated at
+ * the feature level rather than hiding the entire layer.
  */
 const AIRWAYS_LAYER_BASE: LayerProps = {
   id: AIRWAYS_LAYER_ID,
@@ -149,7 +195,7 @@ export function AirwaysLayer(): ReactElement | null {
   );
 
   const filter = useMemo<ExpressionSpecification>(
-    () => ['in', ['get', 'type'], ['literal', [...enabledTypes]]],
+    () => ['all', ['in', ['get', 'type'], ['literal', [...enabledTypes]]], ZOOM_AWARE_VISIBILITY],
     [enabledTypes],
   );
 
@@ -158,7 +204,7 @@ export function AirwaysLayer(): ReactElement | null {
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const highlightFilter: ExpressionSpecification =
       activeRef?.type === 'airway'
-        ? ['==', ['get', 'designation'], activeRef.id]
+        ? ['all', ['==', ['get', 'designation'], activeRef.id], ZOOM_AWARE_VISIBILITY]
         : MATCH_NONE_FILTER;
     return { ...AIRWAYS_HIGHLIGHT_LAYER_BASE, filter: highlightFilter };
   }, [activeRef]);
@@ -180,6 +226,194 @@ export function AirwaysLayer(): ReactElement | null {
     <Source id={AIRWAYS_SOURCE_ID} type="geojson" data={data}>
       <Layer {...layerProps} />
       <Layer {...highlightLayerProps} />
+    </Source>
+  );
+}
+
+/** MapLibre source id for the airway-row focus overlay. */
+const AIRWAY_FOCUS_SOURCE_ID = 'atlas-airway-focus';
+
+/** MapLibre layer id for the focused waypoint dot. */
+const AIRWAY_WAYPOINT_FOCUS_LAYER_ID = 'atlas-airway-focus-waypoint';
+
+/** MapLibre layer id for the focused incoming-leg stroke. */
+const AIRWAY_LEG_FOCUS_LAYER_ID = 'atlas-airway-focus-leg';
+
+/**
+ * Discriminator string distinguishing leg LineString features from
+ * waypoint Point features in the same focus source. The single mixed
+ * source keeps the airway-focus geojson local to one component; each
+ * MapLibre layer's filter selects the right shape via this property.
+ */
+type AirwayFocusFeatureKind = 'leg' | 'waypoint';
+
+/**
+ * Properties carried on every focus feature. Both legs and waypoints
+ * share the source schema; the `kind` discriminator routes each
+ * feature to the matching MapLibre layer (line vs. circle), and
+ * `waypointIndex` is the canonical hover-target identifier:
+ *
+ * - For a `kind: 'waypoint'` feature, the index is its own position
+ *   in the active airway's `waypoints` array.
+ * - For a `kind: 'leg'` feature, the index is the END waypoint of the
+ *   leg (so leg index 1 connects waypoint 0 to waypoint 1, and is
+ *   tagged with `waypointIndex: 1`). This way both layers filter on
+ *   the same index value the inspector hover writes - no separate
+ *   `legIndex` arithmetic at the consumer.
+ */
+interface AirwayFocusProperties {
+  /** Discriminator: leg LineString vs. waypoint Point. */
+  kind: AirwayFocusFeatureKind;
+  /** Waypoint index this feature is keyed on (see interface docs). */
+  waypointIndex: number;
+}
+
+/**
+ * Filter expression that matches nothing. Used as the focus filter
+ * when no inspector row is hovered, so each layer renders empty
+ * without unmounting / re-mounting.
+ */
+const FOCUS_MATCH_NONE_FILTER: ExpressionSpecification = ['==', ['get', 'waypointIndex'], -1];
+
+/**
+ * Top-of-stack overlay that brightens the hovered waypoint and (when
+ * the row has an incoming leg) the leg ending at that waypoint. The
+ * inspector airway panel writes a context-stored waypoint index; this
+ * layer reads it and filters two layers off a shared geojson source -
+ * a circle layer for the waypoint dot, a line layer for the incoming
+ * leg.
+ *
+ * Hovering the first waypoint row (`waypointIndex === 0`) lights up
+ * just the dot - there is no incoming leg, and the line filter
+ * naturally excludes leg index 0 since legs are tagged with the END
+ * waypoint's index (which starts at 1). Hovering any other row lights
+ * up both the dot and the leg.
+ *
+ * The source rebuilds whenever the active airway changes - one Point
+ * per waypoint plus one LineString per consecutive waypoint pair -
+ * and is empty (returns null) for any non-airway selection. Mounted
+ * as a sibling of {@link AirwaysLayer} because the focus shapes need
+ * their own source so the data lifecycle is decoupled from the
+ * always-on airway dataset.
+ */
+export function AirwayLegFocusLayer(): ReactElement | null {
+  const activeRef = useActiveHighlightRef();
+  const hoveredWaypointIndex = useHoveredAirwayWaypointIndex();
+  const state = useAirwayDataset();
+
+  // Build the mixed waypoint + leg feature collection only when the
+  // active selection is an airway; otherwise keep the source absent
+  // so MapLibre does not hold a stale geojson around for a non-airway
+  // selection.
+  const data = useMemo<FeatureCollection<Geometry, AirwayFocusProperties> | undefined>(() => {
+    if (activeRef?.type !== 'airway' || activeRef.id.length === 0) {
+      return undefined;
+    }
+    if (state.status !== 'loaded') {
+      return undefined;
+    }
+    const airway = state.dataset.records.find((record) => record.designation === activeRef.id);
+    if (airway === undefined || airway.waypoints.length === 0) {
+      return undefined;
+    }
+    const features: Feature<Geometry, AirwayFocusProperties>[] = [];
+    // Waypoint Points (one per waypoint, keyed on the waypoint index).
+    airway.waypoints.forEach((waypoint, idx) => {
+      const point: Feature<Point, AirwayFocusProperties> = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [waypoint.lon, waypoint.lat] },
+        properties: { kind: 'waypoint', waypointIndex: idx },
+      };
+      features.push(point);
+    });
+    // Leg LineStrings (one per consecutive pair, keyed on the END
+    // waypoint's index so the line filter matches the same index the
+    // inspector hover writes).
+    for (let i = 0; i < airway.waypoints.length - 1; i += 1) {
+      const start = airway.waypoints[i];
+      const end = airway.waypoints[i + 1];
+      if (start === undefined || end === undefined) {
+        continue;
+      }
+      const line: Feature<LineString, AirwayFocusProperties> = {
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [start.lon, start.lat],
+            [end.lon, end.lat],
+          ],
+        },
+        properties: { kind: 'leg', waypointIndex: i + 1 },
+      };
+      features.push(line);
+    }
+    return { type: 'FeatureCollection', features };
+  }, [activeRef, state]);
+
+  const indexFilter = useMemo<ExpressionSpecification>(() => {
+    if (hoveredWaypointIndex === undefined) {
+      return FOCUS_MATCH_NONE_FILTER;
+    }
+    return ['==', ['get', 'waypointIndex'], hoveredWaypointIndex];
+  }, [hoveredWaypointIndex]);
+
+  const waypointLayerProps = useMemo<LayerProps>(
+    () => ({
+      id: AIRWAY_WAYPOINT_FOCUS_LAYER_ID,
+      source: AIRWAY_FOCUS_SOURCE_ID,
+      type: 'circle',
+      filter: ['all', ['==', ['get', 'kind'], 'waypoint'], indexFilter],
+      paint: {
+        // Lighter yellow so the focused waypoint pops against the
+        // regular highlight on whichever underlying point layer the
+        // waypoint sits on (fix / navaid / airport).
+        'circle-radius': 8,
+        'circle-color': CHART_HIGHLIGHT_COLORS.focusOutline,
+        'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
+        'circle-stroke-width': 2,
+        'circle-opacity': 0.85,
+      },
+    }),
+    [indexFilter],
+  );
+
+  const legLayerProps = useMemo<LayerProps>(
+    () => ({
+      id: AIRWAY_LEG_FOCUS_LAYER_ID,
+      source: AIRWAY_FOCUS_SOURCE_ID,
+      type: 'line',
+      filter: ['all', ['==', ['get', 'kind'], 'leg'], indexFilter],
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      paint: {
+        // Lighter yellow so the focused leg pops against the regular
+        // airway highlight. Wider than the highlight stroke so the
+        // focused leg is visible even when an airport / navaid circle
+        // sits on top of one of its waypoints.
+        'line-color': CHART_HIGHLIGHT_COLORS.focusOutline,
+        'line-width': 6,
+        'line-opacity': 1,
+      },
+    }),
+    [indexFilter],
+  );
+
+  if (data === undefined) {
+    return null;
+  }
+
+  return (
+    <Source id={AIRWAY_FOCUS_SOURCE_ID} type="geojson" data={data}>
+      {/*
+        Leg first, waypoint second so the dot draws on top of the leg
+        terminus - otherwise the wider line would mask the dot when
+        the user hovers the leg's destination row.
+      */}
+      <Layer {...legLayerProps} />
+      <Layer {...waypointLayerProps} />
     </Source>
   );
 }

--- a/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
@@ -12,6 +12,7 @@ import {
   CHART_SYMBOL_STROKE,
 } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
+import { LAYER_MIN_ZOOM } from '../url-state.ts';
 
 /**
  * Properties carried on each fix point feature in the GeoJSON source.
@@ -50,11 +51,20 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 /**
  * Highlight overlay for the currently-selected (or chip-hovered) fix.
  * Mirrors the airport / navaid highlight (yellow + dark stroke).
+ * Inherits the same `minzoom` as the base layer so a stray highlight
+ * does not float over an empty viewport when the user is zoomed out
+ * below the threshold.
+ *
+ * `minzoom` is included via conditional spread so the property is omitted
+ * when {@link LAYER_MIN_ZOOM} carries no entry, satisfying
+ * `exactOptionalPropertyTypes` (which rejects an explicit `undefined` for
+ * an optional property).
  */
 const FIXES_HIGHLIGHT_LAYER_BASE: LayerProps = {
   id: FIXES_HIGHLIGHT_LAYER_ID,
   source: FIXES_SOURCE_ID,
   type: 'circle',
+  ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
   paint: {
     'circle-radius': 9,
     'circle-color': CHART_HIGHLIGHT_COLORS.primary,
@@ -102,32 +112,46 @@ function toFeatureCollection(records: Fix[]): FeatureCollection<Point, FixFeatur
 }
 
 /**
- * MapLibre layer styling. Radius interpolates by zoom and is tiered by
- * usage so compulsory reporting points appear earliest, then enroute
- * waypoints and reporting points, then military and other categories.
- * Color uses an amber hue to distinguish fixes from the blue airports
- * and magenta navaids layers.
+ * Visibility threshold for the secondary fix tier (military, VFR, NRS,
+ * MR, MW). At the layer's minzoom only compulsory reporting points and
+ * enroute waypoints (`WP` / `RP`) are visible; the remaining categories
+ * join from this zoom onward, at the same dot size as the WP they sit
+ * next to.
+ */
+const FIX_SECONDARY_TIER_MIN_ZOOM = 9;
+
+/**
+ * MapLibre layer styling. Visibility is gated by usage code: at the
+ * layer's minzoom only compulsory reporting points and enroute
+ * waypoints (`WP` / `RP`) paint, with the remaining categories
+ * joining at z9. Color uses an amber hue to distinguish fixes from
+ * the blue airports and magenta navaids layers.
+ *
+ * `minzoom` is sourced from the central {@link LAYER_MIN_ZOOM} table so
+ * the layer-toggle dropdown's "appears at z N+" hint and the actual
+ * paint cutoff stay in lockstep.
+ *
+ * Each tier appears at the same dot size as the tiers already on
+ * screen so a military or VFR fix popping in at z9 is the same size
+ * as the WP it sits next to, not a sub-class speck. Visibility runs
+ * through the layer's `filter` rather than a `circle-radius: 0` paint
+ * stop because MapLibre still draws the 0.75px white stroke around a
+ * zero-radius circle, and a chart at the layer's minzoom would show
+ * a fog of speck-sized stroke artifacts otherwise.
  */
 const FIXES_LAYER_PROPS: LayerProps = {
   id: FIXES_LAYER_ID,
   source: FIXES_SOURCE_ID,
   type: 'circle',
+  ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
+  filter: [
+    'any',
+    ['get', 'compulsory'],
+    ['in', ['get', 'useCode'], ['literal', ['WP', 'RP']]],
+    ['>=', ['zoom'], FIX_SECONDARY_TIER_MIN_ZOOM],
+  ],
   paint: {
-    'circle-radius': [
-      'interpolate',
-      ['linear'],
-      ['zoom'],
-      5,
-      ['case', ['get', 'compulsory'], 1.5, 0],
-      7,
-      ['case', ['get', 'compulsory'], 2.5, ['match', ['get', 'useCode'], ['WP', 'RP'], 1.5, 0]],
-      9,
-      ['match', ['get', 'useCode'], ['WP', 'RP'], 2.5, 1.5],
-      12,
-      3,
-      16,
-      8,
-    ],
+    'circle-radius': ['interpolate', ['linear'], ['zoom'], 7, 3, 9, 4, 12, 5, 16, 9],
     'circle-color': CHART_FIX_COLOR,
     'circle-stroke-color': CHART_SYMBOL_STROKE,
     'circle-stroke-width': 0.75,

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
@@ -12,6 +12,7 @@ import {
   CHART_SYMBOL_STROKE,
 } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
+import { LAYER_MIN_ZOOM } from '../url-state.ts';
 
 /**
  * Properties carried on each navaid point feature in the GeoJSON source.
@@ -50,12 +51,20 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 /**
  * Highlight overlay for the currently-selected (or chip-hovered) navaid.
  * Mirrors the airport highlight (yellow + dark stroke) so the highlight
- * style is consistent across point layers.
+ * style is consistent across point layers. Inherits the same `minzoom`
+ * as the base layer so a stray highlight does not float over an empty
+ * viewport when the user is zoomed out below the threshold.
+ *
+ * `minzoom` is included via conditional spread so the property is omitted
+ * when {@link LAYER_MIN_ZOOM} carries no entry, satisfying
+ * `exactOptionalPropertyTypes` (which rejects an explicit `undefined` for
+ * an optional property).
  */
 const NAVAIDS_HIGHLIGHT_LAYER_BASE: LayerProps = {
   id: NAVAIDS_HIGHLIGHT_LAYER_ID,
   source: NAVAIDS_SOURCE_ID,
   type: 'circle',
+  ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
   paint: {
     'circle-radius': 9,
     'circle-color': CHART_HIGHLIGHT_COLORS.primary,
@@ -108,32 +117,51 @@ function toFeatureCollection(records: Navaid[]): FeatureCollection<Point, Navaid
 }
 
 /**
- * MapLibre layer styling. Radius interpolates by zoom and is tiered by
- * navaid type so the IFR backbone (`VOR`, `VORTAC`, `VOR/DME`) stays
- * visible at low zoom while DMEs and NDBs only appear once the user has
- * zoomed in. Color uses a magenta hue to distinguish navaids from the
- * blue/slate airports layer at a glance.
+ * Visibility threshold for the second-tier navaid types (TACAN, DME).
+ * Below this zoom only the IFR-backbone primary types (VOR, VORTAC,
+ * VOR/DME) paint; from here on TACANs and DMEs join at the same dot
+ * size as the VOR they sit next to.
+ */
+const NAVAID_SECONDARY_TIER_MIN_ZOOM = 7;
+/** Visibility threshold for tertiary navaid types (NDB, NDB/DME). */
+const NAVAID_TERTIARY_TIER_MIN_ZOOM = 10;
+
+/**
+ * MapLibre layer styling. Visibility is gated by navaid type: the IFR
+ * backbone (VOR / VORTAC / VOR/DME) shows from the layer's `minzoom`,
+ * TACAN and DME join at z7, NDB and NDB/DME at z10. Color uses a
+ * magenta hue to distinguish navaids from the blue/slate airports
+ * layer at a glance.
+ *
+ * `minzoom` is sourced from the central {@link LAYER_MIN_ZOOM} table so
+ * the layer-toggle dropdown's "appears at z N+" hint and the actual
+ * paint cutoff stay in lockstep.
+ *
+ * Each tier appears at the same dot size as the tier(s) already on
+ * screen so a TACAN popping in at z7 is the same size as the VOR it
+ * sits next to, not a sub-class speck. Visibility runs through the
+ * layer's `filter` rather than a `circle-radius: 0` paint stop because
+ * MapLibre still draws the 1px white stroke around a zero-radius
+ * circle, and a chart at CONUS zoom would show thousands of speck-
+ * sized stroke artifacts otherwise.
  */
 const NAVAIDS_LAYER_PROPS: LayerProps = {
   id: NAVAIDS_LAYER_ID,
   source: NAVAIDS_SOURCE_ID,
   type: 'circle',
-  paint: {
-    'circle-radius': [
-      'interpolate',
-      ['linear'],
-      ['zoom'],
-      4,
-      ['match', ['get', 'type'], ['VOR', 'VORTAC', 'VOR/DME'], 2, 0],
-      6,
-      ['match', ['get', 'type'], ['VOR', 'VORTAC', 'VOR/DME'], 3, ['TACAN', 'DME'], 1.5, 0],
-      9,
-      ['match', ['get', 'type'], ['VOR', 'VORTAC', 'VOR/DME'], 4, 2.5],
-      12,
-      5,
-      16,
-      8,
+  ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
+  filter: [
+    'any',
+    ['in', ['get', 'type'], ['literal', ['VOR', 'VORTAC', 'VOR/DME']]],
+    [
+      'all',
+      ['>=', ['zoom'], NAVAID_SECONDARY_TIER_MIN_ZOOM],
+      ['in', ['get', 'type'], ['literal', ['TACAN', 'DME']]],
     ],
+    ['>=', ['zoom'], NAVAID_TERTIARY_TIER_MIN_ZOOM],
+  ],
+  paint: {
+    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 4, 7, 5, 10, 6, 16, 10],
     'circle-color': CHART_NAVAID_COLOR,
     'circle-stroke-color': CHART_SYMBOL_STROKE,
     'circle-stroke-width': 1,

--- a/apps/atlas/src/modes/chart/url-state.spec.ts
+++ b/apps/atlas/src/modes/chart/url-state.spec.ts
@@ -4,6 +4,7 @@ import {
   AIRWAY_CATEGORIES,
   CHART_DEFAULTS,
   LAYER_IDS,
+  LAYER_MIN_ZOOM,
   chartSearchSchema,
 } from './url-state.ts';
 
@@ -18,7 +19,7 @@ describe('chartSearchSchema', () => {
       ...input,
       pitch: CHART_DEFAULTS.pitch,
       layers: [...LAYER_IDS],
-      airspaceClasses: [...AIRSPACE_CLASSES],
+      airspaceClasses: [...CHART_DEFAULTS.airspaceClasses],
       airwayCategories: [...AIRWAY_CATEGORIES],
     });
   });
@@ -102,16 +103,17 @@ describe('chartSearchSchema', () => {
     expect(result.airspaceClasses).toEqual([]);
   });
 
-  it('falls back to all airspace classes when an unknown class appears', () => {
+  it('falls back to the default airspace classes when an unknown class appears', () => {
     const result = chartSearchSchema.parse({ airspaceClasses: ['CLASS_B', 'CLASS_E2'] });
     // CLASS_E2 is an underlying AirspaceType but not a user-facing class id;
-    // the schema treats it as unknown and falls back to the default.
-    expect(result.airspaceClasses).toEqual([...AIRSPACE_CLASSES]);
+    // the schema treats it as unknown and falls back to the default. The
+    // default is every user-facing class except ARTCC.
+    expect(result.airspaceClasses).toEqual([...CHART_DEFAULTS.airspaceClasses]);
   });
 
-  it('falls back to all airspace classes when airspaceClasses is not an array', () => {
+  it('falls back to the default airspace classes when airspaceClasses is not an array', () => {
     const result = chartSearchSchema.parse({ airspaceClasses: 'CLASS_B' });
-    expect(result.airspaceClasses).toEqual([...AIRSPACE_CLASSES]);
+    expect(result.airspaceClasses).toEqual([...CHART_DEFAULTS.airspaceClasses]);
   });
 
   it('preserves a valid subset of airway categories', () => {
@@ -152,5 +154,50 @@ describe('chartSearchSchema', () => {
     // boundary. Validation of the parsed string lives in entity.ts, not here.
     const result = chartSearchSchema.parse({ selected: ['airport:BOS'] });
     expect(result.selected).toBeUndefined();
+  });
+});
+
+describe('CHART_DEFAULTS', () => {
+  it('excludes ARTCC from the default airspace classes', () => {
+    // ARTCC sectors blanket the entire chart at the CONUS default zoom and
+    // visually drown out every other airspace tint, so they're opted out of
+    // the first-load view. The toggle still exposes ARTCC as an option, just
+    // not as a default.
+    expect(CHART_DEFAULTS.airspaceClasses).not.toContain('ARTCC');
+    expect(AIRSPACE_CLASSES).toContain('ARTCC');
+  });
+
+  it('includes every other airspace class in the defaults', () => {
+    // Every class besides ARTCC is in the default-on set. Re-asserting this
+    // here (rather than just trusting the filter expression) catches a
+    // future drift if someone reorders or renames a class without updating
+    // the default.
+    for (const cls of AIRSPACE_CLASSES) {
+      if (cls === 'ARTCC') {
+        continue;
+      }
+      expect(CHART_DEFAULTS.airspaceClasses).toContain(cls);
+    }
+  });
+});
+
+describe('LAYER_MIN_ZOOM', () => {
+  it('gates fixes at zoom 7 and below', () => {
+    expect(LAYER_MIN_ZOOM.fixes).toBe(7);
+  });
+
+  it('gates navaids at zoom 5 and below', () => {
+    expect(LAYER_MIN_ZOOM.navaids).toBe(5);
+  });
+
+  it('does not gate airports, airspace, or airways at the layer level', () => {
+    // Missing keys are the encoding for "no zoom gating"; the layer toggle
+    // and the MapLibre Layer both treat undefined as "render at every zoom".
+    // Airways are deliberately absent because the layer renders the
+    // high-altitude J / Q backbone at every zoom and gates the V/T web
+    // via an internal per-feature filter rather than a layer-level minzoom.
+    expect(LAYER_MIN_ZOOM.airports).toBeUndefined();
+    expect(LAYER_MIN_ZOOM.airspace).toBeUndefined();
+    expect(LAYER_MIN_ZOOM.airways).toBeUndefined();
   });
 });

--- a/apps/atlas/src/modes/chart/url-state.ts
+++ b/apps/atlas/src/modes/chart/url-state.ts
@@ -23,6 +23,32 @@ export const LAYER_IDS = ['airports', 'navaids', 'fixes', 'airways', 'airspace']
 export type LayerId = (typeof LAYER_IDS)[number];
 
 /**
+ * Minimum zoom level at which each data layer paints. Layers without an
+ * entry are visible at every zoom level. Used by both the MapLibre `Layer`
+ * components (passed through as the layer's `minzoom`) and by the
+ * layer-toggle UI (to flag a row as "appears at z N+" when the current
+ * map zoom is below the threshold). Centralizing the table here keeps
+ * the gating logic and the dropdown hint pinned to the same number, so
+ * adjusting a threshold updates both consumers in lockstep.
+ *
+ * Numbers are tuned for the chart-mode default zoom of 4 (CONUS view):
+ * - `navaids`: matches the airports layer's CONUS-clean threshold.
+ * - `fixes`: even compulsory fixes are sub-pixel specks below 7; they only
+ *   become useful when the user is zoomed enough to read identifiers.
+ *
+ * The airways layer deliberately has no entry: the high-altitude J / Q
+ * backbone stays visible at every zoom so users can see the whole length
+ * of cross-country routes at CONUS view, while the dense V/T web is gated
+ * by a per-feature filter inside the airways layer (see
+ * `MINOR_AIRWAY_MIN_ZOOM` in `layers/airways-layer.tsx`). The toggle row
+ * for airways therefore has no "z N+" hint - something is always visible.
+ */
+export const LAYER_MIN_ZOOM: Partial<Record<LayerId, number>> = {
+  navaids: 5,
+  fixes: 7,
+};
+
+/**
  * User-facing airspace classes exposed by the layer toggle. `CLASS_E`
  * collapses the underlying `CLASS_E2` through `CLASS_E7` AirspaceType
  * variants into a single concept matching how pilots think about Class E
@@ -121,7 +147,10 @@ export const AIRWAY_CATEGORY_TYPES: Record<AirwayCategory, readonly AirwayType[]
 
 /**
  * Default chart-mode map view: continental US center at a zoom that shows the
- * full CONUS area, with every data layer and every sub-class enabled.
+ * full CONUS area, with every data layer enabled and most airspace classes
+ * enabled. ARTCC is opted out by default because its sector boundaries cover
+ * essentially the entire chart and dominate every other airspace tint at the
+ * default CONUS zoom; users who want it can flip it on from the layer toggle.
  */
 export const CHART_DEFAULTS = {
   /** Default map center latitude in decimal degrees, positive north. */
@@ -134,8 +163,11 @@ export const CHART_DEFAULTS = {
   pitch: 0,
   /** Default active layer set: every layer visible. */
   layers: LAYER_IDS,
-  /** Default active airspace classes: every class visible. */
-  airspaceClasses: AIRSPACE_CLASSES,
+  /**
+   * Default active airspace classes. Every class except ARTCC is on; ARTCC
+   * is excluded so the CONUS view is not dominated by sector outlines.
+   */
+  airspaceClasses: AIRSPACE_CLASSES.filter((cls) => cls !== 'ARTCC'),
   /** Default active airway categories: every category visible. */
   airwayCategories: AIRWAY_CATEGORIES,
 } as const;
@@ -176,8 +208,9 @@ export const chartSearchSchema = z.object({
     .catch([...CHART_DEFAULTS.layers]),
   /**
    * Active airspace classes (consulted only when `layers` includes `airspace`).
-   * Default is every class enabled; an empty array yields a layer that renders
-   * no features. Unknown ids or non-array values fall back to the default.
+   * Default is every class except ARTCC; an empty array yields a layer that
+   * renders no features. Unknown ids or non-array values fall back to the
+   * default.
    */
   airspaceClasses: z
     .array(z.enum(AIRSPACE_CLASSES))

--- a/apps/atlas/src/shared/inspector/airspace-feature.spec.ts
+++ b/apps/atlas/src/shared/inspector/airspace-feature.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { compareAirspaceByAltitudeDesc } from './airspace-feature.ts';
+import type { AirspaceAltitudeKey } from './airspace-feature.ts';
+
+describe('compareAirspaceByAltitudeDesc', () => {
+  it('sorts higher ceilings before lower ceilings', () => {
+    const high: AirspaceAltitudeKey = { ceilingFt: 18000, floorFt: 0 };
+    const low: AirspaceAltitudeKey = { ceilingFt: 10000, floorFt: 0 };
+    const ordered = [low, high].sort(compareAirspaceByAltitudeDesc);
+    expect(ordered).toEqual([high, low]);
+  });
+
+  it('breaks ties by higher floor first', () => {
+    // Two Class B rings sharing the same ceiling: the outer ring (higher
+    // floor) should come before the inner ring (SFC floor). This matches
+    // the "top-down altitude stack" mental model the inspector renders.
+    const outerRing: AirspaceAltitudeKey = { ceilingFt: 10000, floorFt: 3000 };
+    const innerRing: AirspaceAltitudeKey = { ceilingFt: 10000, floorFt: 0 };
+    const ordered = [innerRing, outerRing].sort(compareAirspaceByAltitudeDesc);
+    expect(ordered).toEqual([outerRing, innerRing]);
+  });
+
+  it('returns 0 for two identical altitude keys', () => {
+    // Stable sort: identical keys preserve input order.
+    const same: AirspaceAltitudeKey = { ceilingFt: 5000, floorFt: 1000 };
+    expect(compareAirspaceByAltitudeDesc(same, same)).toBe(0);
+  });
+
+  it('orders an ARTCC stack as HIGH then LOW', () => {
+    // ARTCC sectors come in stratums; HIGH sits above LOW. Sorting a
+    // dataset-order pair should always land HIGH first regardless of
+    // the input order.
+    const low: AirspaceAltitudeKey = { ceilingFt: 18000, floorFt: 0 };
+    const high: AirspaceAltitudeKey = { ceilingFt: 60000, floorFt: 18000 };
+    expect([low, high].sort(compareAirspaceByAltitudeDesc)).toEqual([high, low]);
+    expect([high, low].sort(compareAirspaceByAltitudeDesc)).toEqual([high, low]);
+  });
+});

--- a/apps/atlas/src/shared/inspector/airspace-feature.ts
+++ b/apps/atlas/src/shared/inspector/airspace-feature.ts
@@ -2,6 +2,45 @@ import type { Feature, GeoJsonProperties, Geometry, Polygon } from 'geojson';
 import type { AirspaceFeature } from '@squawk/types';
 
 /**
+ * Minimal shape consumed by {@link compareAirspaceByAltitudeDesc}. Two
+ * primitive fields are enough to drive the sort, so call sites that
+ * only have the synthetic GeoJSON properties (e.g. the disambiguation
+ * popover, where the altitude originates from `__atlasCeilingFt` /
+ * `__atlasFloorFt`) can participate without first re-hydrating the
+ * full {@link AirspaceFeature} record.
+ */
+export interface AirspaceAltitudeKey {
+  /** Ceiling altitude in feet. SFC reads as 0. */
+  readonly ceilingFt: number;
+  /** Floor altitude in feet. SFC reads as 0. */
+  readonly floorFt: number;
+}
+
+/**
+ * Comparator that orders airspace listings highest "vertical layer"
+ * first. Primary key is `ceilingFt` descending - the stratum that tops
+ * out higher comes first. Tie-break by `floorFt` descending so a
+ * Class B's outer ring (high floor, same ceiling as inner rings) sits
+ * above its inner rings, matching the "top-down altitude stack"
+ * mental model pilots use when reading a chart.
+ *
+ * MSL and AGL values are compared by their numeric `valueFt` directly.
+ * The approximation conflates the two when they happen to share a
+ * value, but no realistic airspace stack mixes MSL and AGL at the
+ * same altitude band, so the sort lands the right way in practice.
+ *
+ * Used by the inspector's airspace panel (multi-feature sub-sections),
+ * the disambiguation popover (stacked-airspace rows), and the
+ * inspector's "Also here" chip strip (airspace chips).
+ */
+export function compareAirspaceByAltitudeDesc(
+  a: AirspaceAltitudeKey,
+  b: AirspaceAltitudeKey,
+): number {
+  return b.ceilingFt - a.ceilingFt || b.floorFt - a.floorFt;
+}
+
+/**
  * GeoJSON feature carrying the airspace property bag the
  * `@squawk/airspace-data` bundle ships. The geometry is always a
  * `Polygon`; the properties are the full {@link AirspaceFeature} record

--- a/apps/atlas/src/shared/inspector/entity-resolver.spec.ts
+++ b/apps/atlas/src/shared/inspector/entity-resolver.spec.ts
@@ -189,4 +189,59 @@ describe('useResolvedEntity', () => {
     const { result } = renderHook(() => useResolvedEntity('airspace:JFK'));
     expect(result.current.status).toBe('not-found');
   });
+
+  it('orders matched airspace features by altitude descending', () => {
+    // Insert in low-to-high order; the resolver must return high-to-low
+    // so the inspector renders the top stratum first. Tie-break by floor
+    // descending puts the outer Class B ring before its inner ring.
+    const surfaceCore = buildAirspaceFeature({
+      type: 'CLASS_B',
+      identifier: 'JFK',
+      floor: { valueFt: 0, reference: 'SFC' },
+      ceiling: { valueFt: 7000, reference: 'MSL' },
+    });
+    const innerRing = buildAirspaceFeature({
+      type: 'CLASS_B',
+      identifier: 'JFK',
+      floor: { valueFt: 0, reference: 'SFC' },
+      ceiling: { valueFt: 10000, reference: 'MSL' },
+    });
+    const outerRing = buildAirspaceFeature({
+      type: 'CLASS_B',
+      identifier: 'JFK',
+      floor: { valueFt: 3000, reference: 'MSL' },
+      ceiling: { valueFt: 10000, reference: 'MSL' },
+    });
+    airspaceStateMock.mockReturnValue({
+      status: 'loaded',
+      dataset: {
+        features: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Polygon', coordinates: [] },
+            properties: surfaceCore,
+          },
+          {
+            type: 'Feature',
+            geometry: { type: 'Polygon', coordinates: [] },
+            properties: innerRing,
+          },
+          {
+            type: 'Feature',
+            geometry: { type: 'Polygon', coordinates: [] },
+            properties: outerRing,
+          },
+        ],
+      },
+    });
+    const { result } = renderHook(() => useResolvedEntity('airspace:CLASS_B/JFK'));
+    expect(result.current.status).toBe('resolved');
+    if (result.current.status === 'resolved' && result.current.entity.kind === 'airspace') {
+      const ceilings = result.current.entity.features.map((f) => f.ceiling.valueFt);
+      const floors = result.current.entity.features.map((f) => f.floor.valueFt);
+      // outerRing (10k/3k) -> innerRing (10k/0) -> surfaceCore (7k/0)
+      expect(ceilings).toEqual([10000, 10000, 7000]);
+      expect(floors).toEqual([3000, 0, 0]);
+    }
+  });
 });

--- a/apps/atlas/src/shared/inspector/entity-resolver.ts
+++ b/apps/atlas/src/shared/inspector/entity-resolver.ts
@@ -11,7 +11,7 @@ import { useFixDataset } from '../data/fix-dataset.ts';
 import type { FixDatasetState } from '../data/fix-dataset.ts';
 import { useNavaidDataset } from '../data/navaid-dataset.ts';
 import type { NavaidDatasetState } from '../data/navaid-dataset.ts';
-import { isAirspacePolygonFeature } from './airspace-feature.ts';
+import { compareAirspaceByAltitudeDesc, isAirspacePolygonFeature } from './airspace-feature.ts';
 import type { AirspacePolygonFeature } from './airspace-feature.ts';
 import { parseSelected } from './entity.ts';
 import type { EntityRef } from './entity.ts';
@@ -305,6 +305,18 @@ export function resolveSelectionFromState(
           features.push({ ...feature.properties, boundary: feature.geometry });
         }
       }
+      // Sort the matched features so the highest "vertical layer" is
+      // first. Without this the panel's per-feature sub-sections render
+      // in dataset order, which is essentially random for stacked
+      // airspaces (ARTCC LOW/HIGH, MOA altitude bands, Class B
+      // concentric rings) and forces the user to scan to find the
+      // section they care about.
+      features.sort((a, b) =>
+        compareAirspaceByAltitudeDesc(
+          { ceilingFt: a.ceiling.valueFt, floorFt: a.floor.valueFt },
+          { ceilingFt: b.ceiling.valueFt, floorFt: b.floor.valueFt },
+        ),
+      );
       const first = features[0];
       if (first === undefined) {
         return { status: 'not-found', ref };

--- a/apps/atlas/src/shared/inspector/inspector.spec.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.spec.tsx
@@ -58,6 +58,11 @@ vi.mock('./entity-resolver.ts', () => ({
 vi.mock('../../modes/chart/highlight-context.ts', () => ({
   useSetHoveredChipSelection: () => setHoveredChipSelectionMock,
   useSetHoveredFeatureIndex: () => setHoveredFeatureIndexMock,
+  // Hooks the airway-panel + row-hover-pan use; tests do not exercise
+  // the airway-row hover code paths directly, so the value is
+  // undefined and the setter is a stable no-op stub.
+  useHoveredAirwayWaypointIndex: () => undefined,
+  useSetHoveredAirwayWaypointIndex: () => () => {},
 }));
 
 vi.mock('@vis.gl/react-maplibre', () => ({

--- a/apps/atlas/src/shared/inspector/inspector.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.tsx
@@ -10,16 +10,23 @@ import {
   selectedFromFeature,
 } from '../../modes/chart/click-to-select.ts';
 import type { InspectableFeature } from '../../modes/chart/click-to-select.ts';
+import {
+  AIRSPACE_CEILING_FT_PROPERTY,
+  AIRSPACE_FLOOR_FT_PROPERTY,
+} from '../../modes/chart/layers/airspace-layer.tsx';
+import { useHoveredAirwayWaypointIndex } from '../../modes/chart/highlight-context.ts';
 import { AIRSPACE_CLASS_FOR_TYPE, CHART_ROUTE_PATH } from '../../modes/chart/url-state.ts';
 import type { AirspaceClass } from '../../modes/chart/url-state.ts';
 import { useCanHover } from '../styles/use-can-hover.ts';
-import { isAirspacePolygonFeature } from './airspace-feature.ts';
+import { compareAirspaceByAltitudeDesc, isAirspacePolygonFeature } from './airspace-feature.ts';
+import type { AirspaceAltitudeKey } from './airspace-feature.ts';
 import { ENTITY_TYPES, parseSelected } from './entity.ts';
 import type { EntityType } from './entity.ts';
 import { bboxFromWaypoints, combinedBboxFromAirspaceFeatures } from './geometry.ts';
 import type { BoundingBox } from './geometry.ts';
 import { resolveSelectionFromState, useDatasetStates } from './entity-resolver.ts';
 import type { ChartDatasetStates, ResolvedEntity, ResolvedEntityState } from './entity-resolver.ts';
+import { useAirwayLegHoverPan } from './use-airway-leg-hover-pan.ts';
 import { useChipHoverPan } from './use-chip-hover-pan.ts';
 import { AirportPanel } from './renderers/airport-panel.tsx';
 import { AirspacePanel } from './renderers/airspace-panel.tsx';
@@ -50,6 +57,13 @@ interface Chip {
   label: string;
   /** Entity type, used to drive the disclosure's per-type grouping. */
   type: EntityType;
+  /**
+   * Altitude key for airspace chips. Drives the altitude-descending
+   * sort so a stack of vertically-layered airspaces (Class B + ARTCC,
+   * MOA HIGH + MOA LOW) reads top-down. Undefined for non-airspace
+   * chips, which keep their natural collection order.
+   */
+  altitudeKey?: AirspaceAltitudeKey;
 }
 
 /**
@@ -139,6 +153,21 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
       state,
     });
 
+  // Drives the camera while the user hovers per-row entries in the
+  // airway inspector panel. The panel writes
+  // `hoveredAirwayWaypointIndex` into the highlight context (gated on
+  // `useCanHover()` so touch devices never fire it); this hook eases
+  // the camera to the leg midpoint (or the start waypoint for row 0)
+  // when the area is offscreen, restoring the pre-pan center on
+  // unhover.
+  const hoveredAirwayWaypointIndex = useHoveredAirwayWaypointIndex();
+  useAirwayLegHoverPan({
+    selected,
+    hoveredWaypointIndex: hoveredAirwayWaypointIndex,
+    mapRef,
+    state,
+  });
+
   const handleClose = useCallback((): void => {
     resetSession();
     void navigate({
@@ -202,7 +231,13 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
         continue;
       }
       seen.add(selection);
-      result.push({ selection, label: formatChipLabel(feature), type: ref.type });
+      const altitudeKey = readAirspaceAltitudeKeyFromSibling(feature);
+      result.push({
+        selection,
+        label: formatChipLabel(feature),
+        type: ref.type,
+        ...(altitudeKey !== undefined && { altitudeKey }),
+      });
     }
 
     // Overlap chips: walk the airspace dataset for features that
@@ -240,7 +275,25 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
       }
     }
 
-    return disambiguateLabels(result);
+    // Sort airspace chips by altitude descending (highest ceiling first,
+    // floor as tie-break) so a stack of vertically-layered airspaces -
+    // whether from the click siblings (Class B + ARTCC at the same
+    // pixel) or from the overlap walk (MOA HIGH + MOA LOW underneath
+    // the selected feature) - reads top-down. Non-airspace chips keep
+    // their collection order, and the airspace block sits where it
+    // naturally landed in the result list. Sort happens before label
+    // disambiguation so any `(N)` suffix follows the post-sort order.
+    const nonAirspace: Chip[] = [];
+    const airspace: { chip: Chip; key: AirspaceAltitudeKey }[] = [];
+    for (const chip of result) {
+      if (chip.altitudeKey === undefined) {
+        nonAirspace.push(chip);
+      } else {
+        airspace.push({ chip, key: chip.altitudeKey });
+      }
+    }
+    airspace.sort((a, b) => compareAirspaceByAltitudeDesc(a.key, b.key));
+    return disambiguateLabels([...nonAirspace, ...airspace.map((it) => it.chip)]);
   }, [siblings, selected, datasets, state, layers, airspaceClasses, chipViewportBounds]);
 
   if (state.status === 'idle') {
@@ -467,7 +520,7 @@ function* buildOverlappingAirspaceChips(
   seen: ReadonlySet<string>,
   viewportBounds: BoundingBox | undefined,
   activeClasses: readonly AirspaceClass[],
-): Generator<{ selection: string; label: string }, void, void> {
+): Generator<{ selection: string; label: string; altitudeKey: AirspaceAltitudeKey }, void, void> {
   if (datasets.airspace.status !== 'loaded') {
     return;
   }
@@ -530,8 +583,36 @@ function* buildOverlappingAirspaceChips(
         continue;
       }
     }
-    yield { selection, label: formatAirspaceLabel(props.type, props.identifier, props.name) };
+    yield {
+      selection,
+      label: formatAirspaceLabel(props.type, props.identifier, props.name),
+      altitudeKey: { ceilingFt: props.ceiling.valueFt, floorFt: props.floor.valueFt },
+    };
   }
+}
+
+/**
+ * Reads an {@link AirspaceAltitudeKey} off a click-derived sibling
+ * feature's synthetic floor/ceiling primitive properties (added by
+ * `projectAirspaceSource` in the airspace layer). Returns `undefined`
+ * for any feature whose properties bag does not carry the primitive
+ * pair - non-airspace features and any defensive-fallback case land
+ * here, and the chip falls through to the non-airspace bucket so it
+ * keeps its natural collection order.
+ */
+function readAirspaceAltitudeKeyFromSibling(
+  feature: InspectableFeature,
+): AirspaceAltitudeKey | undefined {
+  const props = feature.properties;
+  if (props === null) {
+    return undefined;
+  }
+  const ceilingFt = props[AIRSPACE_CEILING_FT_PROPERTY];
+  const floorFt = props[AIRSPACE_FLOOR_FT_PROPERTY];
+  if (typeof ceilingFt !== 'number' || typeof floorFt !== 'number') {
+    return undefined;
+  }
+  return { ceilingFt, floorFt };
 }
 
 /**

--- a/apps/atlas/src/shared/inspector/renderers/airway-panel.spec.tsx
+++ b/apps/atlas/src/shared/inspector/renderers/airway-panel.spec.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Airway } from '@squawk/types';
+import { AirwayPanel } from './airway-panel.tsx';
+
+const { setHoveredAirwayWaypointIndexMock, canHoverMock } = vi.hoisted(() => ({
+  setHoveredAirwayWaypointIndexMock: vi.fn<(index: number | undefined) => void>(),
+  canHoverMock: vi.fn<() => boolean>(),
+}));
+
+vi.mock('../../../modes/chart/highlight-context.ts', () => ({
+  useSetHoveredAirwayWaypointIndex: () => setHoveredAirwayWaypointIndexMock,
+}));
+
+vi.mock('../../styles/use-can-hover.ts', () => ({
+  useCanHover: canHoverMock,
+}));
+
+/** Builds an airway record with N synthetic waypoints for hover testing. */
+function buildAirway(waypointCount: number): Airway {
+  const waypoints = Array.from({ length: waypointCount }, (_, i) => ({
+    name: `WP${i}`,
+    identifier: `WP${i}`,
+    waypointType: 'WAYPOINT' as const,
+    lat: 40 + i,
+    lon: -100 + i,
+  }));
+  return {
+    designation: 'V16',
+    type: 'VICTOR',
+    region: 'US',
+    waypoints,
+  };
+}
+
+describe('AirwayPanel', () => {
+  beforeEach(() => {
+    setHoveredAirwayWaypointIndexMock.mockClear();
+    canHoverMock.mockReturnValue(true);
+  });
+
+  it('renders one row per waypoint with the waypoint identifier as the label', () => {
+    render(<AirwayPanel record={buildAirway(3)} />);
+    expect(screen.getByText('WP0')).toBeInTheDocument();
+    expect(screen.getByText('WP1')).toBeInTheDocument();
+    expect(screen.getByText('WP2')).toBeInTheDocument();
+  });
+
+  it('reports the hovered waypoint index on per-row pointer enter / leave', () => {
+    // Row at waypoint index 1 (the second row). Hovering it should
+    // set waypoint index 1; leaving should clear.
+    render(<AirwayPanel record={buildAirway(3)} />);
+    const row = screen.getByText('WP1').closest('div');
+    expect(row).not.toBeNull();
+    if (row === null) {
+      return;
+    }
+    fireEvent.pointerEnter(row);
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenCalledWith(1);
+    fireEvent.pointerLeave(row);
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('reports the row position as the waypoint index for any row', () => {
+    // The row at waypoint index N fires N (not N-1) so the focus
+    // layer can light up the dot AND the leg ending at that
+    // waypoint.
+    render(<AirwayPanel record={buildAirway(5)} />);
+    const lastRow = screen.getByText('WP4').closest('div');
+    expect(lastRow).not.toBeNull();
+    if (lastRow === null) {
+      return;
+    }
+    fireEvent.pointerEnter(lastRow);
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenLastCalledWith(4);
+  });
+
+  it('fires the hover handler for the first waypoint row (waypoint index 0)', () => {
+    // The first waypoint is the route's starting point - it has no
+    // incoming leg, but it IS a fix / navaid / airport in its own
+    // right and the user wants the same hover-highlight affordance
+    // as every other row. Setting waypoint index 0 lights up just
+    // the dot (no leg) since the focus-layer's leg filter excludes
+    // index 0.
+    render(<AirwayPanel record={buildAirway(3)} />);
+    const firstRow = screen.getByText('WP0').closest('div');
+    expect(firstRow).not.toBeNull();
+    if (firstRow === null) {
+      return;
+    }
+    fireEvent.pointerEnter(firstRow);
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenCalledWith(0);
+    fireEvent.pointerLeave(firstRow);
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('does not attach the hover handler on touch devices (canHover false)', () => {
+    // Mobile / touch users have `(hover: hover)` resolve false, so
+    // synthesized mouseenter from a tap should never fire the
+    // highlight - which would otherwise yank the camera around on
+    // every list-row tap.
+    canHoverMock.mockReturnValue(false);
+    render(<AirwayPanel record={buildAirway(3)} />);
+    const row = screen.getByText('WP1').closest('div');
+    expect(row).not.toBeNull();
+    if (row === null) {
+      return;
+    }
+    fireEvent.pointerEnter(row);
+    expect(setHoveredAirwayWaypointIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the hovered waypoint index on unmount as a defensive cleanup', () => {
+    const { unmount } = render(<AirwayPanel record={buildAirway(3)} />);
+    setHoveredAirwayWaypointIndexMock.mockClear();
+    unmount();
+    expect(setHoveredAirwayWaypointIndexMock).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/atlas/src/shared/inspector/renderers/airway-panel.tsx
+++ b/apps/atlas/src/shared/inspector/renderers/airway-panel.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
 import type { ReactElement } from 'react';
 import type { Airway, AirwayWaypoint } from '@squawk/types';
+import { useSetHoveredAirwayWaypointIndex } from '../../../modes/chart/highlight-context.ts';
+import { useCanHover } from '../../styles/use-can-hover.ts';
 import { InspectorRow, InspectorSection } from './inspector-row.tsx';
 
 /**
@@ -15,8 +18,28 @@ export interface AirwayPanelProps {
  * plus the ordered waypoint list. Each waypoint row carries the segment MEA
  * when the dataset has it (most enroute segments do; some oceanic routes
  * leave it null), so the user can scan the altitude profile at a glance.
+ *
+ * On hover-capable devices, every waypoint row wires into the highlight
+ * context's `hoveredAirwayWaypointIndex` so a complementary map layer
+ * can brighten the matching waypoint dot AND, when the row is not the
+ * first, the incoming leg ending at that waypoint. The first row is
+ * still hoverable - the user gets a "where on the map is this
+ * fix/navaid/airport?" affordance for the route's starting point even
+ * though it has no incoming leg.
  */
 export function AirwayPanel({ record }: AirwayPanelProps): ReactElement {
+  const setHoveredAirwayWaypointIndex = useSetHoveredAirwayWaypointIndex();
+  const canHover = useCanHover();
+  // Defensive cleanup so a hovered waypoint index does not stick when
+  // the panel unmounts (selection change, inspector close). PointerLeave
+  // on each row covers the common path; the unmount-without-leave case
+  // would otherwise leave a phantom waypoint / leg brightened on the map.
+  useEffect(
+    () => (): void => {
+      setHoveredAirwayWaypointIndex(undefined);
+    },
+    [setHoveredAirwayWaypointIndex],
+  );
   return (
     <>
       <InspectorSection title="Classification">
@@ -30,6 +53,10 @@ export function AirwayPanel({ record }: AirwayPanelProps): ReactElement {
             <InspectorRow
               key={`${waypoint.identifier ?? waypoint.name}-${idx}`}
               label={waypoint.identifier ?? waypoint.name}
+              {...(canHover && {
+                onPointerEnter: (): void => setHoveredAirwayWaypointIndex(idx),
+                onPointerLeave: (): void => setHoveredAirwayWaypointIndex(undefined),
+              })}
             >
               {formatWaypointAltitude(waypoint)}
             </InspectorRow>

--- a/apps/atlas/src/shared/inspector/renderers/inspector-row.tsx
+++ b/apps/atlas/src/shared/inspector/renderers/inspector-row.tsx
@@ -8,6 +8,14 @@ export interface InspectorRowProps {
   label: string;
   /** Right-column value. May be a string, number, or richer JSX. */
   children: ReactNode;
+  /**
+   * Optional pointer-enter handler. The airway renderer uses this so
+   * hovering a per-leg row brightens that segment on the map.
+   * Renderers that leave it unset get a static row.
+   */
+  onPointerEnter?: () => void;
+  /** Optional pointer-leave handler that pairs with {@link onPointerEnter}. */
+  onPointerLeave?: () => void;
 }
 
 /**
@@ -15,13 +23,32 @@ export interface InspectorRowProps {
  * shared building block for every renderer's definition-list layout. Skips
  * rendering when `children` is `null` or `undefined` so callers can pass
  * optional fields directly without a guard at every site.
+ *
+ * When `onPointerEnter` is supplied the row paints with a subtle hover
+ * tint so the user reads it as interactive - hovering drives a
+ * downstream effect (e.g. brightening the matching airway leg on the
+ * map). Static rows without a hover handler keep the flat layout.
  */
-export function InspectorRow({ label, children }: InspectorRowProps): ReactElement | null {
+export function InspectorRow({
+  label,
+  children,
+  onPointerEnter,
+  onPointerLeave,
+}: InspectorRowProps): ReactElement | null {
   if (children === null || children === undefined) {
     return null;
   }
+  const interactive = onPointerEnter !== undefined;
   return (
-    <div className="flex justify-between gap-3 py-1.5 text-sm">
+    <div
+      className={
+        interactive
+          ? 'flex justify-between gap-3 rounded py-1.5 text-sm transition-colors hover:bg-slate-100'
+          : 'flex justify-between gap-3 py-1.5 text-sm'
+      }
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+    >
       <dt className="shrink-0 text-slate-500">{label}</dt>
       <dd className="text-right text-slate-900">{children}</dd>
     </div>

--- a/apps/atlas/src/shared/inspector/use-airway-leg-hover-pan.spec.ts
+++ b/apps/atlas/src/shared/inspector/use-airway-leg-hover-pan.spec.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { MapRef } from '@vis.gl/react-maplibre';
+import type { Airway } from '@squawk/types';
+import { useAirwayLegHoverPan } from './use-airway-leg-hover-pan.ts';
+import type { ResolvedEntityState } from './entity-resolver.ts';
+
+const {
+  getMapInstanceMock,
+  isPointOutsideComfortableAreaMock,
+  panToFeatureWithInspectorOffsetMock,
+  restoreCenterMock,
+} = vi.hoisted(() => ({
+  getMapInstanceMock: vi.fn(),
+  isPointOutsideComfortableAreaMock: vi.fn<() => boolean>(),
+  panToFeatureWithInspectorOffsetMock: vi.fn(),
+  restoreCenterMock: vi.fn(),
+}));
+
+vi.mock('./use-chip-hover-pan.ts', () => ({
+  getMapInstance: getMapInstanceMock,
+  isPointOutsideComfortableArea: isPointOutsideComfortableAreaMock,
+  panToFeatureWithInspectorOffset: panToFeatureWithInspectorOffsetMock,
+  restoreCenter: restoreCenterMock,
+}));
+
+/** Builds a minimal airway entity state with N waypoints starting at (40, -100). */
+function airwayState(waypointCount: number): ResolvedEntityState {
+  const waypoints = Array.from({ length: waypointCount }, (_, i) => ({
+    name: `WP${i}`,
+    identifier: `WP${i}`,
+    waypointType: 'WAYPOINT' as const,
+    lat: 40 + i,
+    lon: -100 + i,
+  }));
+  const record: Airway = { designation: 'V16', type: 'VICTOR', region: 'US', waypoints };
+  return { status: 'resolved', entity: { kind: 'airway', record } };
+}
+
+/**
+ * Returns a stub Map ref where `getCenter` returns `pre-pan-center`,
+ * `on` and `off` are no-ops, and the helper hooks above are pre-wired
+ * via the module mock. Tests mutate `isPointOutsideComfortableAreaMock`
+ * per-case to drive the comfort gate.
+ */
+function makeMapRef(): { ref: MapRef; map: { getCenter: () => { lng: number; lat: number } } } {
+  const map = {
+    getCenter: vi.fn().mockReturnValue({ lng: -50, lat: 50 }),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return {
+    ref: { getMap: () => map } as unknown as MapRef,
+    map,
+  };
+}
+
+describe('useAirwayLegHoverPan', () => {
+  beforeEach(() => {
+    getMapInstanceMock.mockReset();
+    isPointOutsideComfortableAreaMock.mockReset();
+    panToFeatureWithInspectorOffsetMock.mockReset();
+    restoreCenterMock.mockReset();
+  });
+
+  it('eases the camera to the leg midpoint when a non-first waypoint row is hovered', () => {
+    // Hovering waypoint index 1 (the second row) targets the leg
+    // ending at WP1 - midpoint of WP0 [-100, 40] and WP1 [-99, 41]
+    // = (-99.5, 40.5). The comfort gate reports "outside" so the
+    // pre-pan center is captured for later restore.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(true);
+    renderHook(() =>
+      useAirwayLegHoverPan({
+        selected: 'airway:V16',
+        hoveredWaypointIndex: 1,
+        state: airwayState(3),
+        mapRef: ref,
+      }),
+    );
+    expect(panToFeatureWithInspectorOffsetMock).toHaveBeenCalledTimes(1);
+    expect(panToFeatureWithInspectorOffsetMock).toHaveBeenCalledWith(
+      { lng: -99.5, lat: 40.5 },
+      map,
+    );
+    expect(map.getCenter).toHaveBeenCalled();
+  });
+
+  it('eases the camera to the start waypoint itself when row 0 is hovered', () => {
+    // Hovering the first row (waypoint index 0) has no incoming leg,
+    // so the pan target is the waypoint's own coordinates - WP0 sits
+    // at [-100, 40], and that's exactly where the camera lands.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(true);
+    renderHook(() =>
+      useAirwayLegHoverPan({
+        selected: 'airway:V16',
+        hoveredWaypointIndex: 0,
+        state: airwayState(3),
+        mapRef: ref,
+      }),
+    );
+    expect(panToFeatureWithInspectorOffsetMock).toHaveBeenCalledTimes(1);
+    expect(panToFeatureWithInspectorOffsetMock).toHaveBeenCalledWith({ lng: -100, lat: 40 }, map);
+  });
+
+  it('skips the pan when the target is already comfortably onscreen', () => {
+    // The user's stated intent: only pan if the area is out of view.
+    // A target already in the un-occluded portion of the map should
+    // not jolt the camera.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(false);
+    renderHook(() =>
+      useAirwayLegHoverPan({
+        selected: 'airway:V16',
+        hoveredWaypointIndex: 1,
+        state: airwayState(3),
+        mapRef: ref,
+      }),
+    );
+    expect(panToFeatureWithInspectorOffsetMock).not.toHaveBeenCalled();
+    expect(restoreCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('restores the captured pre-pan center when the row is unhovered', () => {
+    // Hover then unhover within one mounted instance: the pre-pan
+    // capture from the hover phase drives the restore.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(true);
+    const { rerender } = renderHook(
+      ({ index }: { index: number | undefined }) =>
+        useAirwayLegHoverPan({
+          selected: 'airway:V16',
+          hoveredWaypointIndex: index,
+          state: airwayState(3),
+          mapRef: ref,
+        }),
+      { initialProps: { index: 1 as number | undefined } },
+    );
+    expect(panToFeatureWithInspectorOffsetMock).toHaveBeenCalledTimes(1);
+    rerender({ index: undefined });
+    expect(restoreCenterMock).toHaveBeenCalledTimes(1);
+    expect(restoreCenterMock).toHaveBeenCalledWith({ lng: -50, lat: 50 }, map);
+  });
+
+  it('does not restore on unhover when no pan ever fired in the session', () => {
+    // If the comfort gate kept the camera still on the hover-enter
+    // (because the target was already onscreen), the unhover phase
+    // has no captured center to restore - leaving the camera where
+    // the user left it.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(false);
+    const { rerender } = renderHook(
+      ({ index }: { index: number | undefined }) =>
+        useAirwayLegHoverPan({
+          selected: 'airway:V16',
+          hoveredWaypointIndex: index,
+          state: airwayState(3),
+          mapRef: ref,
+        }),
+      { initialProps: { index: 1 as number | undefined } },
+    );
+    rerender({ index: undefined });
+    expect(panToFeatureWithInspectorOffsetMock).not.toHaveBeenCalled();
+    expect(restoreCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the resolved entity is not an airway', () => {
+    // The hook is airway-specific: an airport / navaid / fix selection
+    // with a stray waypoint index in flight (e.g. URL flips between
+    // an airway and another entity) must not try to read `waypoints`.
+    // A `not-found` resolution exercises the same early-return path
+    // without forcing the test to construct a full Airport record.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(true);
+    const notFoundState: ResolvedEntityState = {
+      status: 'not-found',
+      ref: { type: 'airway', id: 'V16' },
+    };
+    renderHook(() =>
+      useAirwayLegHoverPan({
+        selected: 'airway:V16',
+        hoveredWaypointIndex: 0,
+        state: notFoundState,
+        mapRef: ref,
+      }),
+    );
+    expect(panToFeatureWithInspectorOffsetMock).not.toHaveBeenCalled();
+  });
+
+  it('does not pan when a waypoint index references a non-existent waypoint', () => {
+    // Defensive: waypoint index 5 in a 3-waypoint airway has no
+    // matching coordinate. The hook should bail rather than try to
+    // read undefined coordinates.
+    const { ref, map } = makeMapRef();
+    getMapInstanceMock.mockReturnValue(map);
+    isPointOutsideComfortableAreaMock.mockReturnValue(true);
+    renderHook(() =>
+      useAirwayLegHoverPan({
+        selected: 'airway:V16',
+        hoveredWaypointIndex: 5,
+        state: airwayState(3),
+        mapRef: ref,
+      }),
+    );
+    expect(panToFeatureWithInspectorOffsetMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the map ref is not yet available', () => {
+    // First render before MapLibre initializes: the hook should be
+    // inert, not throw on a `.getMap()` of undefined.
+    getMapInstanceMock.mockReturnValue(undefined);
+    expect(() =>
+      renderHook(() =>
+        useAirwayLegHoverPan({
+          selected: 'airway:V16',
+          hoveredWaypointIndex: 1,
+          state: airwayState(3),
+          mapRef: undefined,
+        }),
+      ),
+    ).not.toThrow();
+    expect(panToFeatureWithInspectorOffsetMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/atlas/src/shared/inspector/use-airway-leg-hover-pan.ts
+++ b/apps/atlas/src/shared/inspector/use-airway-leg-hover-pan.ts
@@ -1,0 +1,147 @@
+import { useEffect, useRef } from 'react';
+import type { MapRef } from '@vis.gl/react-maplibre';
+import {
+  getMapInstance,
+  isPointOutsideComfortableArea,
+  panToFeatureWithInspectorOffset,
+  restoreCenter,
+} from './use-chip-hover-pan.ts';
+import type { ResolvedEntityState } from './entity-resolver.ts';
+
+/**
+ * Inputs for {@link useAirwayLegHoverPan}. The hook is hard-wired to
+ * the chart-mode map and the inspector's resolved-entity state, so the
+ * caller threads its own copies of those through.
+ */
+export interface UseAirwayLegHoverPanArgs {
+  /**
+   * Currently-selected entity URL string (read from the search params).
+   * Drives the cleanup-on-selection-change effect so a stale captured
+   * center cannot bleed into a new selection.
+   */
+  selected: string | undefined;
+  /**
+   * Index of the waypoint row the inspector panel is currently
+   * hovering, or `undefined` when no row is hovered. Sourced from the
+   * chart-mode highlight context so the airway-panel is the single
+   * point of truth for the hover state.
+   */
+  hoveredWaypointIndex: number | undefined;
+  /**
+   * Resolved entity state for the current `selected`. The hook reads
+   * the airway record's waypoints to compute the pan target.
+   */
+  state: ResolvedEntityState;
+  /** Map ref returned by `useMap()` after `current ?? default` resolution. */
+  mapRef: MapRef | undefined;
+}
+
+/**
+ * Drives the camera while the user hovers per-row entries in the
+ * airway inspector panel. On hover, captures the pre-pan center and
+ * eases the camera so the relevant area lands in the un-occluded
+ * portion of the map; on unhover, eases back to the captured center.
+ * The captured center stays sticky across row-to-row transitions so
+ * the camera flows between legs without snapping back in between,
+ * only restoring once the cursor leaves the panel entirely.
+ *
+ * Pan target by row:
+ * - Row 0 (the route's start waypoint): the waypoint's own coords. No
+ *   incoming leg exists, so panning to the waypoint puts it center.
+ * - Rows 1+: the midpoint of the leg ending at that waypoint, so
+ *   both endpoints sit in view.
+ *
+ * Does nothing when the target is already comfortably onscreen - the
+ * user's request was specifically "if the leg is out of view, pan to
+ * it", and panning toward an already-visible feature would jolt the
+ * camera for no reason.
+ *
+ * Mobile callers gate the hover wiring at the panel level via
+ * `useCanHover()`, so on touch devices `hoveredWaypointIndex` never
+ * transitions and this hook stays inert. The pan-on-hover affordance
+ * is desktop-only by design: synthesized mouse events from a tap
+ * would otherwise yank the camera around on every touch.
+ */
+export function useAirwayLegHoverPan(args: UseAirwayLegHoverPanArgs): void {
+  const { selected, hoveredWaypointIndex, state, mapRef } = args;
+
+  // Pre-pan center captured the first time a leg-hover triggers a pan
+  // in this hover session. Persists across leg-to-leg transitions; the
+  // unhover-restore animates back to it.
+  const prePanCenterRef = useRef<{ lng: number; lat: number } | undefined>(undefined);
+
+  // A user-initiated drag is a clear "I am committed to this view"
+  // signal; clear the captured center so the next hover starts fresh
+  // instead of yanking the camera back to a stale position.
+  useEffect((): (() => void) | undefined => {
+    const map = getMapInstance(mapRef);
+    if (map === undefined) {
+      return undefined;
+    }
+    function handleDragStart(): void {
+      prePanCenterRef.current = undefined;
+    }
+    map.on('dragstart', handleDragStart);
+    return (): void => {
+      map.off('dragstart', handleDragStart);
+    };
+  }, [mapRef]);
+
+  // Selection change cleanup: a new entity should not inherit the
+  // pre-pan center captured for the previous one. useEffect is the
+  // sanctioned place for ref mutation in response to a prop change.
+  useEffect(() => {
+    prePanCenterRef.current = undefined;
+  }, [selected]);
+
+  // Drive the camera in response to hovered-row changes. Reads the
+  // current waypoints off the resolved entity so we always pan to
+  // fresh coordinates even if the airway dataset reloaded mid-session.
+  useEffect((): void => {
+    const map = getMapInstance(mapRef);
+    if (map === undefined) {
+      return;
+    }
+    if (hoveredWaypointIndex === undefined) {
+      const captured = prePanCenterRef.current;
+      if (captured !== undefined) {
+        restoreCenter(captured, map);
+        // Intentionally sticky: captured stays so a rapid leave-then-
+        // enter sequence does not recapture mid-restore.
+      }
+      return;
+    }
+    if (state.status !== 'resolved' || state.entity.kind !== 'airway') {
+      return;
+    }
+    const waypoints = state.entity.record.waypoints;
+    const current = waypoints[hoveredWaypointIndex];
+    if (current === undefined) {
+      return;
+    }
+    // Row 0 has no incoming leg - pan to the start waypoint itself
+    // so the user can see "this is where the route begins". Rows 1+
+    // pan to the leg midpoint so both endpoints stay in view.
+    const target =
+      hoveredWaypointIndex === 0
+        ? { lng: current.lon, lat: current.lat }
+        : (() => {
+            const previous = waypoints[hoveredWaypointIndex - 1];
+            if (previous === undefined) {
+              return { lng: current.lon, lat: current.lat };
+            }
+            return {
+              lng: (previous.lon + current.lon) / 2,
+              lat: (previous.lat + current.lat) / 2,
+            };
+          })();
+    if (!isPointOutsideComfortableArea(target, map)) {
+      return;
+    }
+    if (prePanCenterRef.current === undefined) {
+      const c = map.getCenter();
+      prePanCenterRef.current = { lng: c.lng, lat: c.lat };
+    }
+    panToFeatureWithInspectorOffset(target, map);
+  }, [hoveredWaypointIndex, state, mapRef]);
+}

--- a/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
+++ b/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
@@ -374,7 +374,7 @@ function chipCentroid(
  * the camera does not jolt for chip-hovers on already-visible
  * features.
  */
-function isPointOutsideComfortableArea(
+export function isPointOutsideComfortableArea(
   lngLat: { lng: number; lat: number },
   map: MaplibreMap,
 ): boolean {
@@ -402,7 +402,7 @@ function isPointOutsideComfortableArea(
  * mobile the negative y-offset shifts the focal point up so the
  * target appears in the visible top strip above the bottom sheet.
  */
-function panToFeatureWithInspectorOffset(
+export function panToFeatureWithInspectorOffset(
   lngLat: { lng: number; lat: number },
   map: MaplibreMap,
 ): void {
@@ -426,7 +426,7 @@ function panToFeatureWithInspectorOffset(
  * user's pre-pan view exactly, with no inspector compensation needed
  * since the user established that view themselves.
  */
-function restoreCenter(lngLat: { lng: number; lat: number }, map: MaplibreMap): void {
+export function restoreCenter(lngLat: { lng: number; lat: number }, map: MaplibreMap): void {
   map.easeTo({
     center: [lngLat.lng, lngLat.lat],
     duration: PAN_DURATION_MS,
@@ -439,6 +439,6 @@ function restoreCenter(lngLat: { lng: number; lat: number }, map: MaplibreMap): 
  * inspector renders before MapLibre has initialized, or in tests
  * where `useMap` returns an empty collection).
  */
-function getMapInstance(mapRef: MapRef | undefined): MaplibreMap | undefined {
+export function getMapInstance(mapRef: MapRef | undefined): MaplibreMap | undefined {
   return mapRef?.getMap();
 }

--- a/apps/atlas/src/shared/map/zoom-controls.spec.tsx
+++ b/apps/atlas/src/shared/map/zoom-controls.spec.tsx
@@ -77,6 +77,50 @@ describe('ZoomControls', () => {
     expect(screen.getByRole('button', { name: /tilt down/i })).toBeInTheDocument();
   });
 
+  it('renders the current zoom as a readout chip with an aria-label', () => {
+    // The chip pairs with the layer-toggle dropdown's "Zoom N+" hint, so
+    // it shares the same numeric language. Integer zooms drop the
+    // decimal for a cleaner glyph.
+    render(<ZoomControls />);
+    const readout = screen.getByRole('status');
+    expect(readout).toHaveTextContent('4');
+    expect(readout).toHaveAttribute('aria-label', 'Current zoom: 4');
+  });
+
+  it('renders a magnifying glass icon next to the zoom number so the readout reads as a zoom level', () => {
+    // The icon makes the meaning of "4" obvious - without it the
+    // chip looks like a generic count. Stays decorative (aria-hidden)
+    // because the readout's aria-label already conveys the meaning.
+    render(<ZoomControls />);
+    const readout = screen.getByRole('status');
+    const icon = readout.querySelector('svg');
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('formats fractional zooms to one decimal in the readout', () => {
+    getZoomMock.mockReturnValue(4.5);
+    render(<ZoomControls />);
+    const readout = screen.getByRole('status');
+    expect(readout).toHaveTextContent('4.5');
+    expect(readout).toHaveAttribute('aria-label', 'Current zoom: 4.5');
+  });
+
+  it('rounds zooms before formatting so 4.04 reads as "4" and 4.95 reads as "5"', () => {
+    // Without the round-then-format step a naive toFixed(1) on 4.04
+    // would yield "4.0" (with a stray decimal) and 4.95 would render
+    // "5.0" - both surprises. The formatter rounds first so the chip
+    // stays compact and predictable.
+    getZoomMock.mockReturnValue(4.04);
+    const { unmount } = render(<ZoomControls />);
+    expect(screen.getByRole('status')).toHaveTextContent('4');
+    unmount();
+
+    getZoomMock.mockReturnValue(4.95);
+    render(<ZoomControls />);
+    expect(screen.getByRole('status')).toHaveTextContent('5');
+  });
+
   it('eases to current zoom + 1 when the zoom-in button is clicked', () => {
     render(<ZoomControls />);
     fireEvent.click(screen.getByRole('button', { name: /zoom in/i }));

--- a/apps/atlas/src/shared/map/zoom-controls.tsx
+++ b/apps/atlas/src/shared/map/zoom-controls.tsx
@@ -137,6 +137,8 @@ export function ZoomControls(): ReactElement {
 
   return (
     <div className="absolute bottom-10 left-3 z-10 flex flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-md">
+      <ZoomReadout zoom={currentZoom} />
+      <div className="h-px bg-slate-200" aria-hidden="true" />
       <button
         type="button"
         onClick={handleZoomIn}
@@ -188,6 +190,78 @@ export function ZoomControls(): ReactElement {
  */
 const CONTROL_BUTTON_CLASS =
   'flex h-11 w-11 items-center justify-center text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white md:h-8 md:w-8';
+
+/**
+ * Compact text formatter for the {@link ZoomReadout}: integer zooms
+ * render bare ("4"), fractional zooms render to one decimal ("4.5").
+ * Matches the threshold style in the layer-toggle hints so a user can
+ * visually compare "Zoom 4.5" with a "Zoom 5+" hint at a glance.
+ */
+function formatZoomText(zoom: number): string {
+  // Round first so 4.04 does not display as "4.0" and 4.95 does not
+  // display as "5.0" (toFixed alone would produce both surprises).
+  const rounded = Math.round(zoom * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/**
+ * Static readout chip showing the current map zoom, rendered atop the
+ * zoom/tilt control stack. Drives the same numeric language as the
+ * layer-toggle dropdown's "Zoom N+" hint so the user can sanity-check
+ * whether a zoom-gated layer is about to appear or recently appeared.
+ *
+ * Non-interactive by design - clicking does nothing, the surrounding
+ * `+ / -` buttons are the way to change zoom. The icon stacks above
+ * the digits rather than sitting inline so the magnifying-glass shape
+ * stays large enough to be unambiguous (an inline 11px icon next to
+ * the digits visually compresses into a "Q" at desktop chip width).
+ * `tabular-nums` keeps the digit width stable across "4" / "10" /
+ * "12.5" so the chip footprint does not breathe.
+ */
+function ZoomReadout({ zoom }: { zoom: number }): ReactElement {
+  const text = formatZoomText(zoom);
+  return (
+    <div
+      role="status"
+      aria-label={`Current zoom: ${text}`}
+      className="flex h-11 w-11 flex-col items-center justify-center text-[10px] font-medium leading-none tabular-nums text-slate-600 md:h-8 md:w-8"
+    >
+      <ZoomIcon />
+      <span className="mt-0.5">{text}</span>
+    </div>
+  );
+}
+
+/**
+ * Magnifying-glass glyph used in the {@link ZoomReadout} chip. Sized
+ * at 14x14 (mobile) / 12x12 (desktop) so the round lens reads clearly
+ * - small enough to leave room for the digits below, large enough not
+ * to be mistaken for a "Q" formed by a tiny circle plus inline text.
+ * A small `+` inside the lens disambiguates the icon further: a
+ * magnifying-glass-with-plus is the universally-read "zoom" affordance,
+ * while a plain magnifying glass alone often reads as "search".
+ */
+function ZoomIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className="md:h-3.5 md:w-3.5"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M5 7H9" />
+      <path d="M7 5V9" />
+      <path d="M10.5 10.5L13.5 13.5" />
+    </svg>
+  );
+}
 
 /** Inline plus glyph for the zoom-in button. */
 function PlusIcon(): ReactElement {


### PR DESCRIPTION
Adds zoom-gated layer thresholds with a current-zoom readout, filter-based airport/navaid/fix tier visibility, and altitude-sorted airspace listings. Adds airway-panel row hover that highlights the waypoint plus its incoming leg, panning to it when offscreen.