### PR TITLE
Update icao-registy-data in order to test npm publish provenance added to publish.yml in previous PR

### DIFF
--- a/.changeset/refresh-icao-registry-data.md
+++ b/.changeset/refresh-icao-registry-data.md
@@ -1,0 +1,7 @@
+---
+'@squawk/icao-registry-data': patch
+---
+
+### Changed
+
+- Refreshed bundled FAA ReleasableAircraft snapshot to the 2026-05-03 release (312,230 records).

--- a/packages/libs/icao-registry-data/README.md
+++ b/packages/libs/icao-registry-data/README.md
@@ -2,7 +2,7 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE.md) [![npm](https://img.shields.io/npm/v/@squawk/icao-registry-data)](https://www.npmjs.com/package/@squawk/icao-registry-data) ![TypeScript](https://img.shields.io/badge/TypeScript-blue?logo=typescript&logoColor=white)
 
-Pre-processed snapshot of US aircraft registrations from the **2026-05-02** FAA ReleasableAircraft database. Data only - no dependency on `@squawk/icao-registry`. Versioned and released independently;
+Pre-processed snapshot of US aircraft registrations from the **2026-05-03** FAA ReleasableAircraft database. Data only - no dependency on `@squawk/icao-registry`. Versioned and released independently;
 
 **[Documentation](https://neilcochran.github.io/squawk/modules/_squawk_icao-registry-data.html)**
 


### PR DESCRIPTION
Only updating the data to test the new npm publish provenance added to publish.yml in the last PR