### PR TITLE
Replace deprecated app-id with client-id in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

- Switch the publish workflow's `actions/create-github-app-token` step from the deprecated `app-id` input to `client-id`, sourced from a new `RELEASE_APP_CLIENT_ID` repo variable.
- Resolves the GitHub Actions deprecation warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead`.
- Requires creating a `RELEASE_APP_CLIENT_ID` repo variable (Settings -> Secrets and variables -> Actions -> Variables tab) with the squawk-release-bot app's Client ID before merging, so the post-merge Publish run succeeds. The unused `RELEASE_APP_ID` secret can be removed afterwards.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #

## Checklist

- [x] Tests added or updated (or N/A - explain why) 
    - N/A: workflow-only change, no testable code path.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling) 
    - N/A: CI/workflow change, no published-package surface affected.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->