### PR TITLE
Link project board from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ Short, kebab-case, intent-describing branch names: `fetch-weather`, `route-dista
 
 ## Reporting bugs
 
-Use the [Bug report](.github/ISSUE_TEMPLATE/bug.yml) template. Include reproduction steps, the package and version, and the Node version.
+Before filing, check the [project board](https://github.com/users/neilcochran/projects/2) to see what's already tracked. Use the [Bug report](.github/ISSUE_TEMPLATE/bug.yml) template. Include reproduction steps, the package and version, and the Node version.
 
 ## Suggesting features
 
-Use the [Enhancement](.github/ISSUE_TEMPLATE/enhancement.yml) template. Motivation and use case context go a long way.
+Before filing, check the [project board](https://github.com/users/neilcochran/projects/2) to see what's already tracked. Use the [Enhancement](.github/ISSUE_TEMPLATE/enhancement.yml) template. Motivation and use case context go a long way.
 
 ## Questions and discussions
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ TypeScript libraries for building aviation applications - airspace geometry, wea
 
 **[Discussions](https://github.com/neilcochran/squawk/discussions)**
 
+**[Project board](https://github.com/users/neilcochran/projects/2)**
+
 ## Layout
 
 The repo splits into three top-level directories:


### PR DESCRIPTION
## Summary

Add a Project board link to the README masthead (alongside Discussions) and to the Reporting bugs / Suggesting features sections of CONTRIBUTING so prospective filers can see what's already tracked before opening an issue.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; docs-only change.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; root docs only, no published-package changes.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->