### PR TITLE
Add light/dark/system theme toggle to atlas

### DIFF
--- a/apps/atlas/src/index.css
+++ b/apps/atlas/src/index.css
@@ -1,6 +1,21 @@
 @import 'tailwindcss';
 
 /*
+ * Class-based dark variant. Tailwind v4's default dark variant resolves
+ * via the `prefers-color-scheme` media query, which leaves no room for
+ * a user-driven toggle. The custom variant below activates the `dark:`
+ * utility for any element nested under `<html class="dark">` (or that
+ * carries `.dark` itself), so the in-app theme switcher in the shell
+ * can flip themes by writing the class to `documentElement` regardless
+ * of the OS preference.
+ *
+ * The `:where()` wrapper keeps the variant's selector specificity at
+ * zero so author classes (and the bare `dark:` prefix) continue to win
+ * the cascade as Tailwind users expect.
+ */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/*
  * Atlas-specific Tailwind theme extensions. Each `--spacing-*` entry
  * extends Tailwind's spacing scale and is reachable via every spacing
  * utility (`w-*`, `h-*`, `p-*`, `m-*`, `min-w-*`, etc.). Add a token

--- a/apps/atlas/src/main.tsx
+++ b/apps/atlas/src/main.tsx
@@ -3,6 +3,26 @@ import { createRoot } from 'react-dom/client';
 import { createRouter, RouterProvider } from '@tanstack/react-router';
 import './index.css';
 import { routeTree } from './routeTree.gen.ts';
+import { ThemeProvider } from './shared/styles/theme-provider.tsx';
+import {
+  DARK_CLASS_NAME,
+  PREFERS_DARK_MEDIA_QUERY,
+  THEME_STORAGE_KEY,
+  isThemePreference,
+} from './shared/styles/theme-context.ts';
+
+// FOUC guard. Resolve the persisted theme preference (or the OS preference
+// when the user is on `'system'`) and apply the `.dark` class to
+// `documentElement` synchronously, before React mounts and before the
+// first paint. Without this, a refresh under dark mode would briefly
+// flash the light palette while React works through its initial render
+// and the provider's effect schedules the className update.
+//
+// Mirrors the read logic in `ThemeProvider`; both fall back to `'system'`
+// on a missing or stale storage value, and both honor
+// `prefers-color-scheme` for the system case. Wrapped in try/catch so a
+// privacy-mode browser that throws on localStorage access still boots.
+applyInitialThemeClass();
 
 const router = createRouter({ routeTree });
 
@@ -19,6 +39,37 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <ThemeProvider>
+      <RouterProvider router={router} />
+    </ThemeProvider>
   </StrictMode>,
 );
+
+/**
+ * Reads the stored theme preference (or the OS preference when the
+ * stored value is `'system'`) and writes the matching class onto
+ * `documentElement`. Runs synchronously at module load so the class
+ * is in place before React's first paint.
+ */
+function applyInitialThemeClass(): void {
+  let preference: 'light' | 'dark' | 'system' = 'system';
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (isThemePreference(stored)) {
+      preference = stored;
+    }
+  } catch {
+    // Privacy-mode storage rejection - fall through to the system default.
+  }
+  let isDark = false;
+  if (preference === 'dark') {
+    isDark = true;
+  } else if (preference === 'system' && typeof window.matchMedia === 'function') {
+    isDark = window.matchMedia(PREFERS_DARK_MEDIA_QUERY).matches;
+  }
+  if (isDark) {
+    document.documentElement.classList.add(DARK_CLASS_NAME);
+  } else {
+    document.documentElement.classList.remove(DARK_CLASS_NAME);
+  }
+}

--- a/apps/atlas/src/modes/chart/chart-loading-indicator.tsx
+++ b/apps/atlas/src/modes/chart/chart-loading-indicator.tsx
@@ -147,17 +147,17 @@ export function ChartLoadingIndicator(): ReactElement | null {
   if (erroredSlot !== undefined) {
     return (
       <div
-        className="absolute inset-0 z-10 flex items-center justify-center bg-white/85"
+        className="absolute inset-0 z-10 flex items-center justify-center bg-white/85 dark:bg-slate-950/85"
         role="alert"
       >
-        <div className="w-72 rounded-lg border border-red-200 bg-white px-5 py-4 text-center shadow-md">
-          <div className="text-sm font-medium text-red-700">
+        <div className="w-72 rounded-lg border border-red-200 bg-white px-5 py-4 text-center shadow-md dark:border-red-900 dark:bg-slate-900">
+          <div className="text-sm font-medium text-red-700 dark:text-red-400">
             Couldn&apos;t load {erroredSlot.noun}.
           </div>
           <button
             type="button"
             onClick={() => window.location.reload()}
-            className="mt-3 rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white hover:bg-slate-800 md:py-1.5"
+            className="mt-3 rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white hover:bg-slate-800 md:py-1.5 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-slate-300"
           >
             Reload
           </button>
@@ -177,7 +177,7 @@ export function ChartLoadingIndicator(): ReactElement | null {
 
   return (
     <div
-      className="absolute inset-0 z-10 flex items-center justify-center bg-white/85 transition-opacity"
+      className="absolute inset-0 z-10 flex items-center justify-center bg-white/85 transition-opacity dark:bg-slate-950/85"
       style={{
         transitionDuration: `${FADE_OUT_MS}ms`,
         opacity: dismissing ? 0 : 1,
@@ -185,7 +185,7 @@ export function ChartLoadingIndicator(): ReactElement | null {
       role="status"
       aria-live="polite"
     >
-      <div className="flex w-72 items-center gap-3 rounded-lg border border-slate-200 bg-white px-5 py-3 shadow-md">
+      <div className="flex w-72 items-center gap-3 rounded-lg border border-slate-200 bg-white px-5 py-3 shadow-md dark:border-slate-700 dark:bg-slate-900">
         {complete ? (
           <span
             className="inline-block h-4 w-4 shrink-0 rounded-full bg-emerald-500"
@@ -193,11 +193,11 @@ export function ChartLoadingIndicator(): ReactElement | null {
           />
         ) : (
           <span
-            className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-200 border-t-slate-600"
+            className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-slate-200 border-t-slate-600 dark:border-slate-700 dark:border-t-slate-300"
             aria-hidden="true"
           />
         )}
-        <span className="text-sm font-medium text-slate-700">{message}</span>
+        <span className="text-sm font-medium text-slate-700 dark:text-slate-200">{message}</span>
       </div>
     </div>
   );

--- a/apps/atlas/src/modes/chart/disambiguation-popover.tsx
+++ b/apps/atlas/src/modes/chart/disambiguation-popover.tsx
@@ -197,11 +197,11 @@ export function DisambiguationPopover({
       clampKey={entries.length}
       role="menu"
       aria-label="Select a feature"
-      className="absolute z-30 flex max-h-[70vh] min-w-[12.5rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg"
+      className="absolute z-30 flex max-h-[70vh] min-w-[12.5rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900"
     >
-      <p className="flex shrink-0 items-baseline justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-slate-600 uppercase">
+      <p className="flex shrink-0 items-baseline justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5 text-[11px] font-semibold tracking-wide text-slate-600 uppercase dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
         <span>Select a feature</span>
-        <span className="font-mono text-slate-400">{entries.length}</span>
+        <span className="font-mono text-slate-400 dark:text-slate-500">{entries.length}</span>
       </p>
       <ul className="flex flex-col overflow-y-auto">
         {entries.map((entry) => (
@@ -216,14 +216,14 @@ export function DisambiguationPopover({
               })}
               onFocus={(): void => setHoveredChipSelection(entry.selection)}
               onBlur={(): void => setHoveredChipSelection(undefined)}
-              className="flex w-full items-baseline gap-2 px-3 py-3 text-left text-sm text-slate-700 hover:bg-indigo-50 hover:text-indigo-700 focus:bg-indigo-50 focus:text-indigo-700 focus:outline-none md:py-1.5"
+              className="flex w-full items-baseline gap-2 px-3 py-3 text-left text-sm text-slate-700 hover:bg-indigo-50 hover:text-indigo-700 focus:bg-indigo-50 focus:text-indigo-700 focus:outline-none md:py-1.5 dark:text-slate-200 dark:hover:bg-indigo-950/50 dark:hover:text-indigo-300 dark:focus:bg-indigo-950/50 dark:focus:text-indigo-300"
             >
-              <span className="w-14 shrink-0 text-[10px] font-semibold tracking-wide text-slate-500 uppercase">
+              <span className="w-14 shrink-0 text-[10px] font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
                 {entry.type}
               </span>
               <span className="font-medium">{entry.label}</span>
               {entry.subtitle === undefined ? null : (
-                <span className="ml-auto pl-2 font-mono text-xs text-slate-500">
+                <span className="ml-auto pl-2 font-mono text-xs text-slate-500 dark:text-slate-400">
                   {entry.subtitle}
                 </span>
               )}
@@ -232,7 +232,7 @@ export function DisambiguationPopover({
         ))}
       </ul>
       {entries.length > HINT_THRESHOLD ? (
-        <p className="shrink-0 border-t border-slate-200 bg-slate-50 px-3 py-1.5 text-[10px] tracking-wide text-slate-500 italic">
+        <p className="shrink-0 border-t border-slate-200 bg-slate-50 px-3 py-1.5 text-[10px] tracking-wide text-slate-500 italic dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400">
           Zoom in for fewer options
         </p>
       ) : null}

--- a/apps/atlas/src/modes/chart/layer-toggle.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.tsx
@@ -217,14 +217,14 @@ export function LayerToggle(): ReactElement {
 
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger className="absolute right-3 top-3 z-10 rounded-md border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-slate-700 shadow-md hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:py-1.5">
+      <DropdownMenu.Trigger className="absolute right-3 top-3 z-10 rounded-md border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-slate-700 shadow-md hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:py-1.5 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-slate-500">
         Layers
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           align="end"
           sideOffset={4}
-          className="min-w-[14rem] rounded-md border border-slate-200 bg-white p-1 shadow-lg"
+          className="min-w-[14rem] rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
         >
           {LAYER_OPTIONS.map((option) => {
             const isExpandable = EXPANDABLE_LAYERS.has(option.id);
@@ -323,7 +323,7 @@ function SimpleParentRow({
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
+      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5 dark:text-slate-200 dark:data-[highlighted]:bg-slate-800"
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -399,7 +399,7 @@ function ExpandableParentRow({
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
       onKeyDown={handleKeyDown}
-      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
+      className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5 dark:text-slate-200 dark:data-[highlighted]:bg-slate-800"
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -455,7 +455,7 @@ function ExpandToggleButton({
       onClick={handleClick}
       onPointerDown={stopPointer}
       onPointerUp={stopPointer}
-      className="-mr-1 flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-200 hover:text-slate-700 md:h-7 md:w-7"
+      className="-mr-1 flex h-11 w-11 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-200 hover:text-slate-700 md:h-7 md:w-7 dark:text-slate-400 dark:hover:bg-slate-700 dark:hover:text-slate-100"
     >
       <ChevronIcon expanded={expanded} />
     </button>
@@ -483,7 +483,7 @@ function SubRow({ label, checked, onCheckedChange }: SubRowProps): ReactElement 
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="flex cursor-default items-center gap-2 rounded py-2.5 pl-8 pr-2 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5"
+      className="flex cursor-default items-center gap-2 rounded py-2.5 pl-8 pr-2 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5 dark:text-slate-200 dark:data-[highlighted]:bg-slate-800"
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -518,8 +518,8 @@ function SubCountChip({ enabled, total, dimmed }: SubCountChipProps): ReactEleme
   // when the parent layer is off (and thus the count is informational, not
   // representing visible features).
   const colorClasses = dimmed
-    ? 'border border-slate-200 bg-transparent text-slate-400'
-    : 'bg-slate-700 text-white';
+    ? 'border border-slate-200 bg-transparent text-slate-400 dark:border-slate-700 dark:text-slate-500'
+    : 'bg-slate-700 text-white dark:bg-slate-200 dark:text-slate-900';
   return (
     <span
       className={`${baseClasses} ${colorClasses}`}
@@ -548,7 +548,7 @@ interface ZoomGatedHintProps {
 function ZoomGatedHint({ minZoom }: ZoomGatedHintProps): ReactElement {
   return (
     <span
-      className="inline-flex shrink-0 items-center rounded-sm border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-slate-500"
+      className="inline-flex shrink-0 items-center rounded-sm border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-slate-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400"
       aria-label={`Appears at zoom ${minZoom} and above`}
     >
       Zoom {minZoom}+
@@ -594,8 +594,8 @@ function ChevronIcon({ expanded }: { expanded: boolean }): ReactElement {
       aria-hidden="true"
       className={
         expanded
-          ? 'rotate-90 text-slate-500 transition-transform'
-          : 'text-slate-500 transition-transform'
+          ? 'rotate-90 text-slate-500 transition-transform dark:text-slate-400'
+          : 'text-slate-500 transition-transform dark:text-slate-400'
       }
     >
       <path d="M3.5 2L7 5L3.5 8" />

--- a/apps/atlas/src/modes/chart/layers/airports-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airports-layer.tsx
@@ -6,11 +6,7 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Airport } from '@squawk/types';
 import { useAirportDataset } from '../../../shared/data/airport-dataset.ts';
-import {
-  CHART_AIRPORT_COLORS,
-  CHART_HIGHLIGHT_COLORS,
-  CHART_SYMBOL_STROKE,
-} from '../../../shared/styles/chart-colors.ts';
+import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 
 /**
@@ -90,24 +86,6 @@ function toFeatureCollection(
 }
 
 /**
- * Highlight overlay for the currently-selected (or chip-hovered) airport.
- * A larger yellow circle with a dark stroke, drawn on top of the regular
- * airport layer. Filtered to the active airport's `faaId`; renders
- * nothing when no airport is active.
- */
-const AIRPORTS_HIGHLIGHT_LAYER_BASE: LayerProps = {
-  id: AIRPORTS_HIGHLIGHT_LAYER_ID,
-  source: AIRPORTS_SOURCE_ID,
-  type: 'circle',
-  paint: {
-    'circle-radius': 9,
-    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
-    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
-    'circle-stroke-width': 2,
-  },
-};
-
-/**
  * Per-tier zoom thresholds. An airport is visible at the current zoom
  * iff its tier's threshold is met. A `circle-radius: 0` paint stop is
  * not enough on its own - MapLibre still draws the 1px white stroke
@@ -123,55 +101,40 @@ const AIRPORT_SMALL_TIER_MIN_ZOOM = 9;
 const AIRPORT_TINY_TIER_MIN_ZOOM = 12;
 
 /**
- * MapLibre layer styling. Visibility is gated by runway length: only
- * 8000-ft+ airports show at low zoom, mid-size fields appear at z6,
- * smaller ones at z9, and the long tail at z12. Color separates major
- * airports (longest runway >= 8000 ft) from the rest.
- *
- * Within a single zoom stop every visible airport renders at the same
- * radius - the visibility filter controls *whether* an airport is
- * visible, while the radius interpolation only controls how big the
- * dot grows as the user zooms in. So when 5000-ft airports appear at
- * z6 they pop in at the same dot size as the 8000-ft airports already
- * on screen, rather than as tinier sub-class specks.
+ * Visibility filter shared by every render of {@link AirportsLayer}.
+ * Pulled out so the per-render `useMemo` building the layer props
+ * does not need to recreate the filter array (which is color-
+ * independent) when the theme changes.
  */
-const AIRPORTS_LAYER_PROPS: LayerProps = {
-  id: AIRPORTS_LAYER_ID,
-  source: AIRPORTS_SOURCE_ID,
-  type: 'circle',
-  filter: [
-    'any',
-    ['>=', ['get', 'longestRunwayFt'], 8000],
-    ['all', ['>=', ['zoom'], AIRPORT_MID_TIER_MIN_ZOOM], ['>=', ['get', 'longestRunwayFt'], 5000]],
-    [
-      'all',
-      ['>=', ['zoom'], AIRPORT_SMALL_TIER_MIN_ZOOM],
-      ['>=', ['get', 'longestRunwayFt'], 3000],
-    ],
-    ['>=', ['zoom'], AIRPORT_TINY_TIER_MIN_ZOOM],
-  ],
-  paint: {
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 2.5, 6, 3, 9, 4, 12, 5, 16, 10],
-    'circle-color': [
-      'case',
-      ['>=', ['get', 'longestRunwayFt'], 8000],
-      CHART_AIRPORT_COLORS.major,
-      CHART_AIRPORT_COLORS.minor,
-    ],
-    'circle-stroke-color': CHART_SYMBOL_STROKE,
-    'circle-stroke-width': 1,
-  },
-};
+const AIRPORTS_VISIBILITY_FILTER: ExpressionSpecification = [
+  'any',
+  ['>=', ['get', 'longestRunwayFt'], 8000],
+  ['all', ['>=', ['zoom'], AIRPORT_MID_TIER_MIN_ZOOM], ['>=', ['get', 'longestRunwayFt'], 5000]],
+  ['all', ['>=', ['zoom'], AIRPORT_SMALL_TIER_MIN_ZOOM], ['>=', ['get', 'longestRunwayFt'], 3000]],
+  ['>=', ['zoom'], AIRPORT_TINY_TIER_MIN_ZOOM],
+];
 
 /**
  * Chart-mode overlay that renders airports from `@squawk/airport-data` as
  * MapLibre circle symbols. Returns `null` while the dataset is still being
  * fetched or if the load failed; callers needing fetch-state UI should read
  * the same hook directly.
+ *
+ * Visibility is gated by runway length: only 8000-ft+ airports show at
+ * low zoom, mid-size fields appear at z6, smaller ones at z9, and the
+ * long tail at z12. Color separates major airports (longest runway
+ * >= 8000 ft) from the rest. Within a single zoom stop every visible
+ * airport renders at the same radius - the visibility filter controls
+ * *whether* an airport is visible, while the radius interpolation only
+ * controls how big the dot grows as the user zooms in. So when 5000-ft
+ * airports appear at z6 they pop in at the same dot size as the
+ * 8000-ft airports already on screen, rather than as tinier sub-class
+ * specks.
  */
 export function AirportsLayer(): ReactElement | null {
   const state = useAirportDataset();
   const activeRef = useActiveHighlightRef();
+  const colors = useChartColors();
 
   const data = useMemo<FeatureCollection<Point, AirportFeatureProperties> | undefined>(() => {
     if (state.status !== 'loaded') {
@@ -180,11 +143,50 @@ export function AirportsLayer(): ReactElement | null {
     return toFeatureCollection(state.dataset.records);
   }, [state]);
 
+  // Layer paint props are themed: re-memoize when the resolved chart
+  // palette flips so MapLibre receives the new color values through
+  // its declarative `paint` prop pipeline.
+  const layerProps = useMemo<LayerProps>(
+    () => ({
+      id: AIRPORTS_LAYER_ID,
+      source: AIRPORTS_SOURCE_ID,
+      type: 'circle',
+      filter: AIRPORTS_VISIBILITY_FILTER,
+      paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 4, 2.5, 6, 3, 9, 4, 12, 5, 16, 10],
+        'circle-color': [
+          'case',
+          ['>=', ['get', 'longestRunwayFt'], 8000],
+          colors.airport.major,
+          colors.airport.minor,
+        ],
+        'circle-stroke-color': colors.symbolStroke,
+        'circle-stroke-width': 1,
+      },
+    }),
+    [colors],
+  );
+
+  // Highlight overlay for the currently-selected (or chip-hovered)
+  // airport. A larger yellow circle with a contrasting stroke, drawn
+  // on top of the regular airport layer. Filtered to the active
+  // airport's `faaId`; renders nothing when no airport is active.
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const filter: ExpressionSpecification =
       activeRef?.type === 'airport' ? ['==', ['get', 'faaId'], activeRef.id] : MATCH_NONE_FILTER;
-    return { ...AIRPORTS_HIGHLIGHT_LAYER_BASE, filter };
-  }, [activeRef]);
+    return {
+      id: AIRPORTS_HIGHLIGHT_LAYER_ID,
+      source: AIRPORTS_SOURCE_ID,
+      type: 'circle',
+      filter,
+      paint: {
+        'circle-radius': 9,
+        'circle-color': colors.highlight.primary,
+        'circle-stroke-color': colors.highlight.stroke,
+        'circle-stroke-width': 2,
+      },
+    };
+  }, [activeRef, colors]);
 
   if (data === undefined) {
     return null;
@@ -192,7 +194,7 @@ export function AirportsLayer(): ReactElement | null {
 
   return (
     <Source id={AIRPORTS_SOURCE_ID} type="geojson" data={data}>
-      <Layer {...AIRPORTS_LAYER_PROPS} />
+      <Layer {...layerProps} />
       <Layer {...highlightLayerProps} />
     </Source>
   );

--- a/apps/atlas/src/modes/chart/layers/airspace-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airspace-layer.tsx
@@ -8,10 +8,11 @@ import type { Feature, FeatureCollection } from 'geojson';
 import { polygonGeoJson } from '@squawk/geo';
 import type { AirspaceType } from '@squawk/types';
 import { useAirspaceDataset } from '../../../shared/data/airspace-dataset.ts';
-import {
-  CHART_AIRSPACE_BADGE_COLORS,
-  CHART_AIRSPACE_COLORS,
-  CHART_HIGHLIGHT_COLORS,
+import { useChartColors } from '../../../shared/styles/chart-colors.ts';
+import type {
+  ChartAirspaceBadgeColors,
+  ChartAirspaceColors,
+  ChartHighlightColors,
 } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef, useHoveredFeatureIndex } from '../highlight-context.ts';
 import { AIRSPACE_CLASS_TYPES, CHART_ROUTE_PATH } from '../url-state.ts';
@@ -65,11 +66,22 @@ const TOP_OF_STACK_LAYER_IDS = [
 ] as const;
 
 /**
- * MapLibre image id for the diagonal hatch pattern used by the
- * highlight fill. Registered once per map instance via `addImage` and
- * referenced by name from the layer's `fill-pattern` paint property.
+ * Base name for the diagonal hatch pattern image used by the highlight
+ * fill. The actual MapLibre image id is suffixed with the highlight
+ * color so a theme switch registers a fresh image instead of reusing
+ * the stale one from the previous palette - MapLibre's `hasImage`
+ * short-circuit would otherwise keep the original color forever.
  */
-const HATCH_IMAGE_ID = 'atlas-airspace-hatch';
+const HATCH_IMAGE_BASE_ID = 'atlas-airspace-hatch';
+
+/**
+ * Builds the MapLibre image id for the hatch pattern, suffixed by the
+ * highlight color so light and dark themes reference distinct images
+ * and a theme switch never sees a stale color through `hasImage`.
+ */
+function hatchImageId(highlightPrimary: string): string {
+  return `${HATCH_IMAGE_BASE_ID}-${highlightPrimary}`;
+}
 
 /**
  * Synthetic per-feature property added at source-projection time so the
@@ -153,174 +165,46 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 ];
 
 /**
- * Highlight overlay for the currently-selected (or chip-hovered) airspace.
- * Thick yellow stroke makes the active polygon pop against the basemap and
- * against neighbouring airspaces of the same type.
- */
-const AIRSPACE_HIGHLIGHT_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_HIGHLIGHT_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'line',
-  layout: {
-    'line-cap': 'round',
-    'line-join': 'round',
-  },
-  paint: {
-    'line-color': CHART_HIGHLIGHT_COLORS.primary,
-    'line-width': 3,
-    'line-opacity': 1,
-  },
-};
-
-/**
- * Cross-hatched fill rendered across the entire interior of the
- * highlighted airspace. Lives on top of the regular tinted fill so the
- * underlying class color stays visible underneath; rendered at moderate
- * opacity so dense overlapping selections do not wash out the basemap.
+ * Builds the MapLibre `match` expression that maps airspace type to
+ * color. Shared between the fill and outline layers so they always
+ * agree. Covers every `AirspaceType` value the dataset emits; the
+ * trailing string is the default fallback for any unrecognized future
+ * type. Class E subtypes (E2 through E7) all share a single pink,
+ * mirroring how sectional charts use a magenta family for every Class
+ * E variant.
  *
- * Without this layer, panning so the polygon's outline goes offscreen
- * would leave the user with no visual indicator of which airspace is
- * selected (the yellow outline alone is offscreen). With the hatch,
- * the visible portion of the polygon shows the pattern, anchoring the
- * selection even at extreme zooms.
+ * Built per-render from the resolved palette so a theme switch flips
+ * every airspace fill/outline color in lockstep.
  */
-const AIRSPACE_HIGHLIGHT_FILL_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_HIGHLIGHT_FILL_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'fill',
-  paint: {
-    'fill-pattern': HATCH_IMAGE_ID,
-    'fill-opacity': 0.6,
-  },
-};
-
-/**
- * Per-feature focus outline. Rendered on top of the entity-level
- * highlight stroke so the hovered feature stands out from its
- * siblings. Brighter, lighter yellow + slightly thicker line so the
- * eye registers it as "the one". Filter is empty (matches nothing)
- * when no inspector section is hovered.
- */
-const AIRSPACE_FEATURE_FOCUS_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_FEATURE_FOCUS_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'line',
-  layout: {
-    'line-cap': 'round',
-    'line-join': 'round',
-  },
-  paint: {
-    'line-color': CHART_HIGHLIGHT_COLORS.focusOutline,
-    'line-width': 5,
-    'line-opacity': 1,
-  },
-};
-
-/**
- * Per-feature badge label rendered at each polygon centroid. Symbol
- * layers default to point-placement on Polygon source features, so
- * MapLibre auto-positions the label at the polygon's representative
- * point without a separate Point source. The dark halo gives the text
- * legibility against any basemap or fill underneath. Filter is empty
- * when no airspace is selected or when the selected airspace has only
- * one feature (single-feature airspaces need no disambiguation).
- */
-const AIRSPACE_FEATURE_BADGE_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_FEATURE_BADGE_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'symbol',
-  layout: {
-    'text-field': ['get', AIRSPACE_FEATURE_LABEL_PROPERTY],
-    'text-font': ['Noto Sans Bold'],
-    'text-size': 13,
-    // Per-feature offset attached at projection time. Distributes
-    // badges into a vertical column centered on the polygon centroid
-    // so concentric rings (Class B) and stacked strata (ARTCC) -
-    // whose centroids would otherwise sit on the same pixel - end
-    // up readable at any zoom.
-    'text-offset': ['get', AIRSPACE_BADGE_OFFSET_PROPERTY],
-    'text-allow-overlap': true,
-    'text-ignore-placement': true,
-  },
-  paint: {
-    'text-color': CHART_AIRSPACE_BADGE_COLORS.text,
-    'text-halo-color': CHART_AIRSPACE_BADGE_COLORS.halo,
-    'text-halo-width': 2.5,
-  },
-};
-
-/**
- * MapLibre `match` expression mapping airspace type to color. Shared
- * between the fill and outline layers so they always agree. Covers every
- * `AirspaceType` value the dataset emits; the trailing string is the
- * default fallback for any unrecognized future type.
- *
- * Class E subtypes (E2 through E7) all share a single pink, mirroring how
- * sectional charts use a magenta family for every Class E variant.
- */
-const TYPE_COLOR_EXPRESSION = [
-  'match',
-  ['get', 'type'],
-  'CLASS_B',
-  CHART_AIRSPACE_COLORS.classB,
-  'CLASS_C',
-  CHART_AIRSPACE_COLORS.classC,
-  'CLASS_D',
-  CHART_AIRSPACE_COLORS.classD,
-  ['CLASS_E2', 'CLASS_E3', 'CLASS_E4', 'CLASS_E5', 'CLASS_E6', 'CLASS_E7'],
-  CHART_AIRSPACE_COLORS.classE,
-  'MOA',
-  CHART_AIRSPACE_COLORS.moa,
-  'RESTRICTED',
-  CHART_AIRSPACE_COLORS.restricted,
-  'PROHIBITED',
-  CHART_AIRSPACE_COLORS.prohibited,
-  'WARNING',
-  CHART_AIRSPACE_COLORS.warning,
-  'ALERT',
-  CHART_AIRSPACE_COLORS.alert,
-  'NSA',
-  CHART_AIRSPACE_COLORS.nsa,
-  'ARTCC',
-  CHART_AIRSPACE_COLORS.artcc,
-  CHART_AIRSPACE_COLORS.fallback,
-] satisfies ExpressionSpecification;
-
-/**
- * Polygon fill layer styling, sans filter. Uses a low alpha so airspace
- * boundaries read as gentle tints rather than dominant blocks of color,
- * leaving the basemap and other overlays legible. The visibility filter is
- * built per-render from the active `airspaceClasses` URL state.
- */
-const AIRSPACE_FILL_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_FILL_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'fill',
-  paint: {
-    'fill-color': TYPE_COLOR_EXPRESSION,
-    'fill-opacity': 0.08,
-  },
-};
-
-/**
- * Polygon outline layer styling, sans filter. Stroke color matches the
- * fill so each airspace is visually a single unit; stroke is thin so
- * dense areas do not clutter.
- */
-const AIRSPACE_LINE_LAYER_BASE: LayerProps = {
-  id: AIRSPACE_LINE_LAYER_ID,
-  source: AIRSPACE_SOURCE_ID,
-  type: 'line',
-  layout: {
-    'line-cap': 'round',
-    'line-join': 'round',
-  },
-  paint: {
-    'line-color': TYPE_COLOR_EXPRESSION,
-    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.6, 8, 1.2, 12, 2],
-    'line-opacity': 0.7,
-  },
-};
+function buildTypeColorExpression(airspace: ChartAirspaceColors): ExpressionSpecification {
+  return [
+    'match',
+    ['get', 'type'],
+    'CLASS_B',
+    airspace.classB,
+    'CLASS_C',
+    airspace.classC,
+    'CLASS_D',
+    airspace.classD,
+    ['CLASS_E2', 'CLASS_E3', 'CLASS_E4', 'CLASS_E5', 'CLASS_E6', 'CLASS_E7'],
+    airspace.classE,
+    'MOA',
+    airspace.moa,
+    'RESTRICTED',
+    airspace.restricted,
+    'PROHIBITED',
+    airspace.prohibited,
+    'WARNING',
+    airspace.warning,
+    'ALERT',
+    airspace.alert,
+    'NSA',
+    airspace.nsa,
+    'ARTCC',
+    airspace.artcc,
+    airspace.fallback,
+  ];
+}
 
 /**
  * Chart-mode overlay that renders airspace polygons from
@@ -337,6 +221,8 @@ export function AirspaceLayer(): ReactElement | null {
   const { airspaceClasses } = route.useSearch();
   const state = useAirspaceDataset();
   const activeRef = useActiveHighlightRef();
+  const colors = useChartColors();
+  const hatchId = hatchImageId(colors.highlight.primary);
 
   const enabledTypes = useMemo<readonly AirspaceType[]>(
     () => airspaceClasses.flatMap((cls) => AIRSPACE_CLASS_TYPES[cls]),
@@ -348,14 +234,44 @@ export function AirspaceLayer(): ReactElement | null {
     [enabledTypes],
   );
 
+  // Polygon fill layer. Uses a low alpha so airspace boundaries read
+  // as gentle tints rather than dominant blocks of color, leaving the
+  // basemap and other overlays legible. Re-memoized when the resolved
+  // palette flips so the type-color expression follows the theme.
   const fillLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_FILL_LAYER_BASE, filter }),
-    [filter],
+    () => ({
+      id: AIRSPACE_FILL_LAYER_ID,
+      source: AIRSPACE_SOURCE_ID,
+      type: 'fill',
+      filter,
+      paint: {
+        'fill-color': buildTypeColorExpression(colors.airspace),
+        'fill-opacity': 0.08,
+      },
+    }),
+    [filter, colors],
   );
 
+  // Polygon outline layer. Stroke color matches the fill so each
+  // airspace reads as a single unit; stroke is thin so dense areas do
+  // not clutter.
   const lineLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_LINE_LAYER_BASE, filter }),
-    [filter],
+    () => ({
+      id: AIRSPACE_LINE_LAYER_ID,
+      source: AIRSPACE_SOURCE_ID,
+      type: 'line',
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      filter,
+      paint: {
+        'line-color': buildTypeColorExpression(colors.airspace),
+        'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.6, 8, 1.2, 12, 2],
+        'line-opacity': 0.7,
+      },
+    }),
+    [filter, colors],
   );
 
   // Project the source dataset to add a synthetic match-key property
@@ -377,21 +293,55 @@ export function AirspaceLayer(): ReactElement | null {
     return MATCH_NONE_FILTER;
   }, [activeRef]);
 
+  // Highlight outline overlay for the currently-selected (or
+  // chip-hovered) airspace. Thick yellow stroke makes the active
+  // polygon pop against the basemap and against neighbouring
+  // airspaces of the same type.
   const highlightLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_HIGHLIGHT_LAYER_BASE, filter: highlightFilter }),
-    [highlightFilter],
+    () => ({
+      id: AIRSPACE_HIGHLIGHT_LAYER_ID,
+      source: AIRSPACE_SOURCE_ID,
+      type: 'line',
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      filter: highlightFilter,
+      paint: {
+        'line-color': colors.highlight.primary,
+        'line-width': 3,
+        'line-opacity': 1,
+      },
+    }),
+    [highlightFilter, colors],
   );
 
+  // Cross-hatched fill rendered across the entire interior of the
+  // highlighted airspace. Lives on top of the regular tinted fill so
+  // the underlying class color stays visible underneath; rendered at
+  // moderate opacity so dense overlapping selections do not wash out
+  // the basemap. Without this layer, panning so the polygon's outline
+  // goes offscreen would leave the user with no visual indicator of
+  // which airspace is selected.
   const highlightFillLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_HIGHLIGHT_FILL_LAYER_BASE, filter: highlightFilter }),
-    [highlightFilter],
+    () => ({
+      id: AIRSPACE_HIGHLIGHT_FILL_LAYER_ID,
+      source: AIRSPACE_SOURCE_ID,
+      type: 'fill',
+      filter: highlightFilter,
+      paint: {
+        'fill-pattern': hatchId,
+        'fill-opacity': 0.6,
+      },
+    }),
+    [highlightFilter, hatchId],
   );
 
-  // Register the hatch pattern image once per map instance. The fill
-  // layer references it by name; if the image is missing MapLibre
-  // silently skips the fill, so a slight delay between mount and
-  // pattern-load is harmless.
-  useHatchPatternImage();
+  // Register the hatch pattern image once per map instance per theme.
+  // The fill layer references the per-theme image by name; if the
+  // image is missing MapLibre silently skips the fill, so a slight
+  // delay between mount and pattern-load is harmless.
+  useHatchPatternImage(hatchId, colors.highlight.primary);
 
   if (state.status !== 'loaded' || sourceData === undefined) {
     return null;
@@ -423,6 +373,7 @@ export function AirspaceFeatureOverlayLayers(): ReactElement | null {
   const state = useAirspaceDataset();
   const activeRef = useActiveHighlightRef();
   const hoveredFeatureIndex = useHoveredFeatureIndex();
+  const colors = useChartColors();
 
   // Badge filter: visible when an airspace with 2+ features is the
   // active selection. Single-feature airspaces don't need disambiguation
@@ -438,9 +389,17 @@ export function AirspaceFeatureOverlayLayers(): ReactElement | null {
     return MATCH_NONE_FILTER;
   }, [activeRef]);
 
+  // Per-feature badge label rendered at each polygon centroid. Symbol
+  // layers default to point-placement on Polygon source features, so
+  // MapLibre auto-positions the label at the polygon's representative
+  // point without a separate Point source. The dark halo gives the
+  // text legibility against any basemap or fill underneath. Filter is
+  // empty when no airspace is selected or when the selected airspace
+  // has only one feature (single-feature airspaces need no
+  // disambiguation).
   const badgeLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_FEATURE_BADGE_LAYER_BASE, filter: badgeFilter }),
-    [badgeFilter],
+    () => buildBadgeLayerProps(badgeFilter, colors.airspaceBadge),
+    [badgeFilter, colors],
   );
 
   // Feature-focus filter: matches the polygon whose inspector section
@@ -462,9 +421,14 @@ export function AirspaceFeatureOverlayLayers(): ReactElement | null {
     return MATCH_NONE_FILTER;
   }, [activeRef, hoveredFeatureIndex]);
 
+  // Per-feature focus outline. Rendered on top of the entity-level
+  // highlight stroke so the hovered feature stands out from its
+  // siblings. Brighter, lighter yellow + slightly thicker line so the
+  // eye registers it as "the one". Filter is empty (matches nothing)
+  // when no inspector section is hovered.
   const featureFocusLayerProps = useMemo<LayerProps>(
-    () => ({ ...AIRSPACE_FEATURE_FOCUS_LAYER_BASE, filter: featureFocusFilter }),
-    [featureFocusFilter],
+    () => buildFeatureFocusLayerProps(featureFocusFilter, colors.highlight),
+    [featureFocusFilter, colors],
   );
 
   // Force the focus + badge layers to the very top of MapLibre's layer
@@ -527,17 +491,79 @@ function useTopOfStack(layerIds: readonly string[]): void {
 }
 
 /**
- * Registers the cross-hatch pattern image with the underlying MapLibre
- * map exactly once per style load. The fill-pattern layer above
- * references the image by name, so the image must exist before the
- * layer paints (MapLibre silently skips fill-pattern when the image is
- * missing, then re-paints once it lands).
- *
- * Subscribes to `styledata` so the image is re-registered if the style
- * is reloaded (e.g. on basemap swap). `hasImage` short-circuits the
- * common "already there" case so we only allocate the canvas once.
+ * Builds the {@link LayerProps} for the per-feature focus outline,
+ * sourcing the line color from the resolved highlight palette so a
+ * theme switch flips the focused-polygon outline along with the rest
+ * of the highlight chrome.
  */
-function useHatchPatternImage(): void {
+function buildFeatureFocusLayerProps(
+  filter: ExpressionSpecification,
+  highlight: ChartHighlightColors,
+): LayerProps {
+  return {
+    id: AIRSPACE_FEATURE_FOCUS_LAYER_ID,
+    source: AIRSPACE_SOURCE_ID,
+    type: 'line',
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+    filter,
+    paint: {
+      'line-color': highlight.focusOutline,
+      'line-width': 5,
+      'line-opacity': 1,
+    },
+  };
+}
+
+/**
+ * Builds the {@link LayerProps} for the per-feature badge label,
+ * sourcing the text and halo colors from the resolved badge palette.
+ */
+function buildBadgeLayerProps(
+  filter: ExpressionSpecification,
+  badge: ChartAirspaceBadgeColors,
+): LayerProps {
+  return {
+    id: AIRSPACE_FEATURE_BADGE_LAYER_ID,
+    source: AIRSPACE_SOURCE_ID,
+    type: 'symbol',
+    layout: {
+      'text-field': ['get', AIRSPACE_FEATURE_LABEL_PROPERTY],
+      'text-font': ['Noto Sans Bold'],
+      'text-size': 13,
+      // Per-feature offset attached at projection time. Distributes
+      // badges into a vertical column centered on the polygon
+      // centroid so concentric rings (Class B) and stacked strata
+      // (ARTCC) - whose centroids would otherwise sit on the same
+      // pixel - end up readable at any zoom.
+      'text-offset': ['get', AIRSPACE_BADGE_OFFSET_PROPERTY],
+      'text-allow-overlap': true,
+      'text-ignore-placement': true,
+    },
+    filter,
+    paint: {
+      'text-color': badge.text,
+      'text-halo-color': badge.halo,
+      'text-halo-width': 2.5,
+    },
+  };
+}
+
+/**
+ * Registers the cross-hatch pattern image with the underlying MapLibre
+ * map. The fill-pattern layer above references the image by name, so
+ * the image must exist before the layer paints (MapLibre silently
+ * skips fill-pattern when the image is missing, then re-paints once
+ * it lands).
+ *
+ * The image id is suffixed by the highlight color, so a theme switch
+ * registers a fresh image with the new color rather than reusing a
+ * stale one through `hasImage`. Subscribes to `styledata` so the image
+ * is re-registered if the style is reloaded (e.g. on basemap swap).
+ */
+function useHatchPatternImage(imageId: string, primary: string): void {
   const map = useMap();
   const mapRef = map.current ?? map.default;
   useEffect((): (() => void) | undefined => {
@@ -546,14 +572,14 @@ function useHatchPatternImage(): void {
     }
     const m = mapRef.getMap();
     function ensurePattern(): void {
-      if (m.hasImage(HATCH_IMAGE_ID)) {
+      if (m.hasImage(imageId)) {
         return;
       }
-      const image = createHatchPatternImage();
+      const image = createHatchPatternImage(primary);
       if (image === undefined) {
         return;
       }
-      m.addImage(HATCH_IMAGE_ID, image);
+      m.addImage(imageId, image);
     }
     if (m.isStyleLoaded()) {
       ensurePattern();
@@ -562,18 +588,18 @@ function useHatchPatternImage(): void {
     return (): void => {
       m.off('styledata', ensurePattern);
     };
-  }, [mapRef]);
+  }, [mapRef, imageId, primary]);
 }
 
 /**
- * Builds an 8x8 cross-hatch pattern image (yellow diagonal stripes on a
- * transparent background) used as the highlight fill. Returns undefined
- * if the canvas 2D context is unavailable (e.g. in a non-DOM test
- * environment).
+ * Builds an 8x8 cross-hatch pattern image (diagonal stripes in the
+ * supplied stroke color on a transparent background) used as the
+ * highlight fill. Returns undefined if the canvas 2D context is
+ * unavailable (e.g. in a non-DOM test environment).
  */
-function createHatchPatternImage():
-  | { width: number; height: number; data: Uint8Array }
-  | undefined {
+function createHatchPatternImage(
+  strokeColor: string,
+): { width: number; height: number; data: Uint8Array } | undefined {
   if (typeof document === 'undefined') {
     return undefined;
   }
@@ -585,7 +611,7 @@ function createHatchPatternImage():
   if (ctx === null) {
     return undefined;
   }
-  ctx.strokeStyle = CHART_HIGHLIGHT_COLORS.primary;
+  ctx.strokeStyle = strokeColor;
   ctx.lineWidth = 1.5;
   ctx.lineCap = 'square';
   // Three diagonal segments so the pattern tiles seamlessly across

--- a/apps/atlas/src/modes/chart/layers/airways-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airways-layer.tsx
@@ -14,10 +14,7 @@ import type {
 } from 'geojson';
 import type { Airway, AirwayType } from '@squawk/types';
 import { useAirwayDataset } from '../../../shared/data/airway-dataset.ts';
-import {
-  CHART_AIRWAY_COLORS,
-  CHART_HIGHLIGHT_COLORS,
-} from '../../../shared/styles/chart-colors.ts';
+import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef, useHoveredAirwayWaypointIndex } from '../highlight-context.ts';
 import { AIRWAY_CATEGORY_TYPES, CHART_ROUTE_PATH } from '../url-state.ts';
 import { buildSegments } from './airway-segments.ts';
@@ -90,30 +87,6 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 ];
 
 /**
- * Highlight overlay for the currently-selected (or chip-hovered) airway.
- * Thicker stroke in dark slate over a wider yellow halo so the airway
- * still reads as a line (not a band) at any zoom. The per-render
- * filter combines the entity-match clause with
- * {@link ZOOM_AWARE_VISIBILITY} so the halo follows the same fade-in
- * rules as the base layer - selecting a hidden V-route at low zoom
- * does not leave a yellow ring floating over nothing.
- */
-const AIRWAYS_HIGHLIGHT_LAYER_BASE: LayerProps = {
-  id: AIRWAYS_HIGHLIGHT_LAYER_ID,
-  source: AIRWAYS_SOURCE_ID,
-  type: 'line',
-  layout: {
-    'line-cap': 'round',
-    'line-join': 'round',
-  },
-  paint: {
-    'line-color': CHART_HIGHLIGHT_COLORS.primary,
-    'line-width': 4,
-    'line-opacity': 0.95,
-  },
-};
-
-/**
  * Projects the bundled airway records into a GeoJSON `FeatureCollection`
  * suitable for a MapLibre `geojson` source. One `MultiLineString` feature
  * per airway, drawn through the embedded waypoint coordinates in
@@ -143,39 +116,6 @@ function toFeatureCollection(
 }
 
 /**
- * MapLibre layer styling, sans filter. Lines are thin and semi-transparent
- * so the airway web reads as a structural underlay rather than dominant
- * symbology. Color is tiered by airway type: low-altitude V-routes and
- * RNAV T-routes in slate, high-altitude J-routes and RNAV Q-routes in
- * indigo, regional and oceanic routes in muted gray. The visibility filter
- * is built per-render from the active `airwayCategories` URL state plus
- * {@link ZOOM_AWARE_VISIBILITY} so non-major airways are zoom-gated at
- * the feature level rather than hiding the entire layer.
- */
-const AIRWAYS_LAYER_BASE: LayerProps = {
-  id: AIRWAYS_LAYER_ID,
-  source: AIRWAYS_SOURCE_ID,
-  type: 'line',
-  layout: {
-    'line-cap': 'round',
-    'line-join': 'round',
-  },
-  paint: {
-    'line-color': [
-      'match',
-      ['get', 'type'],
-      ['VICTOR', 'RNAV_T'],
-      CHART_AIRWAY_COLORS.low,
-      ['JET', 'RNAV_Q'],
-      CHART_AIRWAY_COLORS.high,
-      CHART_AIRWAY_COLORS.regional,
-    ],
-    'line-width': ['interpolate', ['linear'], ['zoom'], 4, 1, 7, 1.6, 10, 2.6],
-    'line-opacity': 0.45,
-  },
-};
-
-/**
  * Chart-mode overlay that renders airways from `@squawk/airway-data` as
  * MapLibre line features. Reads the active `airwayCategories` from URL
  * state and applies a MapLibre `filter` expression so toggling categories
@@ -183,11 +123,21 @@ const AIRWAYS_LAYER_BASE: LayerProps = {
  * source. Returns `null` while the dataset is still being fetched or if
  * the load failed; callers needing fetch-state UI should read the same
  * hook directly.
+ *
+ * Lines are thin and semi-transparent so the airway web reads as a
+ * structural underlay rather than dominant symbology. Color is tiered
+ * by airway type: low-altitude V-routes and RNAV T-routes use the
+ * `low` token, high-altitude J-routes and RNAV Q-routes use `high`,
+ * regional and oceanic routes use `regional`. The visibility filter is
+ * built per-render from the active `airwayCategories` URL state plus
+ * {@link ZOOM_AWARE_VISIBILITY} so non-major airways are zoom-gated at
+ * the feature level rather than hiding the entire layer.
  */
 export function AirwaysLayer(): ReactElement | null {
   const { airwayCategories } = route.useSearch();
   const state = useAirwayDataset();
   const activeRef = useActiveHighlightRef();
+  const colors = useChartColors();
 
   const enabledTypes = useMemo<readonly AirwayType[]>(
     () => airwayCategories.flatMap((category) => AIRWAY_CATEGORY_TYPES[category]),
@@ -199,15 +149,60 @@ export function AirwaysLayer(): ReactElement | null {
     [enabledTypes],
   );
 
-  const layerProps = useMemo<LayerProps>(() => ({ ...AIRWAYS_LAYER_BASE, filter }), [filter]);
+  const layerProps = useMemo<LayerProps>(
+    () => ({
+      id: AIRWAYS_LAYER_ID,
+      source: AIRWAYS_SOURCE_ID,
+      type: 'line',
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      filter,
+      paint: {
+        'line-color': [
+          'match',
+          ['get', 'type'],
+          ['VICTOR', 'RNAV_T'],
+          colors.airway.low,
+          ['JET', 'RNAV_Q'],
+          colors.airway.high,
+          colors.airway.regional,
+        ],
+        'line-width': ['interpolate', ['linear'], ['zoom'], 4, 1, 7, 1.6, 10, 2.6],
+        'line-opacity': 0.45,
+      },
+    }),
+    [filter, colors],
+  );
 
+  // Highlight overlay for the currently-selected (or chip-hovered) airway.
+  // Thicker yellow stroke that still reads as a line (not a band) at any
+  // zoom. The filter combines the entity-match clause with
+  // {@link ZOOM_AWARE_VISIBILITY} so the halo follows the same fade-in
+  // rules as the base layer - selecting a hidden V-route at low zoom
+  // does not leave a yellow ring floating over nothing.
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const highlightFilter: ExpressionSpecification =
       activeRef?.type === 'airway'
         ? ['all', ['==', ['get', 'designation'], activeRef.id], ZOOM_AWARE_VISIBILITY]
         : MATCH_NONE_FILTER;
-    return { ...AIRWAYS_HIGHLIGHT_LAYER_BASE, filter: highlightFilter };
-  }, [activeRef]);
+    return {
+      id: AIRWAYS_HIGHLIGHT_LAYER_ID,
+      source: AIRWAYS_SOURCE_ID,
+      type: 'line',
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      filter: highlightFilter,
+      paint: {
+        'line-color': colors.highlight.primary,
+        'line-width': 4,
+        'line-opacity': 0.95,
+      },
+    };
+  }, [activeRef, colors]);
 
   const data = useMemo<
     FeatureCollection<MultiLineString, AirwayFeatureProperties> | undefined
@@ -300,6 +295,7 @@ export function AirwayLegFocusLayer(): ReactElement | null {
   const activeRef = useActiveHighlightRef();
   const hoveredWaypointIndex = useHoveredAirwayWaypointIndex();
   const state = useAirwayDataset();
+  const colors = useChartColors();
 
   // Build the mixed waypoint + leg feature collection only when the
   // active selection is an airway; otherwise keep the source absent
@@ -369,13 +365,13 @@ export function AirwayLegFocusLayer(): ReactElement | null {
         // regular highlight on whichever underlying point layer the
         // waypoint sits on (fix / navaid / airport).
         'circle-radius': 8,
-        'circle-color': CHART_HIGHLIGHT_COLORS.focusOutline,
-        'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
+        'circle-color': colors.highlight.focusOutline,
+        'circle-stroke-color': colors.highlight.stroke,
         'circle-stroke-width': 2,
         'circle-opacity': 0.85,
       },
     }),
-    [indexFilter],
+    [indexFilter, colors],
   );
 
   const legLayerProps = useMemo<LayerProps>(
@@ -393,12 +389,12 @@ export function AirwayLegFocusLayer(): ReactElement | null {
         // airway highlight. Wider than the highlight stroke so the
         // focused leg is visible even when an airport / navaid circle
         // sits on top of one of its waypoints.
-        'line-color': CHART_HIGHLIGHT_COLORS.focusOutline,
+        'line-color': colors.highlight.focusOutline,
         'line-width': 6,
         'line-opacity': 1,
       },
     }),
-    [indexFilter],
+    [indexFilter, colors],
   );
 
   if (data === undefined) {

--- a/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
@@ -6,11 +6,7 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Fix, FixUseCode } from '@squawk/types';
 import { useFixDataset } from '../../../shared/data/fix-dataset.ts';
-import {
-  CHART_FIX_COLOR,
-  CHART_HIGHLIGHT_COLORS,
-  CHART_SYMBOL_STROKE,
-} from '../../../shared/styles/chart-colors.ts';
+import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { LAYER_MIN_ZOOM } from '../url-state.ts';
 
@@ -47,31 +43,6 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
   ['get', 'identifier'],
   '__atlas-no-match__',
 ];
-
-/**
- * Highlight overlay for the currently-selected (or chip-hovered) fix.
- * Mirrors the airport / navaid highlight (yellow + dark stroke).
- * Inherits the same `minzoom` as the base layer so a stray highlight
- * does not float over an empty viewport when the user is zoomed out
- * below the threshold.
- *
- * `minzoom` is included via conditional spread so the property is omitted
- * when {@link LAYER_MIN_ZOOM} carries no entry, satisfying
- * `exactOptionalPropertyTypes` (which rejects an explicit `undefined` for
- * an optional property).
- */
-const FIXES_HIGHLIGHT_LAYER_BASE: LayerProps = {
-  id: FIXES_HIGHLIGHT_LAYER_ID,
-  source: FIXES_SOURCE_ID,
-  type: 'circle',
-  ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
-  paint: {
-    'circle-radius': 9,
-    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
-    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
-    'circle-stroke-width': 2,
-  },
-};
 
 /**
  * Fix usage codes we render. `CN` (computer navigation fix - internal FAA
@@ -121,15 +92,31 @@ function toFeatureCollection(records: Fix[]): FeatureCollection<Point, FixFeatur
 const FIX_SECONDARY_TIER_MIN_ZOOM = 9;
 
 /**
- * MapLibre layer styling. Visibility is gated by usage code: at the
- * layer's minzoom only compulsory reporting points and enroute
- * waypoints (`WP` / `RP`) paint, with the remaining categories
- * joining at z9. Color uses an amber hue to distinguish fixes from
- * the blue airports and magenta navaids layers.
+ * Visibility filter shared by every render of {@link FixesLayer}.
+ * Pulled out so the per-render `useMemo` building the layer props
+ * does not need to recreate the filter array (which is color-
+ * independent) when the theme changes.
+ */
+const FIXES_VISIBILITY_FILTER: ExpressionSpecification = [
+  'any',
+  ['get', 'compulsory'],
+  ['in', ['get', 'useCode'], ['literal', ['WP', 'RP']]],
+  ['>=', ['zoom'], FIX_SECONDARY_TIER_MIN_ZOOM],
+];
+
+/**
+ * Chart-mode overlay that renders fixes from `@squawk/fix-data` as
+ * MapLibre circle symbols. Returns `null` while the dataset is still being
+ * fetched or if the load failed; callers needing fetch-state UI should read
+ * the same hook directly.
  *
- * `minzoom` is sourced from the central {@link LAYER_MIN_ZOOM} table so
- * the layer-toggle dropdown's "appears at z N+" hint and the actual
- * paint cutoff stay in lockstep.
+ * Visibility is gated by usage code: at the layer's minzoom only
+ * compulsory reporting points and enroute waypoints (`WP` / `RP`)
+ * paint, with the remaining categories joining at z9. Color uses an
+ * amber hue to distinguish fixes from the blue airports and magenta
+ * navaids layers. `minzoom` is sourced from the central
+ * {@link LAYER_MIN_ZOOM} table so the layer-toggle dropdown's
+ * "appears at z N+" hint and the actual paint cutoff stay in lockstep.
  *
  * Each tier appears at the same dot size as the tiers already on
  * screen so a military or VFR fix popping in at z9 is the same size
@@ -139,34 +126,10 @@ const FIX_SECONDARY_TIER_MIN_ZOOM = 9;
  * zero-radius circle, and a chart at the layer's minzoom would show
  * a fog of speck-sized stroke artifacts otherwise.
  */
-const FIXES_LAYER_PROPS: LayerProps = {
-  id: FIXES_LAYER_ID,
-  source: FIXES_SOURCE_ID,
-  type: 'circle',
-  ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
-  filter: [
-    'any',
-    ['get', 'compulsory'],
-    ['in', ['get', 'useCode'], ['literal', ['WP', 'RP']]],
-    ['>=', ['zoom'], FIX_SECONDARY_TIER_MIN_ZOOM],
-  ],
-  paint: {
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 7, 3, 9, 4, 12, 5, 16, 9],
-    'circle-color': CHART_FIX_COLOR,
-    'circle-stroke-color': CHART_SYMBOL_STROKE,
-    'circle-stroke-width': 0.75,
-  },
-};
-
-/**
- * Chart-mode overlay that renders fixes from `@squawk/fix-data` as
- * MapLibre circle symbols. Returns `null` while the dataset is still being
- * fetched or if the load failed; callers needing fetch-state UI should read
- * the same hook directly.
- */
 export function FixesLayer(): ReactElement | null {
   const state = useFixDataset();
   const activeRef = useActiveHighlightRef();
+  const colors = useChartColors();
 
   const data = useMemo<FeatureCollection<Point, FixFeatureProperties> | undefined>(() => {
     if (state.status !== 'loaded') {
@@ -175,11 +138,47 @@ export function FixesLayer(): ReactElement | null {
     return toFeatureCollection(state.dataset.records);
   }, [state]);
 
+  // Layer paint props are themed: re-memoize when the resolved chart
+  // palette flips so MapLibre receives the new color values through
+  // its declarative `paint` prop pipeline.
+  const layerProps = useMemo<LayerProps>(
+    () => ({
+      id: FIXES_LAYER_ID,
+      source: FIXES_SOURCE_ID,
+      type: 'circle',
+      ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
+      filter: FIXES_VISIBILITY_FILTER,
+      paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 7, 3, 9, 4, 12, 5, 16, 9],
+        'circle-color': colors.fix,
+        'circle-stroke-color': colors.symbolStroke,
+        'circle-stroke-width': 0.75,
+      },
+    }),
+    [colors],
+  );
+
+  // Highlight overlay for the currently-selected (or chip-hovered) fix.
+  // Mirrors the airport / navaid highlight. Inherits the same `minzoom`
+  // as the base layer so a stray highlight does not float over an
+  // empty viewport when the user is zoomed out below the threshold.
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const filter: ExpressionSpecification =
       activeRef?.type === 'fix' ? ['==', ['get', 'identifier'], activeRef.id] : MATCH_NONE_FILTER;
-    return { ...FIXES_HIGHLIGHT_LAYER_BASE, filter };
-  }, [activeRef]);
+    return {
+      id: FIXES_HIGHLIGHT_LAYER_ID,
+      source: FIXES_SOURCE_ID,
+      type: 'circle',
+      ...(LAYER_MIN_ZOOM.fixes !== undefined && { minzoom: LAYER_MIN_ZOOM.fixes }),
+      filter,
+      paint: {
+        'circle-radius': 9,
+        'circle-color': colors.highlight.primary,
+        'circle-stroke-color': colors.highlight.stroke,
+        'circle-stroke-width': 2,
+      },
+    };
+  }, [activeRef, colors]);
 
   if (data === undefined) {
     return null;
@@ -187,7 +186,7 @@ export function FixesLayer(): ReactElement | null {
 
   return (
     <Source id={FIXES_SOURCE_ID} type="geojson" data={data}>
-      <Layer {...FIXES_LAYER_PROPS} />
+      <Layer {...layerProps} />
       <Layer {...highlightLayerProps} />
     </Source>
   );

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
@@ -6,11 +6,7 @@ import type { ExpressionSpecification } from '@maplibre/maplibre-gl-style-spec';
 import type { Feature, FeatureCollection, Point } from 'geojson';
 import type { Navaid, NavaidType } from '@squawk/types';
 import { useNavaidDataset } from '../../../shared/data/navaid-dataset.ts';
-import {
-  CHART_HIGHLIGHT_COLORS,
-  CHART_NAVAID_COLOR,
-  CHART_SYMBOL_STROKE,
-} from '../../../shared/styles/chart-colors.ts';
+import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { LAYER_MIN_ZOOM } from '../url-state.ts';
 
@@ -47,31 +43,6 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
   ['get', 'identifier'],
   '__atlas-no-match__',
 ];
-
-/**
- * Highlight overlay for the currently-selected (or chip-hovered) navaid.
- * Mirrors the airport highlight (yellow + dark stroke) so the highlight
- * style is consistent across point layers. Inherits the same `minzoom`
- * as the base layer so a stray highlight does not float over an empty
- * viewport when the user is zoomed out below the threshold.
- *
- * `minzoom` is included via conditional spread so the property is omitted
- * when {@link LAYER_MIN_ZOOM} carries no entry, satisfying
- * `exactOptionalPropertyTypes` (which rejects an explicit `undefined` for
- * an optional property).
- */
-const NAVAIDS_HIGHLIGHT_LAYER_BASE: LayerProps = {
-  id: NAVAIDS_HIGHLIGHT_LAYER_ID,
-  source: NAVAIDS_SOURCE_ID,
-  type: 'circle',
-  ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
-  paint: {
-    'circle-radius': 9,
-    'circle-color': CHART_HIGHLIGHT_COLORS.primary,
-    'circle-stroke-color': CHART_HIGHLIGHT_COLORS.stroke,
-    'circle-stroke-width': 2,
-  },
-};
 
 /**
  * Navaid types we render. `FAN_MARKER`, `MARINE_NDB`, and `VOT` are
@@ -127,15 +98,35 @@ const NAVAID_SECONDARY_TIER_MIN_ZOOM = 7;
 const NAVAID_TERTIARY_TIER_MIN_ZOOM = 10;
 
 /**
- * MapLibre layer styling. Visibility is gated by navaid type: the IFR
- * backbone (VOR / VORTAC / VOR/DME) shows from the layer's `minzoom`,
- * TACAN and DME join at z7, NDB and NDB/DME at z10. Color uses a
- * magenta hue to distinguish navaids from the blue/slate airports
- * layer at a glance.
+ * Visibility filter shared by every render of {@link NavaidsLayer}.
+ * Pulled out so the per-render `useMemo` building the layer props
+ * does not need to recreate the filter array (which is color-
+ * independent) when the theme changes.
+ */
+const NAVAIDS_VISIBILITY_FILTER: ExpressionSpecification = [
+  'any',
+  ['in', ['get', 'type'], ['literal', ['VOR', 'VORTAC', 'VOR/DME']]],
+  [
+    'all',
+    ['>=', ['zoom'], NAVAID_SECONDARY_TIER_MIN_ZOOM],
+    ['in', ['get', 'type'], ['literal', ['TACAN', 'DME']]],
+  ],
+  ['>=', ['zoom'], NAVAID_TERTIARY_TIER_MIN_ZOOM],
+];
+
+/**
+ * Chart-mode overlay that renders navaids from `@squawk/navaid-data` as
+ * MapLibre circle symbols. Returns `null` while the dataset is still being
+ * fetched or if the load failed; callers needing fetch-state UI should read
+ * the same hook directly.
  *
- * `minzoom` is sourced from the central {@link LAYER_MIN_ZOOM} table so
- * the layer-toggle dropdown's "appears at z N+" hint and the actual
- * paint cutoff stay in lockstep.
+ * Visibility is gated by navaid type: the IFR backbone (VOR / VORTAC /
+ * VOR/DME) shows from the layer's `minzoom`, TACAN and DME join at z7,
+ * NDB and NDB/DME at z10. Color uses a magenta hue to distinguish
+ * navaids from the blue/slate airports layer at a glance. `minzoom` is
+ * sourced from the central {@link LAYER_MIN_ZOOM} table so the
+ * layer-toggle dropdown's "appears at z N+" hint and the actual paint
+ * cutoff stay in lockstep.
  *
  * Each tier appears at the same dot size as the tier(s) already on
  * screen so a TACAN popping in at z7 is the same size as the VOR it
@@ -145,38 +136,10 @@ const NAVAID_TERTIARY_TIER_MIN_ZOOM = 10;
  * circle, and a chart at CONUS zoom would show thousands of speck-
  * sized stroke artifacts otherwise.
  */
-const NAVAIDS_LAYER_PROPS: LayerProps = {
-  id: NAVAIDS_LAYER_ID,
-  source: NAVAIDS_SOURCE_ID,
-  type: 'circle',
-  ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
-  filter: [
-    'any',
-    ['in', ['get', 'type'], ['literal', ['VOR', 'VORTAC', 'VOR/DME']]],
-    [
-      'all',
-      ['>=', ['zoom'], NAVAID_SECONDARY_TIER_MIN_ZOOM],
-      ['in', ['get', 'type'], ['literal', ['TACAN', 'DME']]],
-    ],
-    ['>=', ['zoom'], NAVAID_TERTIARY_TIER_MIN_ZOOM],
-  ],
-  paint: {
-    'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 4, 7, 5, 10, 6, 16, 10],
-    'circle-color': CHART_NAVAID_COLOR,
-    'circle-stroke-color': CHART_SYMBOL_STROKE,
-    'circle-stroke-width': 1,
-  },
-};
-
-/**
- * Chart-mode overlay that renders navaids from `@squawk/navaid-data` as
- * MapLibre circle symbols. Returns `null` while the dataset is still being
- * fetched or if the load failed; callers needing fetch-state UI should read
- * the same hook directly.
- */
 export function NavaidsLayer(): ReactElement | null {
   const state = useNavaidDataset();
   const activeRef = useActiveHighlightRef();
+  const colors = useChartColors();
 
   const data = useMemo<FeatureCollection<Point, NavaidFeatureProperties> | undefined>(() => {
     if (state.status !== 'loaded') {
@@ -185,13 +148,50 @@ export function NavaidsLayer(): ReactElement | null {
     return toFeatureCollection(state.dataset.records);
   }, [state]);
 
+  // Layer paint props are themed: re-memoize when the resolved chart
+  // palette flips so MapLibre receives the new color values through
+  // its declarative `paint` prop pipeline.
+  const layerProps = useMemo<LayerProps>(
+    () => ({
+      id: NAVAIDS_LAYER_ID,
+      source: NAVAIDS_SOURCE_ID,
+      type: 'circle',
+      ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
+      filter: NAVAIDS_VISIBILITY_FILTER,
+      paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 4, 7, 5, 10, 6, 16, 10],
+        'circle-color': colors.navaid,
+        'circle-stroke-color': colors.symbolStroke,
+        'circle-stroke-width': 1,
+      },
+    }),
+    [colors],
+  );
+
+  // Highlight overlay for the currently-selected (or chip-hovered)
+  // navaid. Mirrors the airport / fix highlight so the affordance is
+  // consistent across point layers. Inherits the base layer's
+  // `minzoom` so a stray highlight does not float over an empty
+  // viewport when the user is zoomed out below the threshold.
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const filter: ExpressionSpecification =
       activeRef?.type === 'navaid'
         ? ['==', ['get', 'identifier'], activeRef.id]
         : MATCH_NONE_FILTER;
-    return { ...NAVAIDS_HIGHLIGHT_LAYER_BASE, filter };
-  }, [activeRef]);
+    return {
+      id: NAVAIDS_HIGHLIGHT_LAYER_ID,
+      source: NAVAIDS_SOURCE_ID,
+      type: 'circle',
+      ...(LAYER_MIN_ZOOM.navaids !== undefined && { minzoom: LAYER_MIN_ZOOM.navaids }),
+      filter,
+      paint: {
+        'circle-radius': 9,
+        'circle-color': colors.highlight.primary,
+        'circle-stroke-color': colors.highlight.stroke,
+        'circle-stroke-width': 2,
+      },
+    };
+  }, [activeRef, colors]);
 
   if (data === undefined) {
     return null;
@@ -199,7 +199,7 @@ export function NavaidsLayer(): ReactElement | null {
 
   return (
     <Source id={NAVAIDS_SOURCE_ID} type="geojson" data={data}>
-      <Layer {...NAVAIDS_LAYER_PROPS} />
+      <Layer {...layerProps} />
       <Layer {...highlightLayerProps} />
     </Source>
   );

--- a/apps/atlas/src/shared/inspector/inspector.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.tsx
@@ -302,7 +302,7 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
 
   return (
     <aside
-      className="absolute right-0 bottom-0 left-0 z-20 max-h-[60vh] overflow-y-auto rounded-t-xl border-t border-slate-200 bg-white shadow-lg md:top-0 md:left-auto md:max-h-none md:w-inspector md:rounded-none md:border-t-0 md:border-l"
+      className="absolute right-0 bottom-0 left-0 z-20 max-h-[60vh] overflow-y-auto rounded-t-xl border-t border-slate-200 bg-white shadow-lg md:top-0 md:left-auto md:max-h-none md:w-inspector md:rounded-none md:border-t-0 md:border-l dark:border-slate-700 dark:bg-slate-900"
       aria-label="Entity inspector"
     >
       <InspectorHeader
@@ -393,12 +393,12 @@ function SiblingChips({
     chips.length === 1 ? '1 other feature here' : `${chips.length} other features here`;
 
   return (
-    <div className="border-y-2 border-indigo-200 bg-indigo-50">
+    <div className="border-y-2 border-indigo-200 bg-indigo-50 dark:border-indigo-900 dark:bg-indigo-950/40">
       <button
         type="button"
         onClick={(): void => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-1.5 px-4 py-3 text-left text-xs font-semibold tracking-wide text-indigo-700 uppercase hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-400 md:py-2"
+        className="flex w-full items-center gap-1.5 px-4 py-3 text-left text-xs font-semibold tracking-wide text-indigo-700 uppercase hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-400 md:py-2 dark:text-indigo-300 dark:hover:bg-indigo-900/50"
       >
         <SwitchIcon />
         <span className="flex-1">{headerText}</span>
@@ -408,7 +408,7 @@ function SiblingChips({
         <div className="flex flex-col gap-2 px-4 pt-1 pb-3">
           {groups.map((group) => (
             <div key={group.type}>
-              <p className="mb-1 text-[10px] font-semibold tracking-wider text-indigo-600/80 uppercase">
+              <p className="mb-1 text-[10px] font-semibold tracking-wider text-indigo-600/80 uppercase dark:text-indigo-300/80">
                 {CHIP_GROUP_LABELS[group.type]}
               </p>
               <div className="flex flex-wrap gap-1.5">
@@ -423,7 +423,7 @@ function SiblingChips({
                     })}
                     onFocus={(): void => onHover(chip.selection)}
                     onBlur={(): void => onHover(undefined)}
-                    className="rounded-full border border-indigo-300 bg-white px-3 py-2 text-xs font-medium text-indigo-700 shadow-sm hover:border-indigo-400 hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 md:px-2.5 md:py-1"
+                    className="rounded-full border border-indigo-300 bg-white px-3 py-2 text-xs font-medium text-indigo-700 shadow-sm hover:border-indigo-400 hover:bg-indigo-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 md:px-2.5 md:py-1 dark:border-indigo-700 dark:bg-slate-900 dark:text-indigo-300 dark:hover:border-indigo-500 dark:hover:bg-indigo-900/50"
                   >
                     {chip.label}
                   </button>
@@ -726,7 +726,7 @@ function InspectorHeader({
   onRecenter?: () => void;
 }): ReactElement {
   return (
-    <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3">
+    <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-900">
       <HeaderText state={state} />
       <div className="flex shrink-0 items-center gap-1">
         {onRecenter === undefined ? null : (
@@ -735,7 +735,7 @@ function InspectorHeader({
             onClick={onRecenter}
             aria-label="Recenter on this feature"
             title="Recenter on this feature"
-            className="flex h-11 w-11 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7"
+            className="flex h-11 w-11 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus-visible:ring-slate-500"
           >
             <RecenterIcon />
           </button>
@@ -765,22 +765,26 @@ function HeaderText({ state }: { state: ResolvedEntityState }): ReactElement | n
   if (state.status === 'loading') {
     return (
       <div>
-        <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+        <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
           {state.ref.type}
         </p>
-        <h2 className="text-base font-semibold text-slate-900">{state.ref.id}</h2>
-        <p className="mt-1 text-xs text-slate-500">Loading dataset...</p>
+        <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+          {state.ref.id}
+        </h2>
+        <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Loading dataset...</p>
       </div>
     );
   }
   if (state.status === 'not-found') {
     return (
       <div>
-        <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+        <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
           {state.ref.type}
         </p>
-        <h2 className="text-base font-semibold text-slate-900">{state.ref.id}</h2>
-        <p className="mt-1 text-xs text-rose-600">No matching record</p>
+        <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+          {state.ref.id}
+        </h2>
+        <p className="mt-1 text-xs text-rose-600 dark:text-rose-400">No matching record</p>
       </div>
     );
   }
@@ -796,50 +800,64 @@ function ResolvedHeaderText({ entity }: { entity: ResolvedEntity }): ReactElemen
     case 'airport':
       return (
         <div>
-          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">Airport</p>
-          <h2 className="text-base font-semibold text-slate-900">
+          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
+            Airport
+          </p>
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
             {entity.record.faaId}
             {entity.record.icao !== undefined ? (
-              <span className="ml-2 text-sm font-normal text-slate-500">{entity.record.icao}</span>
+              <span className="ml-2 text-sm font-normal text-slate-500 dark:text-slate-400">
+                {entity.record.icao}
+              </span>
             ) : null}
           </h2>
-          <p className="mt-0.5 text-xs text-slate-600">{entity.record.name}</p>
+          <p className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">{entity.record.name}</p>
         </div>
       );
     case 'navaid':
       return (
         <div>
-          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
             {entity.record.type}
           </p>
-          <h2 className="text-base font-semibold text-slate-900">{entity.record.identifier}</h2>
-          <p className="mt-0.5 text-xs text-slate-600">{entity.record.name}</p>
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            {entity.record.identifier}
+          </h2>
+          <p className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">{entity.record.name}</p>
         </div>
       );
     case 'fix':
       return (
         <div>
-          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">Fix</p>
-          <h2 className="text-base font-semibold text-slate-900">{entity.record.identifier}</h2>
+          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
+            Fix
+          </p>
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            {entity.record.identifier}
+          </h2>
         </div>
       );
     case 'airway':
       return (
         <div>
-          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
             {entity.record.type} airway
           </p>
-          <h2 className="text-base font-semibold text-slate-900">{entity.record.designation}</h2>
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            {entity.record.designation}
+          </h2>
         </div>
       );
     case 'airspace':
       return (
         <div>
-          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+          <p className="text-xs font-medium tracking-wide text-slate-500 uppercase dark:text-slate-400">
             {entity.airspaceType.replace(/_/g, ' ')}
           </p>
-          <h2 className="text-base font-semibold text-slate-900">{entity.identifier}</h2>
-          <p className="mt-0.5 text-xs text-slate-600">
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            {entity.identifier}
+          </h2>
+          <p className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">
             {entity.features.length} feature{entity.features.length === 1 ? '' : 's'}
           </p>
         </div>

--- a/apps/atlas/src/shared/inspector/renderers/fix-panel.tsx
+++ b/apps/atlas/src/shared/inspector/renderers/fix-panel.tsx
@@ -48,7 +48,7 @@ export function FixPanel({ record }: FixPanelProps): ReactElement {
       ) : null}
       {record.chartingRemark !== undefined ? (
         <InspectorSection title="Remark">
-          <p className="text-sm text-slate-700">{record.chartingRemark}</p>
+          <p className="text-sm text-slate-700 dark:text-slate-300">{record.chartingRemark}</p>
         </InspectorSection>
       ) : null}
     </>

--- a/apps/atlas/src/shared/inspector/renderers/inspector-row.tsx
+++ b/apps/atlas/src/shared/inspector/renderers/inspector-row.tsx
@@ -43,14 +43,14 @@ export function InspectorRow({
     <div
       className={
         interactive
-          ? 'flex justify-between gap-3 rounded py-1.5 text-sm transition-colors hover:bg-slate-100'
+          ? 'flex justify-between gap-3 rounded py-1.5 text-sm transition-colors hover:bg-slate-100 dark:hover:bg-slate-800'
           : 'flex justify-between gap-3 py-1.5 text-sm'
       }
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
     >
-      <dt className="shrink-0 text-slate-500">{label}</dt>
-      <dd className="text-right text-slate-900">{children}</dd>
+      <dt className="shrink-0 text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd className="text-right text-slate-900 dark:text-slate-100">{children}</dd>
     </div>
   );
 }
@@ -97,8 +97,8 @@ export function InspectorSection({
     <section
       className={
         interactive
-          ? 'group relative border-b border-slate-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-slate-100'
-          : 'border-b border-slate-100 px-4 py-3 last:border-b-0'
+          ? 'group relative border-b border-slate-100 px-4 py-3 transition-colors last:border-b-0 hover:bg-slate-100 dark:border-slate-800 dark:hover:bg-slate-800'
+          : 'border-b border-slate-100 px-4 py-3 last:border-b-0 dark:border-slate-800'
       }
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
@@ -106,10 +106,12 @@ export function InspectorSection({
       {interactive ? (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-indigo-500 opacity-0 transition-opacity group-hover:opacity-100"
+          className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-indigo-500 opacity-0 transition-opacity group-hover:opacity-100 dark:bg-indigo-400"
         />
       ) : null}
-      <h3 className="mb-1 text-xs font-semibold tracking-wide text-slate-500 uppercase">{title}</h3>
+      <h3 className="mb-1 text-xs font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+        {title}
+      </h3>
       <dl>{children}</dl>
     </section>
   );

--- a/apps/atlas/src/shared/map/map-canvas.tsx
+++ b/apps/atlas/src/shared/map/map-canvas.tsx
@@ -1,12 +1,22 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
-import { Map } from '@vis.gl/react-maplibre';
+import { Map, useMap } from '@vis.gl/react-maplibre';
 import type { MapLayerMouseEvent, ViewStateChangeEvent } from '@vis.gl/react-maplibre';
 import maplibregl from 'maplibre-gl';
 import type { StyleSpecification } from 'maplibre-gl';
 import { Protocol } from 'pmtiles';
 import { layers, namedFlavor } from '@protomaps/basemaps';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import { useResolvedTheme } from '../styles/theme-context.ts';
+import type { ResolvedTheme } from '../styles/theme-context.ts';
+
+/**
+ * Prefix every atlas-owned MapLibre source and layer id starts with.
+ * Used by {@link ThemeStyleSync} to identify which entries to carry
+ * over from the previous style across a basemap swap, so chart
+ * features stay visible while the basemap flips themes.
+ */
+const ATLAS_LAYER_ID_PREFIX = 'atlas-';
 
 maplibregl.addProtocol('pmtiles', new Protocol().tile);
 
@@ -28,7 +38,17 @@ const PMTILES_URL = import.meta.env.VITE_PMTILES_URL ?? PROTOMAPS_DEMO_PMTILES;
 
 const PROTOMAPS_GLYPHS =
   'https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf';
-const PROTOMAPS_SPRITES = 'https://protomaps.github.io/basemaps-assets/sprites/v4/light';
+
+/**
+ * Returns the Protomaps sprite URL matching the resolved theme. Light
+ * and dark sprites differ in the icon-fill colors used by the
+ * Protomaps style layers, so the sprite URL must flip in lockstep with
+ * the basemap flavor; otherwise dark-flavored layers reference icons
+ * the light sprite carries with light-mode tints (and vice versa).
+ */
+function protomapsSpriteUrl(theme: ResolvedTheme): string {
+  return `https://protomaps.github.io/basemaps-assets/sprites/v4/${theme}`;
+}
 
 /**
  * Maximum pitch (in degrees) the map will accept. Raised above MapLibre's
@@ -39,20 +59,30 @@ const PROTOMAPS_SPRITES = 'https://protomaps.github.io/basemaps-assets/sprites/v
  */
 export const MAP_MAX_PITCH = 75;
 
-const MAP_STYLE: StyleSpecification = {
-  version: 8,
-  glyphs: PROTOMAPS_GLYPHS,
-  sprite: PROTOMAPS_SPRITES,
-  sources: {
-    protomaps: {
-      type: 'vector',
-      url: PMTILES_URL,
-      attribution:
-        '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> · <a href="https://protomaps.com">Protomaps</a>',
+/**
+ * Builds the MapLibre `StyleSpecification` for the basemap matching
+ * the resolved theme. Both the layer set (via Protomaps'
+ * `namedFlavor()`) and the sprite URL flip in lockstep so a theme
+ * switch produces a coherent dark-or-light basemap. `@vis.gl/react-maplibre`
+ * passes the new value to `map.setStyle()` when the prop changes, so
+ * this is fully declarative on the React side.
+ */
+function buildMapStyle(theme: ResolvedTheme): StyleSpecification {
+  return {
+    version: 8,
+    glyphs: PROTOMAPS_GLYPHS,
+    sprite: protomapsSpriteUrl(theme),
+    sources: {
+      protomaps: {
+        type: 'vector',
+        url: PMTILES_URL,
+        attribution:
+          '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> · <a href="https://protomaps.com">Protomaps</a>',
+      },
     },
-  },
-  layers: layers('protomaps', namedFlavor('light'), { lang: 'en' }),
-};
+    layers: layers('protomaps', namedFlavor(theme), { lang: 'en' }),
+  };
+}
 
 /**
  * A simplified view-state snapshot suitable for URL serialization. Bearing
@@ -127,6 +157,20 @@ export function MapCanvas({
   interactiveLayerIds,
   children,
 }: MapCanvasProps): ReactElement {
+  const resolvedTheme = useResolvedTheme();
+  // Mount-only style. `<Map>` calls `setStyle` whenever its `mapStyle`
+  // prop reference changes, and that swap diffs out atlas-* sources
+  // and layers (because they were added imperatively via `<Source>` /
+  // `<Layer>` and aren't part of the basemap spec) - so chart features
+  // would briefly disappear while the basemap re-paints, then snap
+  // back when the React tree's effects re-add them. Instead, capture
+  // the initial theme into a stable state value (lazy `useState`
+  // initializer so it's read once at mount), and let
+  // {@link ThemeStyleSync} handle subsequent theme changes
+  // imperatively with a transformStyle that preserves the atlas-*
+  // layers across the swap.
+  const [initialMapStyle] = useState<StyleSpecification>(() => buildMapStyle(resolvedTheme));
+
   const handleMoveEnd = useCallback(
     (event: ViewStateChangeEvent): void => {
       if (onViewStateChange === undefined) {
@@ -156,13 +200,76 @@ export function MapCanvas({
     <Map
       initialViewState={{ longitude: lon, latitude: lat, zoom, pitch }}
       style={{ position: 'absolute', inset: 0 }}
-      mapStyle={MAP_STYLE}
+      mapStyle={initialMapStyle}
       maxPitch={MAP_MAX_PITCH}
       onMoveEnd={handleMoveEnd}
       onClick={handleClick}
       interactiveLayerIds={interactiveLayerIds === undefined ? [] : [...interactiveLayerIds]}
     >
+      <ThemeStyleSync resolvedTheme={resolvedTheme} />
       {children}
     </Map>
   );
+}
+
+/**
+ * Imperatively swaps the basemap style when the resolved theme changes,
+ * preserving every atlas-owned source and layer across the swap so
+ * chart features remain visible during the transition. Renders
+ * nothing.
+ *
+ * MapLibre's `setStyle` with `diff: true` removes any source / layer
+ * present in the current style but absent from the next - which would
+ * include all of our chart overlays (added imperatively by `<Source>`
+ * / `<Layer>` children, never present in the basemap spec). The
+ * `transformStyle` callback merges those entries back into the next
+ * style before MapLibre computes the diff, so the diff sees them in
+ * both and leaves them alone.
+ *
+ * The chart layer components also re-run their `useChartColors()`
+ * memos on the same theme change and call `setPaintProperty` on each
+ * paint value that differs between palettes, so feature colors update
+ * to the new palette in the same React commit. Net effect: features
+ * stay on screen, basemap flips, feature colors flip, all in one
+ * frame.
+ */
+function ThemeStyleSync({ resolvedTheme }: { resolvedTheme: ResolvedTheme }): null {
+  const map = useMap();
+  const mapRef = map.current ?? map.default;
+  const lastAppliedRef = useRef<ResolvedTheme>(resolvedTheme);
+
+  useEffect((): void => {
+    if (mapRef === undefined) {
+      return;
+    }
+    if (lastAppliedRef.current === resolvedTheme) {
+      return;
+    }
+    lastAppliedRef.current = resolvedTheme;
+    const m = mapRef.getMap();
+    m.setStyle(buildMapStyle(resolvedTheme), {
+      diff: true,
+      transformStyle: (previous, next) => {
+        if (previous === undefined) {
+          return next;
+        }
+        const preservedSources: typeof next.sources = { ...next.sources };
+        for (const [id, source] of Object.entries(previous.sources ?? {})) {
+          if (id.startsWith(ATLAS_LAYER_ID_PREFIX)) {
+            preservedSources[id] = source;
+          }
+        }
+        const preservedLayers = (previous.layers ?? []).filter((layer) =>
+          layer.id.startsWith(ATLAS_LAYER_ID_PREFIX),
+        );
+        return {
+          ...next,
+          sources: preservedSources,
+          layers: [...(next.layers ?? []), ...preservedLayers],
+        };
+      },
+    });
+  }, [mapRef, resolvedTheme]);
+
+  return null;
 }

--- a/apps/atlas/src/shared/map/zoom-controls.tsx
+++ b/apps/atlas/src/shared/map/zoom-controls.tsx
@@ -136,9 +136,9 @@ export function ZoomControls(): ReactElement {
   }, [mapRef]);
 
   return (
-    <div className="absolute bottom-10 left-3 z-10 flex flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-md">
+    <div className="absolute bottom-10 left-3 z-10 flex flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-md dark:border-slate-700 dark:bg-slate-900">
       <ZoomReadout zoom={currentZoom} />
-      <div className="h-px bg-slate-200" aria-hidden="true" />
+      <div className="h-px bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
       <button
         type="button"
         onClick={handleZoomIn}
@@ -148,7 +148,7 @@ export function ZoomControls(): ReactElement {
       >
         <PlusIcon />
       </button>
-      <div className="h-px bg-slate-200" aria-hidden="true" />
+      <div className="h-px bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
       <button
         type="button"
         onClick={handleZoomOut}
@@ -158,7 +158,7 @@ export function ZoomControls(): ReactElement {
       >
         <MinusIcon />
       </button>
-      <div className="h-px bg-slate-200" aria-hidden="true" />
+      <div className="h-px bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
       <button
         type="button"
         onClick={handleTiltUp}
@@ -168,7 +168,7 @@ export function ZoomControls(): ReactElement {
       >
         <TiltUpIcon />
       </button>
-      <div className="h-px bg-slate-200" aria-hidden="true" />
+      <div className="h-px bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
       <button
         type="button"
         onClick={handleTiltDown}
@@ -189,7 +189,7 @@ export function ZoomControls(): ReactElement {
  * stack - keeping the control geometry stable at the bounds.
  */
 const CONTROL_BUTTON_CLASS =
-  'flex h-11 w-11 items-center justify-center text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white md:h-8 md:w-8';
+  'flex h-11 w-11 items-center justify-center text-slate-700 hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-white md:h-8 md:w-8 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-slate-500 dark:disabled:text-slate-600 dark:disabled:hover:bg-slate-900';
 
 /**
  * Compact text formatter for the {@link ZoomReadout}: integer zooms
@@ -224,7 +224,7 @@ function ZoomReadout({ zoom }: { zoom: number }): ReactElement {
     <div
       role="status"
       aria-label={`Current zoom: ${text}`}
-      className="flex h-11 w-11 flex-col items-center justify-center text-[10px] font-medium leading-none tabular-nums text-slate-600 md:h-8 md:w-8"
+      className="flex h-11 w-11 flex-col items-center justify-center text-[10px] font-medium leading-none tabular-nums text-slate-600 md:h-8 md:w-8 dark:text-slate-300"
     >
       <ZoomIcon />
       <span className="mt-0.5">{text}</span>

--- a/apps/atlas/src/shared/styles/chart-colors.spec.tsx
+++ b/apps/atlas/src/shared/styles/chart-colors.spec.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { useChartColors } from './chart-colors.ts';
+import type { ChartColorPalette } from './chart-colors.ts';
+import { ThemeProvider } from './theme-provider.tsx';
+import { PREFERS_DARK_MEDIA_QUERY, THEME_STORAGE_KEY } from './theme-context.ts';
+
+/**
+ * Builds a matchMedia stub honoring the supplied dark preference for
+ * `(prefers-color-scheme: dark)` and falling through to `matches: true`
+ * for every other query (matching the global shim).
+ */
+function stubMatchMedia(prefersDark: boolean): void {
+  vi.stubGlobal('matchMedia', (query: string): MediaQueryList => {
+    const matches = query === PREFERS_DARK_MEDIA_QUERY ? prefersDark : true;
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: (): void => {},
+      removeListener: (): void => {},
+      addEventListener: (): void => {},
+      removeEventListener: (): void => {},
+      dispatchEvent: (): boolean => false,
+    };
+  });
+}
+
+/**
+ * Test probe that reads the resolved palette and exposes a few
+ * representative tokens for assertions. Passing the palette object
+ * straight to the test would be cleaner if React rendered objects, so
+ * we expose the fields in `data-*` attributes instead.
+ */
+function PaletteProbe({
+  onResolve,
+}: {
+  onResolve: (palette: ChartColorPalette) => void;
+}): ReactElement {
+  const colors = useChartColors();
+  onResolve(colors);
+  return <span />;
+}
+
+describe('useChartColors', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it('returns the light palette under a light theme preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    stubMatchMedia(true);
+    let resolved!: ChartColorPalette;
+    render(
+      <ThemeProvider>
+        <PaletteProbe
+          onResolve={(palette): void => {
+            resolved = palette;
+          }}
+        />
+      </ThemeProvider>,
+    );
+    // Light-palette signature: dark slate minor airport, dark highlight stroke.
+    expect(resolved.airport.minor).toBe('#0f172a');
+    expect(resolved.highlight.stroke).toBe('#0f172a');
+    expect(resolved.symbolStroke).toBe('#ffffff');
+  });
+
+  it('returns the dark palette under a dark theme preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    stubMatchMedia(false);
+    let resolved!: ChartColorPalette;
+    render(
+      <ThemeProvider>
+        <PaletteProbe
+          onResolve={(palette): void => {
+            resolved = palette;
+          }}
+        />
+      </ThemeProvider>,
+    );
+    // Dark-palette signature: lifted minor airport, lighter highlight stroke,
+    // and the dark airway low color is bright slate (vs light's dark slate).
+    expect(resolved.airport.minor).toBe('#cbd5e1');
+    expect(resolved.highlight.stroke).toBe('#cbd5e1');
+    expect(resolved.airway.low).toBe('#cbd5e1');
+  });
+
+  it('falls back to the light palette when no provider is mounted', () => {
+    let resolved!: ChartColorPalette;
+    render(
+      <PaletteProbe
+        onResolve={(palette): void => {
+          resolved = palette;
+        }}
+      />,
+    );
+    expect(resolved.airport.minor).toBe('#0f172a');
+  });
+});

--- a/apps/atlas/src/shared/styles/chart-colors.ts
+++ b/apps/atlas/src/shared/styles/chart-colors.ts
@@ -1,12 +1,20 @@
+import { useResolvedTheme } from './theme-context.ts';
+
 /**
  * Centralized color tokens for chart-mode MapLibre layers.
  *
  * MapLibre `paint` and `layout` properties take literal color strings -
  * they cannot read CSS custom properties at runtime - so chart palette
- * tokens live here as a TypeScript module and are imported by each
- * layer file. UI chrome (panels, buttons, text) continues to use
- * Tailwind utilities directly; only chart-domain colors flow through
- * this module.
+ * tokens live here as TypeScript constants and reach layer code via
+ * the {@link useChartColors} hook. UI chrome (panels, buttons, text)
+ * continues to use Tailwind utilities directly with the `dark:` variant;
+ * only chart-domain colors flow through this module.
+ *
+ * Two palettes are defined: one for the light basemap and one for the
+ * dark basemap. Layer components call {@link useChartColors} inside
+ * their function body and rebuild any `LayerProps` that reference
+ * palette values via `useMemo` so a theme switch propagates through
+ * MapLibre's declarative `paint` props with no manual `setStyle` plumbing.
  *
  * Add a new token here whenever a layer would otherwise inline a hex
  * literal. Reuse an existing token when the color is already named for
@@ -19,45 +27,32 @@
  * highlight palette keeps the active-feature affordance recognizable
  * regardless of which layer the feature came from.
  */
-export const CHART_HIGHLIGHT_COLORS = {
+export interface ChartHighlightColors {
   /** Primary highlight fill / stroke (yellow). */
-  primary: '#fde047',
-  /** Dark stroke paired with the primary highlight on point symbols. */
-  stroke: '#0f172a',
+  primary: string;
+  /** Stroke paired with the primary highlight on point symbols. */
+  stroke: string;
   /** Lighter outline used for the per-feature focus ring on multi-feature airspace groupings. */
-  focusOutline: '#fef9c3',
-} as const;
-
-/**
- * Default white stroke around point symbols (airports, fixes, navaids).
- * Sits between the symbol fill and the basemap so the marker reads as a
- * coin rather than blending into chart background tiles.
- */
-export const CHART_SYMBOL_STROKE = '#ffffff';
+  focusOutline: string;
+}
 
 /** Airport circle fill colors keyed by longest-runway tier. */
-export const CHART_AIRPORT_COLORS = {
-  /** Major airport (longest runway >= 8000 ft) - blue. */
-  major: '#1d4ed8',
-  /** Minor airport - dark slate. */
-  minor: '#0f172a',
-} as const;
-
-/** Fix (waypoint) point symbol fill color (amber). */
-export const CHART_FIX_COLOR = '#ea580c';
-
-/** Navaid point symbol fill color (purple). */
-export const CHART_NAVAID_COLOR = '#7c3aed';
+export interface ChartAirportColors {
+  /** Major airport (longest runway >= 8000 ft). */
+  major: string;
+  /** Minor airport. */
+  minor: string;
+}
 
 /** Airway line colors keyed by altitude band. */
-export const CHART_AIRWAY_COLORS = {
-  /** Low-altitude airways (VICTOR / RNAV_T) - slate. */
-  low: '#475569',
-  /** High-altitude airways (JET / RNAV_Q) - indigo. */
-  high: '#4338ca',
-  /** Regional / oceanic airways - muted slate. */
-  regional: '#94a3b8',
-} as const;
+export interface ChartAirwayColors {
+  /** Low-altitude airways (VICTOR / RNAV_T). */
+  low: string;
+  /** High-altitude airways (JET / RNAV_Q). */
+  high: string;
+  /** Regional / oceanic airways. */
+  regional: string;
+}
 
 /**
  * Airspace polygon fill / outline palette keyed by airspace class. Class
@@ -65,41 +60,181 @@ export const CHART_AIRWAY_COLORS = {
  * use a single magenta family for every Class E subtype. `fallback` is
  * the default for any unrecognized future `AirspaceType` value.
  */
-export const CHART_AIRSPACE_COLORS = {
-  /** Class B terminal airspace (blue-900). */
-  classB: '#1e3a8a',
-  /** Class C terminal airspace (rose-900). */
-  classC: '#be185d',
-  /** Class D terminal airspace (blue-600). */
-  classD: '#2563eb',
-  /** Class E surface airspace and all E2-E7 subtypes (pink-600). */
-  classE: '#ec4899',
-  /** Military Operations Area (amber-600). */
-  moa: '#d97706',
-  /** Restricted area (red-600). */
-  restricted: '#dc2626',
-  /** Prohibited area (red-900). */
-  prohibited: '#991b1b',
-  /** Warning area (orange-600). */
-  warning: '#f97316',
-  /** Alert area (yellow-400). */
-  alert: '#facc15',
-  /** National Security Area (gray-500). */
-  nsa: '#6b7280',
-  /** ARTCC boundary (slate-400). */
-  artcc: '#94a3b8',
-  /** Catch-all for unrecognized airspace types (slate-500). */
-  fallback: '#64748b',
-} as const;
+export interface ChartAirspaceColors {
+  /** Class B terminal airspace. */
+  classB: string;
+  /** Class C terminal airspace. */
+  classC: string;
+  /** Class D terminal airspace. */
+  classD: string;
+  /** Class E surface airspace and all E2-E7 subtypes. */
+  classE: string;
+  /** Military Operations Area. */
+  moa: string;
+  /** Restricted area. */
+  restricted: string;
+  /** Prohibited area. */
+  prohibited: string;
+  /** Warning area. */
+  warning: string;
+  /** Alert area. */
+  alert: string;
+  /** National Security Area. */
+  nsa: string;
+  /** ARTCC boundary. */
+  artcc: string;
+  /** Catch-all for unrecognized airspace types. */
+  fallback: string;
+}
 
 /**
  * Airspace per-feature badge label colors. The badge is the small
  * centroid label ("1", "2", "LOW", "HIGH") that disambiguates polygons
  * inside a multi-feature airspace grouping.
  */
-export const CHART_AIRSPACE_BADGE_COLORS = {
-  /** Badge text color (light yellow). */
-  text: '#fef08a',
-  /** Halo color drawn around badge text for legibility against any basemap or fill. */
-  halo: '#0f172a',
-} as const;
+export interface ChartAirspaceBadgeColors {
+  /** Badge text color. */
+  text: string;
+  /** Halo color drawn around badge text for legibility. */
+  halo: string;
+}
+
+/**
+ * Full chart-color palette returned by {@link useChartColors}. Each
+ * field carries the same semantic meaning across the light and dark
+ * variants; only the underlying hex values change.
+ */
+export interface ChartColorPalette {
+  /** Selection / hover highlight palette shared by every chart layer. */
+  highlight: ChartHighlightColors;
+  /** Default outline drawn around point symbols (airports, fixes, navaids). */
+  symbolStroke: string;
+  /** Airport circle fills keyed by runway tier. */
+  airport: ChartAirportColors;
+  /** Fix point symbol fill. */
+  fix: string;
+  /** Navaid point symbol fill. */
+  navaid: string;
+  /** Airway line colors keyed by altitude band. */
+  airway: ChartAirwayColors;
+  /** Airspace polygon fill / outline palette keyed by class. */
+  airspace: ChartAirspaceColors;
+  /** Airspace per-feature badge colors. */
+  airspaceBadge: ChartAirspaceBadgeColors;
+}
+
+/**
+ * Light-basemap palette. Tuned against Protomaps' `light` flavor: dark
+ * point fills and saturated polygon tints sit cleanly on a near-white
+ * tile background, and the white symbol stroke separates colored
+ * circles from the basemap.
+ */
+const LIGHT_PALETTE: ChartColorPalette = {
+  highlight: {
+    primary: '#fde047',
+    stroke: '#0f172a',
+    focusOutline: '#fef9c3',
+  },
+  symbolStroke: '#ffffff',
+  airport: {
+    major: '#1d4ed8',
+    minor: '#0f172a',
+  },
+  fix: '#ea580c',
+  navaid: '#7c3aed',
+  airway: {
+    low: '#475569',
+    high: '#4338ca',
+    regional: '#94a3b8',
+  },
+  airspace: {
+    classB: '#1e3a8a',
+    classC: '#be185d',
+    classD: '#2563eb',
+    classE: '#ec4899',
+    moa: '#d97706',
+    restricted: '#dc2626',
+    prohibited: '#991b1b',
+    warning: '#f97316',
+    alert: '#facc15',
+    nsa: '#6b7280',
+    artcc: '#94a3b8',
+    fallback: '#64748b',
+  },
+  airspaceBadge: {
+    text: '#fef08a',
+    halo: '#0f172a',
+  },
+};
+
+/**
+ * Dark-basemap palette. Tuned against Protomaps' `dark` flavor: dark
+ * point fills are swapped for light neutrals, deeply-saturated polygon
+ * tints are lifted to mid-saturation so the low-alpha fills still tint
+ * the dark tiles legibly, and the highlight stroke is light enough to
+ * read against a near-black backdrop.
+ */
+const DARK_PALETTE: ChartColorPalette = {
+  highlight: {
+    primary: '#fde047',
+    stroke: '#cbd5e1',
+    focusOutline: '#fef9c3',
+  },
+  symbolStroke: '#ffffff',
+  airport: {
+    major: '#3b82f6',
+    minor: '#cbd5e1',
+  },
+  fix: '#fb923c',
+  navaid: '#a78bfa',
+  airway: {
+    low: '#cbd5e1',
+    high: '#818cf8',
+    regional: '#94a3b8',
+  },
+  airspace: {
+    classB: '#3b82f6',
+    classC: '#ec4899',
+    classD: '#60a5fa',
+    classE: '#f472b6',
+    moa: '#fbbf24',
+    restricted: '#ef4444',
+    prohibited: '#f87171',
+    warning: '#fb923c',
+    alert: '#fde047',
+    nsa: '#9ca3af',
+    artcc: '#cbd5e1',
+    fallback: '#94a3b8',
+  },
+  airspaceBadge: {
+    text: '#fef08a',
+    halo: '#0f172a',
+  },
+};
+
+/**
+ * Returns the chart-color palette matching the resolved theme. Layer
+ * components call this inside the function body and rebuild any
+ * `LayerProps` that reference palette values via `useMemo` so a theme
+ * switch propagates through MapLibre's declarative `paint` props
+ * without a manual `setStyle` call.
+ *
+ * Falls back to the light palette when the surrounding `<ThemeProvider>`
+ * is missing (the context default resolves to `'light'`), which keeps
+ * isolated component tests render-safe without a wrapper.
+ *
+ * ```tsx
+ * function MyLayer(): ReactElement | null {
+ *   const colors = useChartColors();
+ *   const layerProps = useMemo<LayerProps>(
+ *     () => ({ ..., paint: { 'circle-color': colors.airport.major } }),
+ *     [colors],
+ *   );
+ *   return <Layer {...layerProps} />;
+ * }
+ * ```
+ */
+export function useChartColors(): ChartColorPalette {
+  const resolved = useResolvedTheme();
+  return resolved === 'dark' ? DARK_PALETTE : LIGHT_PALETTE;
+}

--- a/apps/atlas/src/shared/styles/theme-context.ts
+++ b/apps/atlas/src/shared/styles/theme-context.ts
@@ -1,0 +1,115 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * User-selectable theme preference. `'light'` and `'dark'` are explicit
+ * overrides that win regardless of the operating system; `'system'`
+ * defers to the `prefers-color-scheme` media query so the app follows
+ * whichever setting the OS reports.
+ */
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+/**
+ * Concrete theme actually applied to the DOM and the chart palette
+ * after the `'system'` preference has been resolved against the
+ * `prefers-color-scheme` media query. UI code that wants to branch on
+ * "is the page light or dark right now?" reads {@link useResolvedTheme}
+ * and matches against this union instead of {@link ThemePreference},
+ * which carries the indirection.
+ */
+export type ResolvedTheme = 'light' | 'dark';
+
+/**
+ * Shape of the value carried by {@link ThemeContext}. The provider builds
+ * this by reading the persisted preference, listening to the system
+ * preference, and exposing a setter that both writes localStorage and
+ * applies the `.dark` class to `documentElement`.
+ */
+export interface ThemeContextValue {
+  /** Currently-stored user preference (light / dark / system). */
+  preference: ThemePreference;
+  /**
+   * Concrete theme after resolving `'system'` against the OS preference
+   * (`prefers-color-scheme: dark`). Always `'light'` or `'dark'`,
+   * never `'system'`.
+   */
+  resolved: ResolvedTheme;
+  /** Updates the persisted preference and re-resolves the theme. */
+  setPreference: (preference: ThemePreference) => void;
+}
+
+/**
+ * localStorage key used by the provider to persist the user's choice
+ * across sessions. Exported so the FOUC bootstrap script in `main.tsx`
+ * can read it before React mounts and apply the matching class to
+ * `documentElement` synchronously, avoiding a white flash on first
+ * paint when the resolved theme is dark.
+ */
+export const THEME_STORAGE_KEY = 'atlas:theme';
+
+/**
+ * CSS media query the provider listens on to resolve the `'system'`
+ * preference. Exported so tests and the FOUC bootstrap can use the
+ * same string and stay in lockstep.
+ */
+export const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * Class name applied to `documentElement` whenever the resolved theme
+ * is dark. The custom `dark:` Tailwind variant in `src/index.css`
+ * targets this class.
+ */
+export const DARK_CLASS_NAME = 'dark';
+
+/**
+ * Default value for the context, used when a consumer renders outside
+ * the provider (e.g. an isolated test that mounts a single component
+ * without the shell). The default keeps the resolved theme on
+ * `'light'`, exposes a no-op setter, and ensures hooks remain safe to
+ * call - matching the safe-defaults convention used by
+ * `highlight-context.ts`.
+ */
+const DEFAULT_VALUE: ThemeContextValue = {
+  preference: 'system',
+  resolved: 'light',
+  setPreference: (): void => {},
+};
+
+/**
+ * React context carrying the active theme preference, the resolved
+ * theme, and the setter. Populated by `<ThemeProvider>` in
+ * `theme-provider.tsx`; consumed via {@link useTheme} and
+ * {@link useResolvedTheme}.
+ */
+export const ThemeContext = createContext<ThemeContextValue>(DEFAULT_VALUE);
+
+/**
+ * Reads the full {@link ThemeContextValue} from the surrounding
+ * provider. Use this when both the user-selected preference and the
+ * setter are needed (e.g. the theme-switcher dropdown). Components
+ * that only need the resolved light / dark theme should prefer
+ * {@link useResolvedTheme} so re-renders are limited to the resolved
+ * value changing.
+ */
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}
+
+/**
+ * Reads the resolved (post-`'system'`-resolution) theme from the
+ * surrounding provider. Use this from chart-color hooks, basemap
+ * components, and anywhere the UI cares only about "is this light or
+ * dark right now?" rather than the user's preference indirection.
+ */
+export function useResolvedTheme(): ResolvedTheme {
+  return useContext(ThemeContext).resolved;
+}
+
+/**
+ * Type guard that narrows an unknown localStorage value to a valid
+ * {@link ThemePreference}. Defensive against a stale or hand-edited
+ * key surviving across schema changes; callers fall back to the
+ * default preference (`'system'`) when the guard returns false.
+ */
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'light' || value === 'dark' || value === 'system';
+}

--- a/apps/atlas/src/shared/styles/theme-provider.spec.tsx
+++ b/apps/atlas/src/shared/styles/theme-provider.spec.tsx
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { ThemeProvider } from './theme-provider.tsx';
+import {
+  DARK_CLASS_NAME,
+  PREFERS_DARK_MEDIA_QUERY,
+  THEME_STORAGE_KEY,
+  useTheme,
+} from './theme-context.ts';
+
+/**
+ * Builds a matchMedia stub that lets tests force a specific
+ * `prefers-color-scheme: dark` outcome and dispatch live changes to
+ * subscribed listeners. Other queries default to `matches: true` to
+ * preserve the global shim's desktop-hover convention.
+ *
+ * Stores listeners as the standard `EventListenerOrEventListenerObject`
+ * union so the stub satisfies the strict `MediaQueryList` interface,
+ * and dispatches real `MediaQueryListEvent` instances on change so
+ * subscribers receive the same shape they would in a real browser.
+ */
+function buildMatchMediaStub(initialPrefersDark: boolean): {
+  matchMedia: (query: string) => MediaQueryList;
+  setPrefersDark: (next: boolean) => void;
+} {
+  let prefersDark = initialPrefersDark;
+  const listenersByQuery = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  function matchMedia(query: string): MediaQueryList {
+    const matches = query === PREFERS_DARK_MEDIA_QUERY ? prefersDark : true;
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: (): void => {},
+      removeListener: (): void => {},
+      addEventListener: (type: string, listener: EventListenerOrEventListenerObject): void => {
+        if (type !== 'change') {
+          return;
+        }
+        const bucket = listenersByQuery.get(query) ?? new Set<EventListenerOrEventListenerObject>();
+        bucket.add(listener);
+        listenersByQuery.set(query, bucket);
+      },
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject): void => {
+        if (type !== 'change') {
+          return;
+        }
+        listenersByQuery.get(query)?.delete(listener);
+      },
+      dispatchEvent: (): boolean => false,
+    };
+  }
+  function setPrefersDark(next: boolean): void {
+    prefersDark = next;
+    const subs = listenersByQuery.get(PREFERS_DARK_MEDIA_QUERY);
+    if (subs === undefined) {
+      return;
+    }
+    // jsdom does not expose `MediaQueryListEvent`, so build a regular
+    // `Event` and augment it with the `matches` / `media` fields via
+    // `Object.assign`. The listener stored as
+    // `EventListenerOrEventListenerObject` accepts a plain `Event`, and
+    // the provider's real handler only reads `event.matches`.
+    const event = Object.assign(new Event('change'), {
+      matches: next,
+      media: PREFERS_DARK_MEDIA_QUERY,
+    });
+    for (const listener of subs) {
+      if (typeof listener === 'function') {
+        listener(event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+  }
+  return { matchMedia, setPrefersDark };
+}
+
+/**
+ * Test probe rendered inside the provider that surfaces the resolved
+ * theme and the user preference into the DOM where Testing Library can
+ * read them.
+ */
+function ThemeProbe(): ReactElement {
+  const { preference, resolved } = useTheme();
+  return (
+    <div>
+      <span data-testid="preference">{preference}</span>
+      <span data-testid="resolved">{resolved}</span>
+    </div>
+  );
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove(DARK_CLASS_NAME);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+    document.documentElement.classList.remove(DARK_CLASS_NAME);
+  });
+
+  it('defaults to system when no preference is stored', () => {
+    const { matchMedia } = buildMatchMediaStub(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('resolved')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass(DARK_CLASS_NAME);
+  });
+
+  it('resolves system to dark when prefers-color-scheme matches', () => {
+    const { matchMedia } = buildMatchMediaStub(true);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+    expect(screen.getByTestId('resolved')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass(DARK_CLASS_NAME);
+  });
+
+  it('reads explicit dark preference from localStorage', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    const { matchMedia } = buildMatchMediaStub(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('dark');
+    expect(screen.getByTestId('resolved')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass(DARK_CLASS_NAME);
+  });
+
+  it('explicit light preference wins over a dark OS preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    const { matchMedia } = buildMatchMediaStub(true);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('light');
+    expect(screen.getByTestId('resolved')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass(DARK_CLASS_NAME);
+  });
+
+  it('falls back to system when the stored value is invalid', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'not-a-real-value');
+    const { matchMedia } = buildMatchMediaStub(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('preference')).toHaveTextContent('system');
+  });
+
+  it('follows a live OS theme change while on system', () => {
+    const { matchMedia, setPrefersDark } = buildMatchMediaStub(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('resolved')).toHaveTextContent('light');
+    act(() => {
+      setPrefersDark(true);
+    });
+    expect(screen.getByTestId('resolved')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass(DARK_CLASS_NAME);
+  });
+});
+
+/**
+ * Test rig that exposes the provider's setter through real buttons.
+ * Driving the side effect through DOM events (instead of capturing the
+ * hook return into a module-scope let) keeps the test pure-render and
+ * satisfies the `react-hooks/globals` lint rule.
+ */
+function PreferenceSetterButtons(): ReactElement {
+  const { setPreference } = useTheme();
+  return (
+    <div>
+      <button type="button" onClick={(): void => setPreference('light')}>
+        set light
+      </button>
+      <button type="button" onClick={(): void => setPreference('dark')}>
+        set dark
+      </button>
+      <button type="button" onClick={(): void => setPreference('system')}>
+        set system
+      </button>
+    </div>
+  );
+}
+
+describe('useTheme().setPreference', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove(DARK_CLASS_NAME);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+    document.documentElement.classList.remove(DARK_CLASS_NAME);
+  });
+
+  it('writes the new preference to localStorage and toggles the dark class', () => {
+    const { matchMedia } = buildMatchMediaStub(false);
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(
+      <ThemeProvider>
+        <PreferenceSetterButtons />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement).not.toHaveClass(DARK_CLASS_NAME);
+    fireEvent.click(screen.getByRole('button', { name: 'set dark' }));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement).toHaveClass(DARK_CLASS_NAME);
+    fireEvent.click(screen.getByRole('button', { name: 'set light' }));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(document.documentElement).not.toHaveClass(DARK_CLASS_NAME);
+  });
+});

--- a/apps/atlas/src/shared/styles/theme-provider.tsx
+++ b/apps/atlas/src/shared/styles/theme-provider.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import {
+  DARK_CLASS_NAME,
+  PREFERS_DARK_MEDIA_QUERY,
+  THEME_STORAGE_KEY,
+  ThemeContext,
+  isThemePreference,
+} from './theme-context.ts';
+import type { ResolvedTheme, ThemePreference } from './theme-context.ts';
+
+/**
+ * Props for {@link ThemeProvider}.
+ */
+export interface ThemeProviderProps {
+  /** App tree that should receive the theme context. */
+  children: ReactNode;
+}
+
+/**
+ * Top-level provider that owns the active theme preference and keeps
+ * `documentElement.classList` in sync with the resolved theme. Mount
+ * this once near the root of the app (above the router) so every
+ * descendant - the shell, the inspector, and every chart layer - reads
+ * the same source of truth via {@link useTheme} or
+ * {@link useResolvedTheme}.
+ *
+ * Behavior:
+ *
+ * - Reads the persisted preference from `localStorage[THEME_STORAGE_KEY]`
+ *   on mount; falls back to `'system'` when the key is missing or
+ *   carries a stale value the type guard rejects.
+ * - Resolves `'system'` against the `(prefers-color-scheme: dark)`
+ *   media query and subscribes to `change` events so the app follows
+ *   the OS preference live while the user is on `'system'`.
+ * - Writes `.dark` to `documentElement` whenever the resolved theme is
+ *   dark and removes it otherwise. The `<html>` flag is the same hook
+ *   the FOUC bootstrap in `main.tsx` writes pre-mount, so the class
+ *   transition stays continuous from the very first paint.
+ * - Persists every preference change back to localStorage on update,
+ *   so a refresh reproduces the chosen state.
+ */
+export function ThemeProvider({ children }: ThemeProviderProps): ReactElement {
+  const [preference, setPreferenceState] = useState<ThemePreference>(() => readStoredPreference());
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(() =>
+    readSystemPrefersDark(),
+  );
+
+  // Subscribe to OS theme changes so a `'system'` preference follows the
+  // user toggling their OS dark mode without requiring a refresh.
+  // matchMedia is unavailable in SSR / older test environments;
+  // bail out cleanly so the provider still renders.
+  useEffect((): (() => void) | undefined => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const mq = window.matchMedia(PREFERS_DARK_MEDIA_QUERY);
+    function handleChange(event: MediaQueryListEvent): void {
+      setSystemPrefersDark(event.matches);
+    }
+    mq.addEventListener('change', handleChange);
+    return (): void => {
+      mq.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const resolved: ResolvedTheme =
+    preference === 'system' ? (systemPrefersDark ? 'dark' : 'light') : preference;
+
+  // Keep `documentElement` in sync with the resolved theme. The class
+  // is the hook the custom Tailwind `dark:` variant targets and the
+  // same class the FOUC bootstrap in `main.tsx` writes before React
+  // mounts.
+  useEffect((): void => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const root = document.documentElement;
+    if (resolved === 'dark') {
+      root.classList.add(DARK_CLASS_NAME);
+    } else {
+      root.classList.remove(DARK_CLASS_NAME);
+    }
+  }, [resolved]);
+
+  const setPreference = useCallback((next: ThemePreference): void => {
+    setPreferenceState(next);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // localStorage may throw under privacy modes / disabled storage;
+      // the in-memory preference still updates so the session works,
+      // it just will not persist across reloads.
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ preference, resolved, setPreference }),
+    [preference, resolved, setPreference],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+/**
+ * Reads the persisted theme preference from localStorage, falling
+ * back to `'system'` when the key is missing, the storage API is
+ * unavailable, or the stored value fails the type guard. Pulled out
+ * of the provider body so the lazy `useState` initializer stays
+ * readable.
+ */
+function readStoredPreference(): ThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (isThemePreference(stored)) {
+      return stored;
+    }
+  } catch {
+    // Privacy-mode browsers throw on getItem; fall through to default.
+  }
+  return 'system';
+}
+
+/**
+ * Reads the current OS dark-mode preference, defaulting to `false`
+ * when the matchMedia API is unavailable. Pulled out of the provider
+ * body so the lazy `useState` initializer stays readable.
+ */
+function readSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(PREFERS_DARK_MEDIA_QUERY).matches;
+}

--- a/apps/atlas/src/shell/mode-switcher.tsx
+++ b/apps/atlas/src/shell/mode-switcher.tsx
@@ -46,8 +46,8 @@ function ModeLink({ to, children }: ModeLinkProps): ReactElement {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const active = pathname === to || pathname.startsWith(`${to}/`);
   const className = active
-    ? 'inline-flex items-center rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white md:py-1.5'
-    : 'inline-flex items-center rounded-md px-3 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-100 md:py-1.5';
+    ? 'inline-flex items-center rounded-md bg-slate-900 px-3 py-2.5 text-sm font-medium text-white md:py-1.5 dark:bg-slate-100 dark:text-slate-900'
+    : 'inline-flex items-center rounded-md px-3 py-2.5 text-sm font-medium text-slate-700 hover:bg-slate-100 md:py-1.5 dark:text-slate-300 dark:hover:bg-slate-800';
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {

--- a/apps/atlas/src/shell/shell-layout.tsx
+++ b/apps/atlas/src/shell/shell-layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import { ModeSwitcher } from './mode-switcher.tsx';
+import { ThemeSwitcher } from './theme-switcher.tsx';
 
 /**
  * Props for the top-level app shell layout.
@@ -10,16 +11,24 @@ export interface ShellLayoutProps {
 }
 
 /**
- * Top-level app layout. Owns the shell chrome (brand, mode switcher) and renders
- * the active mode's content. The shell is mode-agnostic: it knows nothing about
- * any specific mode beyond what {@link ModeSwitcher} renders in the header.
+ * Top-level app layout. Owns the shell chrome (brand, theme switcher,
+ * mode switcher) and renders the active mode's content. The shell is
+ * mode-agnostic: it knows nothing about any specific mode beyond what
+ * {@link ModeSwitcher} renders in the header. {@link ThemeSwitcher} is
+ * shell-level so it sits above every mode regardless of which page is
+ * active.
  */
 export function ShellLayout({ children }: ShellLayoutProps): ReactElement {
   return (
-    <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-2">
-        <span className="font-semibold tracking-tight text-slate-900">Squawk Atlas</span>
-        <ModeSwitcher />
+    <div className="flex h-full flex-col bg-white dark:bg-slate-950">
+      <header className="flex items-center justify-between border-b border-slate-200 bg-white px-4 py-2 dark:border-slate-800 dark:bg-slate-900">
+        <span className="font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+          Squawk Atlas
+        </span>
+        <div className="flex items-center gap-2">
+          <ThemeSwitcher />
+          <ModeSwitcher />
+        </div>
       </header>
       <main className="relative flex-1 overflow-hidden">{children}</main>
     </div>

--- a/apps/atlas/src/shell/theme-switcher.spec.tsx
+++ b/apps/atlas/src/shell/theme-switcher.spec.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeSwitcher } from './theme-switcher.tsx';
+import { ThemeProvider } from '../shared/styles/theme-provider.tsx';
+import { THEME_STORAGE_KEY } from '../shared/styles/theme-context.ts';
+
+// Radix DropdownMenu's open/close cycle drives off pointer events that
+// jsdom does not fully simulate, and its internals (portal layout,
+// keyboard handling, etc.) are third-party concerns we do not want to
+// pin down. Mock the primitives so menu items render unconditionally
+// and row clicks call the right handler. RadioItem renders as a
+// `role="menuitemradio"` div whose click triggers the surrounding
+// RadioGroup's `onValueChange`, mirroring the production behavior the
+// switcher relies on.
+vi.mock('@radix-ui/react-dropdown-menu', () => {
+  function Root({ children }: { children: ReactNode }): ReactNode {
+    return children;
+  }
+  function Trigger({
+    children,
+    className,
+    'aria-label': ariaLabel,
+    title,
+  }: {
+    children: ReactNode;
+    className?: string;
+    'aria-label'?: string;
+    title?: string;
+  }): ReactNode {
+    return (
+      <button type="button" className={className} aria-label={ariaLabel} title={title}>
+        {children}
+      </button>
+    );
+  }
+  function Portal({ children }: { children: ReactNode }): ReactNode {
+    return children;
+  }
+  function Content({ children }: { children: ReactNode }): ReactNode {
+    return <div>{children}</div>;
+  }
+  function ItemIndicator({ children }: { children: ReactNode }): ReactNode {
+    return <span>{children}</span>;
+  }
+  function RadioGroup({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    value: string;
+    onValueChange: (next: string) => void;
+  }): ReactNode {
+    return (
+      <RadioGroupContext.Provider value={{ value, onValueChange }}>
+        <div role="radiogroup" data-value={value}>
+          {children}
+        </div>
+      </RadioGroupContext.Provider>
+    );
+  }
+  function RadioItem({
+    children,
+    value,
+    className,
+  }: {
+    children: ReactNode;
+    value: string;
+    className?: string;
+  }): ReactNode {
+    return (
+      <RadioGroupContext.Consumer>
+        {(ctx) => (
+          <div
+            role="menuitemradio"
+            aria-checked={ctx?.value === value}
+            tabIndex={0}
+            className={className}
+            onClick={() => ctx?.onValueChange(value)}
+            onKeyDown={(event) => {
+              if (event.key === ' ' || event.key === 'Enter') {
+                event.preventDefault();
+                ctx?.onValueChange(value);
+              }
+            }}
+          >
+            {children}
+          </div>
+        )}
+      </RadioGroupContext.Consumer>
+    );
+  }
+  return {
+    Root,
+    Trigger,
+    Portal,
+    Content,
+    ItemIndicator,
+    RadioGroup,
+    RadioItem,
+  };
+});
+
+// Lightweight context shim used by the mocked RadioGroup/RadioItem to
+// thread the current value + change handler from the parent into the
+// items, mirroring Radix's real implementation.
+import { createContext } from 'react';
+const RadioGroupContext = createContext<
+  { value: string; onValueChange: (next: string) => void } | undefined
+>(undefined);
+
+describe('ThemeSwitcher', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('renders a menu of Light / Dark / System options', () => {
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole('menuitemradio', { name: /Light/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /Dark/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /System/ })).toBeInTheDocument();
+  });
+
+  it('selecting Dark persists the preference and applies the dark class', () => {
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Dark/ }));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+  });
+
+  it('selecting Light removes the dark class and writes the preference', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher />
+      </ThemeProvider>,
+    );
+    expect(document.documentElement).toHaveClass('dark');
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Light/ }));
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+  });
+
+  it('trigger label reflects the current preference, not the resolved theme', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'system');
+    render(
+      <ThemeProvider>
+        <ThemeSwitcher />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole('button', { name: /Theme: System/ })).toBeInTheDocument();
+  });
+});

--- a/apps/atlas/src/shell/theme-switcher.tsx
+++ b/apps/atlas/src/shell/theme-switcher.tsx
@@ -1,0 +1,201 @@
+import type { ReactElement } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { useTheme } from '../shared/styles/theme-context.ts';
+import type { ThemePreference } from '../shared/styles/theme-context.ts';
+
+/**
+ * One row in the theme-preference dropdown menu.
+ */
+interface ThemeOption {
+  /** Stored preference value this row writes to context + localStorage. */
+  id: ThemePreference;
+  /** Visible label rendered in the menu row. */
+  label: string;
+  /**
+   * Tiny secondary line shown beneath the label, describing what the
+   * option actually does (e.g. "Match my OS"). Omitted to keep a row
+   * compact when the label alone is unambiguous.
+   */
+  description?: string;
+}
+
+/**
+ * Theme rows in display order. `'system'` lands last because it is the
+ * "let the OS decide" escape hatch and most users will reach for an
+ * explicit choice; presenting Light first keeps the menu's primary
+ * affordance the most common pick.
+ */
+const THEME_OPTIONS: readonly ThemeOption[] = [
+  { id: 'light', label: 'Light' },
+  { id: 'dark', label: 'Dark' },
+  { id: 'system', label: 'System', description: 'Match my OS' },
+];
+
+/**
+ * Theme-preference dropdown rendered in the shell header. The trigger
+ * shows whichever icon (sun / moon / monitor) reflects the user's
+ * current preference - not the resolved theme - so a user on `'system'`
+ * sees a monitor glyph instead of the sun/moon their OS is currently
+ * resolving to. This keeps the affordance honest: clicking the trigger
+ * does not change the *appearance* of the icon, just opens the menu
+ * where the user can switch.
+ */
+export function ThemeSwitcher(): ReactElement {
+  const { preference, setPreference } = useTheme();
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        aria-label={`Theme: ${labelFor(preference)} (click to change)`}
+        title="Change theme"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-md text-slate-700 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7 dark:text-slate-300 dark:hover:bg-slate-800 dark:focus-visible:ring-slate-500"
+      >
+        <ThemeTriggerIcon preference={preference} />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="min-w-[10rem] rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
+        >
+          <DropdownMenu.RadioGroup
+            value={preference}
+            onValueChange={(value: string): void => {
+              if (value === 'light' || value === 'dark' || value === 'system') {
+                setPreference(value);
+              }
+            }}
+          >
+            {THEME_OPTIONS.map((option) => (
+              <DropdownMenu.RadioItem
+                key={option.id}
+                value={option.id}
+                className="flex cursor-default items-center gap-2 rounded px-2 py-2.5 text-sm text-slate-700 outline-none data-[highlighted]:bg-slate-100 md:py-1.5 dark:text-slate-200 dark:data-[highlighted]:bg-slate-800"
+              >
+                <span
+                  aria-hidden="true"
+                  className="inline-flex h-4 w-4 items-center justify-center"
+                >
+                  <DropdownMenu.ItemIndicator>
+                    <CheckIcon />
+                  </DropdownMenu.ItemIndicator>
+                </span>
+                <span className="flex flex-col">
+                  <span>{option.label}</span>
+                  {option.description !== undefined ? (
+                    <span className="text-[11px] text-slate-500 dark:text-slate-400">
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </DropdownMenu.RadioItem>
+            ))}
+          </DropdownMenu.RadioGroup>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+/**
+ * Looks up the visible label for a preference, used in the trigger's
+ * accessible name so screen readers announce the current state.
+ */
+function labelFor(preference: ThemePreference): string {
+  const match = THEME_OPTIONS.find((option) => option.id === preference);
+  return match?.label ?? 'System';
+}
+
+/**
+ * Trigger glyph that mirrors the current preference: sun for Light,
+ * moon for Dark, monitor for System. Shows the user's stored choice
+ * rather than the resolved theme so a user on `'system'` always sees
+ * the monitor glyph (and is not surprised when clicking the trigger
+ * does not toggle to the inverse appearance).
+ */
+function ThemeTriggerIcon({ preference }: { preference: ThemePreference }): ReactElement {
+  if (preference === 'light') {
+    return <SunIcon />;
+  }
+  if (preference === 'dark') {
+    return <MoonIcon />;
+  }
+  return <MonitorIcon />;
+}
+
+/** Sun glyph rendered for the Light preference. */
+function SunIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="3" />
+      <path d="M8 1.5V3M8 13V14.5M3.5 3.5L4.5 4.5M11.5 11.5L12.5 12.5M1.5 8H3M13 8H14.5M3.5 12.5L4.5 11.5M11.5 4.5L12.5 3.5" />
+    </svg>
+  );
+}
+
+/** Moon glyph rendered for the Dark preference. */
+function MoonIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M13.5 9.5C12.7 11.6 10.7 13 8.5 13C5.5 13 3 10.5 3 7.5C3 5.3 4.4 3.3 6.5 2.5C6.2 3.3 6 4.1 6 5C6 8 8.5 10.5 11.5 10.5C12.4 10.5 13.2 10.3 14 10C13.9 9.8 13.7 9.6 13.5 9.5Z" />
+    </svg>
+  );
+}
+
+/** Monitor glyph rendered for the System preference. */
+function MonitorIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="12" height="8" rx="1" />
+      <path d="M5 13.5H11M8 11V13.5" />
+    </svg>
+  );
+}
+
+/** Inline checkmark glyph rendered inside the Radix `ItemIndicator`. */
+function CheckIcon(): ReactElement {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 6.5L4.5 9L10 3.5" />
+    </svg>
+  );
+}

--- a/apps/atlas/src/test-setup.ts
+++ b/apps/atlas/src/test-setup.ts
@@ -10,12 +10,17 @@
  * accumulate in the document.
  *
  * Provides a minimal `window.matchMedia` shim for jsdom, which omits the
- * API entirely. Defaults every query to `matches: true` so hooks like
+ * API entirely. Most queries default to `matches: true` so hooks like
  * `useCanHover` (which inspects `(hover: hover)`) treat the test
  * environment as a desktop with a real hover gesture - matching the
- * default UX that hover-dependent specs were originally written
- * against. Tests that need to exercise the touch / no-hover path can
- * override this per-suite by stubbing `window.matchMedia`.
+ * default UX that hover-dependent specs were originally written against.
+ *
+ * `prefers-color-scheme: dark` is the one explicit exception: it
+ * defaults to `false` so tests that resolve theme from the system
+ * preference deterministically pick the light theme regardless of the
+ * host machine's OS setting. Tests that need to exercise the dark /
+ * touch / no-hover path can override this per-suite by stubbing
+ * `window.matchMedia`.
  */
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
@@ -23,7 +28,7 @@ import { afterEach } from 'vitest';
 
 if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   window.matchMedia = (query: string): MediaQueryList => ({
-    matches: true,
+    matches: query !== '(prefers-color-scheme: dark)',
     media: query,
     onchange: null,
     addListener: (): void => {},


### PR DESCRIPTION
Adds a header dropdown that flips Light/Dark/System, persisted in localStorage and applied via a class-based Tailwind dark variant (with a pre-paint bootstrap to avoid FOUC). Chart colors reshape into light/dark palettes behind a useChartColors hook; the basemap swap preserves atlas-* sources and layers via setStyle's transformStyle so features stay visible while tiles re-render.