### PR TITLE
fix readme drift

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Closes #
 - [ ] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
 
 <!--
-For changeset format and CI gate details, see ARCHITECTURE.md.
+For the changeset format, see CONVENTIONS.md (Changeset format).
+For CI gate details, see ARCHITECTURE.md (Quality gates).
 For security vulnerabilities, do not use this template - see SECURITY.md.
 -->

--- a/packages/libs/airport-data/README.md
+++ b/packages/libs/airport-data/README.md
@@ -31,8 +31,8 @@ npm install @squawk/airport-data
 import { usBundledAirports } from '@squawk/airport-data';
 
 // Inspect metadata
-console.log(usBundledAirports.properties.nasrCycleDate); // "2026-01-22"
-console.log(usBundledAirports.properties.recordCount); // 19146
+console.log(usBundledAirports.properties.nasrCycleDate); // YYYY-MM-DD
+console.log(usBundledAirports.properties.recordCount);
 
 // Use with @squawk/airports for zero-config airport queries
 import { createAirportResolver } from '@squawk/airports';

--- a/packages/libs/airway-data/README.md
+++ b/packages/libs/airway-data/README.md
@@ -36,7 +36,7 @@ npm install @squawk/airway-data
 import { usBundledAirways } from '@squawk/airway-data';
 
 // Inspect metadata
-console.log(usBundledAirways.properties.nasrCycleDate); // "2026-01-22"
+console.log(usBundledAirways.properties.nasrCycleDate); // YYYY-MM-DD
 console.log(usBundledAirways.properties.recordCount);
 console.log(usBundledAirways.properties.waypointCount);
 

--- a/packages/libs/fix-data/README.md
+++ b/packages/libs/fix-data/README.md
@@ -34,7 +34,7 @@ npm install @squawk/fix-data
 import { usBundledFixes } from '@squawk/fix-data';
 
 // Inspect metadata
-console.log(usBundledFixes.properties.nasrCycleDate); // "2026-01-22"
+console.log(usBundledFixes.properties.nasrCycleDate); // YYYY-MM-DD
 console.log(usBundledFixes.properties.recordCount);
 
 // Use with @squawk/fixes for zero-config fix queries

--- a/packages/libs/flight-math/README.md
+++ b/packages/libs/flight-math/README.md
@@ -76,3 +76,4 @@ Functions that already exist in `@squawk/units` are not re-exported. Import them
 - **pivotal** - Pivotal altitude for ground reference maneuvers
 - **solar** - Sunrise/sunset, civil twilight, day/night determination (NOAA algorithm)
 - **magnetic** - Magnetic declination and field components (WMM2025), true/magnetic bearing conversion
+- **planning** - Fuel required, endurance, point of no return, equal time point

--- a/packages/libs/icao-registry-data/README.md
+++ b/packages/libs/icao-registry-data/README.md
@@ -2,7 +2,7 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](../../../LICENSE.md) [![npm](https://img.shields.io/npm/v/@squawk/icao-registry-data)](https://www.npmjs.com/package/@squawk/icao-registry-data) ![TypeScript](https://img.shields.io/badge/TypeScript-blue?logo=typescript&logoColor=white)
 
-Pre-processed snapshot of US aircraft registrations from the **2026-05-03** FAA ReleasableAircraft database. Data only - no dependency on `@squawk/icao-registry`. Versioned and released independently;
+Pre-processed snapshot of US aircraft registrations from the **2026-05-03** FAA ReleasableAircraft database. Data only - no dependency on `@squawk/icao-registry`. Versioned and released independently.
 
 **[Documentation](https://neilcochran.github.io/squawk/modules/_squawk_icao-registry-data.html)**
 

--- a/packages/libs/navaid-data/README.md
+++ b/packages/libs/navaid-data/README.md
@@ -31,7 +31,7 @@ npm install @squawk/navaid-data
 import { usBundledNavaids } from '@squawk/navaid-data';
 
 // Inspect metadata
-console.log(usBundledNavaids.properties.nasrCycleDate); // "2026-01-22"
+console.log(usBundledNavaids.properties.nasrCycleDate); // YYYY-MM-DD
 console.log(usBundledNavaids.properties.recordCount);
 
 // Use with @squawk/navaids for zero-config navaid queries

--- a/tools/build-airport-data/README.md
+++ b/tools/build-airport-data/README.md
@@ -47,7 +47,9 @@ All input files come from the NASR subscription CSV data ZIP (e.g.
 
 ## Dependencies
 
-| Package         | Purpose                                |
-| --------------- | -------------------------------------- |
-| `@squawk/types` | `Airport` and related type definitions |
-| `adm-zip`       | ZIP extraction                         |
+| Package                | Purpose                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| `@squawk/build-shared` | Shared NASR build utilities (CLI args, input resolution) |
+| `@squawk/types`        | `Airport` and related type definitions                   |
+| `adm-zip`              | ZIP extraction                                           |
+| `geo-tz`               | IANA timezone resolution from airport coordinates        |

--- a/tools/build-airspace-data/README.md
+++ b/tools/build-airspace-data/README.md
@@ -20,7 +20,7 @@ The `--local` path must be the root of an extracted NASR 28-day subscription
 directory named `28DaySubscription_Effective_YYYY-MM-DD`. The cycle date is
 parsed from the directory name and embedded in the output metadata.
 
-The default output path is `packages/libs/airspace-data/data/airspace.geojson`.
+The default output path is `packages/libs/airspace-data/data/airspace.geojson.gz`.
 
 ### Validating output
 
@@ -60,9 +60,10 @@ All input files come from inside the NASR subscription directory:
 
 ## Dependencies
 
-| Package           | Purpose                                                |
-| ----------------- | ------------------------------------------------------ |
-| `shapefile`       | Parse ESRI Shapefile format                            |
-| `fast-xml-parser` | Parse SAA AIXM 5.0 XML                                 |
-| `adm-zip`         | Read nested ZIP archives in memory                     |
-| `@squawk/types`   | `AirspaceFeature` and `AltitudeBound` type definitions |
+| Package                | Purpose                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| `@squawk/build-shared` | Shared NASR build utilities (CLI args, input resolution) |
+| `@squawk/types`        | `AirspaceFeature` and `AltitudeBound` type definitions   |
+| `shapefile`            | Parse ESRI Shapefile format                              |
+| `fast-xml-parser`      | Parse SAA AIXM 5.0 XML                                   |
+| `adm-zip`              | Read nested ZIP archives in memory                       |

--- a/tools/build-airway-data/README.md
+++ b/tools/build-airway-data/README.md
@@ -1,0 +1,47 @@
+# build-airway-data
+
+Internal build script that processes FAA NASR airway data into the
+`@squawk/airway-data` dataset. Not published to npm.
+
+## Input
+
+An extracted FAA NASR 28-day subscription directory containing the fixed-width
+files `AWY.txt` and `ATS.txt`. Both files live at the root of the subscription
+directory rather than inside the `CSV_Data` ZIP, so no archive extraction is
+needed.
+
+## Process
+
+1. Reads `AWY.txt` line-by-line, parsing `AWY1` records (airway header per
+   sequence) and `AWY2` records (waypoint detail per sequence)
+2. Joins `AWY1` / `AWY2` records by `(designation, type-char, sequence)` into
+   ordered waypoint sequences for Victor, Jet, RNAV Q/T, and color (Green,
+   Red, Amber, Blue) airways
+3. Reads `ATS.txt` line-by-line, parsing `ATS1` and `ATS2` records the same
+   way for Atlantic, Bahama, Pacific, and Puerto Rico routes
+4. Resolves each airway's `type` (from the designation prefix) and `region`
+   (from the airway-type character) via `@squawk/types` mapping constants
+5. Sorts the merged result by designation and writes it as gzipped JSON
+
+## Output
+
+Gzipped JSON file written to `packages/libs/airway-data/data/airways.json.gz`.
+
+## Input files
+
+| File      | Purpose                                                   |
+| --------- | --------------------------------------------------------- |
+| `AWY.txt` | US-domestic airways: Victor, Jet, RNAV Q/T, color routes  |
+| `ATS.txt` | Oceanic and territorial routes: Atlantic, Bahama, Pacific |
+
+## Usage
+
+```bash
+npm run build
+node dist/index.js --local /path/to/28DaySubscription_Effective_YYYY-MM-DD
+```
+
+## Dependencies
+
+- `@squawk/build-shared` - Shared NASR build utilities (CLI args, input resolution)
+- `@squawk/types` - Airway type definitions and mapping constants

--- a/tools/build-fix-data/README.md
+++ b/tools/build-fix-data/README.md
@@ -39,5 +39,6 @@ node dist/index.js --local /path/to/28DaySubscription_Effective_YYYY-MM-DD
 
 ## Dependencies
 
+- `@squawk/build-shared` - Shared NASR build utilities (CLI args, input resolution)
 - `@squawk/types` - Fix type definitions and mapping constants
 - `adm-zip` - ZIP file extraction

--- a/tools/build-icao-registry-data/README.md
+++ b/tools/build-icao-registry-data/README.md
@@ -33,7 +33,7 @@ The default output path is `packages/libs/icao-registry-data/data/icao-registry.
 
 ## Dependencies
 
-| Package                 | Purpose                               |
-| ----------------------- | ------------------------------------- |
-| `@squawk/icao-registry` | `parseFaaRegistryZip()` parsing logic |
-| `adm-zip`               | ZIP extraction                        |
+| Package                 | Purpose                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `@squawk/build-shared`  | Shared NASR build utilities (CLI args, input resolution) |
+| `@squawk/icao-registry` | `parseFaaRegistryZip()` parsing logic                    |

--- a/tools/build-navaid-data/README.md
+++ b/tools/build-navaid-data/README.md
@@ -35,5 +35,6 @@ node dist/index.js --local /path/to/28DaySubscription_Effective_YYYY-MM-DD
 
 ## Dependencies
 
+- `@squawk/build-shared` - Shared NASR build utilities (CLI args, input resolution)
 - `@squawk/types` - Navaid type definitions and mapping constants
 - `adm-zip` - ZIP file extraction


### PR DESCRIPTION
## Summary

Correct READMEs that had drifted to become inaccurate

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #

## Checklist

- [x] Tests added or updated (or N/A - explain why)
    - N/A README changes only
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
    - N/A no library changes to publish, README changes only

<!--
For changeset format and CI gate details, see ARCHITECTURE.md.
For security vulnerabilities, do not use this template - see SECURITY.md.
-->
