### PR TITLE
Add /browser exports subpath to every query logic package

### DIFF
--- a/.changeset/logic-packages-browser-entries.md
+++ b/.changeset/logic-packages-browser-entries.md
@@ -1,0 +1,15 @@
+---
+'@squawk/airports': minor
+'@squawk/airspace': minor
+'@squawk/airways': minor
+'@squawk/fixes': minor
+'@squawk/navaids': minor
+'@squawk/procedures': minor
+'@squawk/icao-registry': minor
+---
+
+### Added
+
+- `/browser` exports subpath on every query logic package. SPAs and edge runtimes can now `import { create<X>Resolver } from '@squawk/<pkg>/browser'` and pair it with the matching `@squawk/<pkg>-data/browser` async loader for zero-config browser usage. Browser support was already implicit since the resolver factories have no Node-specific imports; the new entry makes it an explicit, `publint`-verified part of the public API surface, so a future Node-only import would have to split the surface intentionally rather than silently breaking SPA bundles.
+- For `@squawk/icao-registry`, the `/browser` entry is a strict subset that re-exports `createIcaoRegistry` and the shared types but omits `parseFaaRegistryZip`. The parser depends on Node's `Buffer` and the `adm-zip` package and remains exported from the default entry for Node consumers that want fresh FAA registry data.
+- The default (Node) entry on every package is unchanged; existing imports keep working.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ Five guiding principles shape every decision in this repo:
 - **Real-world data, not toy examples.** Libraries work against actual FAA datasets and live aviation weather feeds, not mocked or synthetic data.
 - **Designed for composition.** Libraries fit together naturally when building an application, but never require each other.
 - **Published quality from day one.** Every library ships with a README, TypeScript types, unit tests, and a changelog. No "I'll clean this up before publishing."
-- **Backend-first for libraries; data packages also ship browser entries.** Library packages target Node and stay pure. Data packages expose a `/browser` async loader so SPAs and edge runtimes can consume them too.
+- **Backend-first for libraries; data packages and most logic packages also ship browser entries.** Libraries target Node first and stay pure. Data packages expose a `/browser` async loader so SPAs and edge runtimes can consume them, and pure-logic query libraries (airports, airspace, airways, fixes, navaids, procedures) expose a `/browser` resolver entry that mirrors the main entry. Packages that include a Node-only surface ship a slim `/browser` entry that excludes it (`@squawk/icao-registry/browser` omits `parseFaaRegistryZip`). Server-only packages like `@squawk/mcp` and the build tools remain Node-only.
 - **Complete data models.** Models capture all reasonable, distinct fields for a concept, even fields not currently consumed. The libraries are published for others to build on; completeness and correctness of the data model is a primary goal.
 
 ---
@@ -88,9 +88,13 @@ Types shared across multiple packages live in `@squawk/types` - position, aircra
 
 Why: keeping `@squawk/types` focused on genuinely shared models avoids forcing a version bump on every package whenever a single domain's types evolve.
 
-### Browser entries on data packages
+### Browser entries on data and logic packages
 
-Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume them. The library packages themselves are Node-only.
+Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume the bundled snapshots. Pure-logic query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`) also expose a `/browser` subpath that aliases the main entry, since their resolver code has no Node-specific imports. The `/browser` import is the explicit, supported way for SPAs to consume these packages; the contract is enforced by `lint:pack` (publint) so a future Node-only import would have to split the surface explicitly rather than silently breaking browsers.
+
+`@squawk/icao-registry` is a hybrid: the main entry exposes a runtime `parseFaaRegistryZip` parser that depends on Node's `Buffer` and the `adm-zip` package, so the `/browser` entry is a strict subset that re-exports only `createIcaoRegistry` and the shared types.
+
+`@squawk/mcp` and the build tools under `tools/` remain Node-only.
 
 ### Namespace exports for utility packages
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -104,6 +104,16 @@ Each data package's metadata includes at least `generatedAt` (ISO timestamp), `r
 
 ---
 
+## Logic package browser entries
+
+Query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/icao-registry`) ship a `/browser` exports subpath alongside the default entry. For pure-logic packages with no Node-specific imports, the `/browser` subpath aliases the same compiled `dist/index.js`; the separate entry exists so browser support is an explicit, `publint`-verified part of the public API surface and a future Node-only import has to split the surface intentionally.
+
+Packages that mix pure-logic with a Node-only helper (e.g. `@squawk/icao-registry`'s `parseFaaRegistryZip`) instead expose a thin `src/browser.ts` re-exporting only the browser-safe symbols, with the `/browser` subpath pointing at its compiled output. The Node-only helper stays exported from the default entry.
+
+When adding a new query library, mirror this pattern: add a `./browser` entry to `package.json` `exports`, and create `src/browser.ts` only if the main entry transitively reaches Node-only code.
+
+---
+
 ## TSDoc
 
 Every exported symbol (interface, type, function, const, enum) must have a `/** */` TSDoc comment. Every property and parameter must have its own inline `/** */` comment.

--- a/packages/libs/airport-data/README.md
+++ b/packages/libs/airport-data/README.md
@@ -52,7 +52,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledAirports } from '@squawk/airport-data/browser';
-import { createAirportResolver } from '@squawk/airports';
+import { createAirportResolver } from '@squawk/airports/browser';
 
 const dataset = await loadUsBundledAirports();
 const resolver = createAirportResolver({ data: dataset.records });

--- a/packages/libs/airports/README.md
+++ b/packages/libs/airports/README.md
@@ -40,6 +40,20 @@ import { createAirportResolver } from '@squawk/airports';
 const resolver = createAirportResolver({ data: myAirports });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/airport-data/browser`:
+
+```typescript
+import { loadUsBundledAirports } from '@squawk/airport-data/browser';
+import { createAirportResolver } from '@squawk/airports/browser';
+
+const dataset = await loadUsBundledAirports();
+const resolver = createAirportResolver({ data: dataset.records });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createAirportResolver(options)`

--- a/packages/libs/airports/package.json
+++ b/packages/libs/airports/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/airspace-data/README.md
+++ b/packages/libs/airspace-data/README.md
@@ -43,7 +43,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledAirspace } from '@squawk/airspace-data/browser';
-import { createAirspaceResolver } from '@squawk/airspace';
+import { createAirspaceResolver } from '@squawk/airspace/browser';
 
 const dataset = await loadUsBundledAirspace();
 const resolver = createAirspaceResolver({ data: dataset });

--- a/packages/libs/airspace/README.md
+++ b/packages/libs/airspace/README.md
@@ -50,6 +50,20 @@ import { createAirspaceResolver } from '@squawk/airspace';
 const resolver = createAirspaceResolver({ data: myGeoJson });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/airspace-data/browser`:
+
+```typescript
+import { loadUsBundledAirspace } from '@squawk/airspace-data/browser';
+import { createAirspaceResolver } from '@squawk/airspace/browser';
+
+const dataset = await loadUsBundledAirspace();
+const resolver = createAirspaceResolver({ data: dataset });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## How it works
 
 `createAirspaceResolver` parses the GeoJSON FeatureCollection at initialization and

--- a/packages/libs/airspace/package.json
+++ b/packages/libs/airspace/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/airway-data/README.md
+++ b/packages/libs/airway-data/README.md
@@ -58,7 +58,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledAirways } from '@squawk/airway-data/browser';
-import { createAirwayResolver } from '@squawk/airways';
+import { createAirwayResolver } from '@squawk/airways/browser';
 
 const dataset = await loadUsBundledAirways();
 const resolver = createAirwayResolver({ data: dataset.records });

--- a/packages/libs/airways/README.md
+++ b/packages/libs/airways/README.md
@@ -47,6 +47,20 @@ import { createAirwayResolver } from '@squawk/airways';
 const resolver = createAirwayResolver({ data: myAirways });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/airway-data/browser`:
+
+```typescript
+import { loadUsBundledAirways } from '@squawk/airway-data/browser';
+import { createAirwayResolver } from '@squawk/airways/browser';
+
+const dataset = await loadUsBundledAirways();
+const resolver = createAirwayResolver({ data: dataset.records });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createAirwayResolver(options)`

--- a/packages/libs/airways/package.json
+++ b/packages/libs/airways/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/fix-data/README.md
+++ b/packages/libs/fix-data/README.md
@@ -55,7 +55,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledFixes } from '@squawk/fix-data/browser';
-import { createFixResolver } from '@squawk/fixes';
+import { createFixResolver } from '@squawk/fixes/browser';
 
 const dataset = await loadUsBundledFixes();
 const resolver = createFixResolver({ data: dataset.records });

--- a/packages/libs/fixes/README.md
+++ b/packages/libs/fixes/README.md
@@ -38,6 +38,20 @@ import { createFixResolver } from '@squawk/fixes';
 const resolver = createFixResolver({ data: myFixes });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/fix-data/browser`:
+
+```typescript
+import { loadUsBundledFixes } from '@squawk/fix-data/browser';
+import { createFixResolver } from '@squawk/fixes/browser';
+
+const dataset = await loadUsBundledFixes();
+const resolver = createFixResolver({ data: dataset.records });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createFixResolver(options)`

--- a/packages/libs/fixes/package.json
+++ b/packages/libs/fixes/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/icao-registry-data/README.md
+++ b/packages/libs/icao-registry-data/README.md
@@ -35,7 +35,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledRegistry } from '@squawk/icao-registry-data/browser';
-import { createIcaoRegistry } from '@squawk/icao-registry';
+import { createIcaoRegistry } from '@squawk/icao-registry/browser';
 
 const dataset = await loadUsBundledRegistry();
 const registry = createIcaoRegistry({ data: dataset.records });

--- a/packages/libs/icao-registry/README.md
+++ b/packages/libs/icao-registry/README.md
@@ -52,4 +52,18 @@ const registry = createIcaoRegistry({
 });
 ```
 
+## Browser / SPA usage
+
+For SPAs and edge runtimes, import from the `/browser` subpath. It re-exports `createIcaoRegistry` and the shared types but omits `parseFaaRegistryZip`, which depends on Node's `Buffer` and the `adm-zip` package and is unsuitable for browser bundles. Pair it with `@squawk/icao-registry-data/browser`:
+
+```typescript
+import { loadUsBundledRegistry } from '@squawk/icao-registry-data/browser';
+import { createIcaoRegistry } from '@squawk/icao-registry/browser';
+
+const dataset = await loadUsBundledRegistry();
+const registry = createIcaoRegistry({ data: dataset.records });
+```
+
+Browser consumers that need fresh FAA data should fetch and parse the ZIP server-side (where `parseFaaRegistryZip` is available) and feed the resulting records into the browser via their own API.
+
 > Under active development. See the [docs](https://neilcochran.github.io/squawk/modules/_squawk_icao-registry.html) for current API status.

--- a/packages/libs/icao-registry/package.json
+++ b/packages/libs/icao-registry/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/browser.d.ts",
+      "import": "./dist/browser.js"
     }
   },
   "files": [

--- a/packages/libs/icao-registry/src/browser.spec.ts
+++ b/packages/libs/icao-registry/src/browser.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+import * as browserEntry from './browser.js';
+
+describe('browser entry', () => {
+  it('exposes createIcaoRegistry', () => {
+    expect(typeof browserEntry.createIcaoRegistry).toBe('function');
+  });
+
+  it('does not expose parseFaaRegistryZip', () => {
+    expect('parseFaaRegistryZip' in browserEntry).toBe(false);
+  });
+});

--- a/packages/libs/icao-registry/src/browser.ts
+++ b/packages/libs/icao-registry/src/browser.ts
@@ -1,0 +1,14 @@
+/**
+ * @packageDocumentation
+ * Browser / edge entry point. Exposes the resolver factory and shared types
+ * without pulling in `parseFaaRegistryZip`, which depends on Node's `Buffer`
+ * and the `adm-zip` package and is unsuitable for browser bundles. Pair with
+ * `@squawk/icao-registry-data/browser` to consume the bundled snapshot.
+ *
+ * Node consumers should use the default {@link "."} entry point, which also
+ * exports `parseFaaRegistryZip` for parsing fresh FAA ReleasableAircraft ZIPs
+ * at runtime.
+ */
+export { createIcaoRegistry } from './registry.js';
+export type { IcaoRegistry, IcaoRegistryOptions } from './registry.js';
+export type { AircraftRegistration, AircraftType, EngineType } from '@squawk/types';

--- a/packages/libs/navaid-data/README.md
+++ b/packages/libs/navaid-data/README.md
@@ -52,7 +52,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledNavaids } from '@squawk/navaid-data/browser';
-import { createNavaidResolver } from '@squawk/navaids';
+import { createNavaidResolver } from '@squawk/navaids/browser';
 
 const dataset = await loadUsBundledNavaids();
 const resolver = createNavaidResolver({ data: dataset.records });

--- a/packages/libs/navaids/README.md
+++ b/packages/libs/navaids/README.md
@@ -44,6 +44,20 @@ import { createNavaidResolver } from '@squawk/navaids';
 const resolver = createNavaidResolver({ data: myNavaids });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/navaid-data/browser`:
+
+```typescript
+import { loadUsBundledNavaids } from '@squawk/navaid-data/browser';
+import { createNavaidResolver } from '@squawk/navaids/browser';
+
+const dataset = await loadUsBundledNavaids();
+const resolver = createNavaidResolver({ data: dataset.records });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createNavaidResolver(options)`

--- a/packages/libs/navaids/package.json
+++ b/packages/libs/navaids/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/procedure-data/README.md
+++ b/packages/libs/procedure-data/README.md
@@ -61,7 +61,7 @@ subpath. It fetches and decompresses the bundled `.gz` using Web Streams
 
 ```typescript
 import { loadUsBundledProcedures } from '@squawk/procedure-data/browser';
-import { createProcedureResolver } from '@squawk/procedures';
+import { createProcedureResolver } from '@squawk/procedures/browser';
 
 const dataset = await loadUsBundledProcedures();
 const resolver = createProcedureResolver({ data: dataset.records });

--- a/packages/libs/procedures/README.md
+++ b/packages/libs/procedures/README.md
@@ -60,6 +60,20 @@ import { createProcedureResolver } from '@squawk/procedures';
 const resolver = createProcedureResolver({ data: myProcedures });
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with `@squawk/procedure-data/browser`:
+
+```typescript
+import { loadUsBundledProcedures } from '@squawk/procedure-data/browser';
+import { createProcedureResolver } from '@squawk/procedures/browser';
+
+const dataset = await loadUsBundledProcedures();
+const resolver = createProcedureResolver({ data: dataset.records });
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createProcedureResolver(options)`

--- a/packages/libs/procedures/package.json
+++ b/packages/libs/procedures/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Adds an explicit `./browser` exports entry to all 7 query logic packages (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/icao-registry`) so SPAs can `import { create<X>Resolver } from '@squawk/<pkg>/browser'` and pair it with the matching `@squawk/<pkg>-data/browser` async loader. Browser support was already implicit since the resolver factories have no Node-specific imports; the new entry makes it `publint`-verified API surface so a future Node-only import has to split the surface intentionally rather than silently breaking SPA bundles.
- For the 6 pure-logic packages the `/browser` entry aliases the same `dist/index.js`. For `@squawk/icao-registry` the `/browser` entry is a strict subset (new `src/browser.ts`) that omits `parseFaaRegistryZip`, which depends on Node's `Buffer` and `adm-zip` and stays exported from the default entry.
- Documentation updated: `ARCHITECTURE.md` "Backend-first for libraries" principle and "Browser entries on data packages" section, new "Logic package browser entries" section in `CONVENTIONS.md`, "Browser / SPA usage" section added to each logic-package README, and the 7 data-package READMEs' browser examples now import the resolver from `/browser` for consistency. Default Node entries are unchanged across all packages.

## Related issue

N/A - maintainer-driven, no tracking issue.

## Checklist

- [x] Tests added or updated (or N/A - explain why)
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)