### PR TITLE
Cap turbo concurrency at 50% globally in turbo.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "test": "turbo run test --concurrency=50%",
-    "test:coverage": "turbo run test:coverage --concurrency=50% --continue=always && node scripts/check-coverage.js",
-    "test:coverage:fresh": "turbo run test:coverage --concurrency=50% --force --continue=always && node scripts/check-coverage.js",
+    "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage --continue=always && node scripts/check-coverage.js",
+    "test:coverage:fresh": "turbo run test:coverage --force --continue=always && node scripts/check-coverage.js",
     "lint": "turbo run lint",
     "lint:pack": "turbo run lint:pack",
     "knip": "knip",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "concurrency": "50%",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Move `--concurrency=50%` from per-script flags in `package.json` into a top-level `concurrency` default in `turbo.json`. This caps `build`, `lint`, and `lint:pack` (previously uncapped) in addition to the test scripts (already capped), preventing `npm run lint` from spawning ~30 parallel `tsc`/`eslint` processes during the pre-commit hook on cold-cache runs. `dev` is unaffected since it is a persistent task. Per-invocation `--concurrency=...` flags still override.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A - tooling config change, no behavior to assert in tests. Verified locally with `npx turbo run lint --dry=json` (config accepted).
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A - root tooling config only; no published package surface changed.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->