### PR TITLE
Fix doc drift, add flightplan /browser entry, and gate mcp pin

### DIFF
--- a/.changeset/flightplan-browser-entry.md
+++ b/.changeset/flightplan-browser-entry.md
@@ -1,0 +1,7 @@
+---
+'@squawk/flightplan': minor
+---
+
+### Added
+
+- `/browser` exports subpath aliasing the main entry, so SPAs and edge runtimes have an explicit, `publint`-verified browser surface that mirrors the other query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Check README data dates
         run: node scripts/check-readme-dates.js
+
+      - name: Check MCP pinned-version snippet
+        run: node scripts/check-mcp-pin.js

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,15 +24,15 @@ Big-picture orientation: the principles, conventions, and processes that shape t
 
 ## Vision
 
-A monorepo of focused, well-documented Node.js / TypeScript libraries covering common aviation data problems - airspace geometry, weather parsing, flight planning, and more - plus the apps that compose them. Libraries publish to npm under `@squawk/*`; apps are private.
+A monorepo of focused, well-documented TypeScript libraries covering common aviation data problems - airspace geometry, weather parsing, flight planning, and more - plus the apps that compose them. Libraries publish to npm under `@squawk/*`; apps are private.
 
-Five guiding principles shape every decision in this repo:
+Six guiding principles shape every decision in this repo:
 
-- **Focused scope per package.** Each library does one thing well. No library should have to know about another to function. Shared types are the only acceptable cross-dependency.
-- **Real-world data, not toy examples.** Libraries work against actual FAA datasets and live aviation weather feeds, not mocked or synthetic data.
-- **Designed for composition.** Libraries fit together naturally when building an application, but never require each other.
-- **Published quality from day one.** Every library ships with a README, TypeScript types, unit tests, and a changelog. No "I'll clean this up before publishing."
-- **Backend-first for libraries; data packages and most logic packages also ship browser entries.** Libraries target Node first and stay pure. Data packages expose a `/browser` async loader so SPAs and edge runtimes can consume them, and pure-logic query libraries (airports, airspace, airways, fixes, navaids, procedures) expose a `/browser` resolver entry that mirrors the main entry. Packages that include a Node-only surface ship a slim `/browser` entry that excludes it (`@squawk/icao-registry/browser` omits `parseFaaRegistryZip`). Server-only packages like `@squawk/mcp` and the build tools remain Node-only.
+- **Focused scope per package.** Each library does one thing well. Domain libraries (airports, navaids, weather, etc.) do not depend on each other; cross-dependencies are limited to the foundational tier (`@squawk/types`, `@squawk/units`, `@squawk/geo`).
+- **Real-world data.** Libraries work against actual FAA datasets and live aviation weather feeds, not mocked or synthetic data.
+- **Designed for composition.** Libraries fit together naturally when building an application. Domain libraries are independent of each other - the foundational tier is the only shared substrate.
+- **Published quality from day one.** Every library ships with a README, TypeScript types, unit tests, and a changelog.
+- **Runtime-pure libraries.** Libraries are written to run in any modern JS runtime. Node-only surface is isolated to opt-in entries; server-only packages (`@squawk/mcp`, build tools) are explicitly Node-only.
 - **Complete data models.** Models capture all reasonable, distinct fields for a concept, even fields not currently consumed. The libraries are published for others to build on; completeness and correctness of the data model is a primary goal.
 
 ---
@@ -75,7 +75,7 @@ This pattern only applies to query / lookup libraries. Utility libraries (`@squa
 
 ### Bundled snapshots loaded eagerly
 
-Each data package bundles a gzipped JSON snapshot containing the full typed records plus build metadata. Two entry points expose the same shape:
+Each data package bundles a gzipped snapshot (JSON or GeoJSON) containing the full typed records plus build metadata. Two entry points expose the same shape:
 
 - The default (Node) entry reads, decompresses, and parses synchronously at module load via `node:fs` + `node:zlib`, exposing a single eager constant (`usBundled<X>`).
 - The `/browser` entry exposes an async loader (`loadUsBundled<X>`) that uses `fetch` + `DecompressionStream('gzip')` so SPAs and edge runtimes consume the same shape without Node-only APIs.
@@ -90,7 +90,7 @@ Why: keeping `@squawk/types` focused on genuinely shared models avoids forcing a
 
 ### Browser entries on data and logic packages
 
-Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume the bundled snapshots. Pure-logic query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`) also expose a `/browser` subpath that aliases the main entry, since their resolver code has no Node-specific imports. The `/browser` import is the explicit, supported way for SPAs to consume these packages; the contract is enforced by `lint:pack` (publint) so a future Node-only import would have to split the surface explicitly rather than silently breaking browsers.
+Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume the bundled snapshots. Pure-logic query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`) also expose a `/browser` subpath that aliases the main entry, since their resolver code has no Node-specific imports. The `/browser` import is the explicit, supported way for SPAs to consume these packages; the contract is enforced by `lint:pack` (publint) so a future Node-only import would have to split the surface explicitly rather than silently breaking browsers.
 
 `@squawk/icao-registry` is a hybrid: the main entry exposes a runtime `parseFaaRegistryZip` parser that depends on Node's `Buffer` and the `adm-zip` package, so the `/browser` entry is a strict subset that re-exports only `createIcaoRegistry` and the shared types.
 
@@ -139,7 +139,7 @@ App-specific principles:
 
 ## Data pipelines
 
-The `*-data` packages each ship a gzipped JSON snapshot derived from FAA source data. Snapshots are produced by the private workspaces under [`tools/`](tools/) and orchestrated by [`scripts/build-data.js`](scripts/build-data.js) (`npm run build:data -- --help` for usage).
+The `*-data` packages each ship a gzipped snapshot (JSON or GeoJSON) derived from FAA source data. Snapshots are produced by the private workspaces under [`tools/`](tools/) and orchestrated by [`scripts/build-data.js`](scripts/build-data.js) (`npm run build:data -- --help` for usage).
 
 Sources:
 
@@ -157,16 +157,17 @@ The date embedded in each data package's README matches the cycle date inside th
 
 The gates that run in [.github/workflows/ci.yml](.github/workflows/ci.yml) on every PR:
 
-| Gate                     | Tool                                                                   | What it covers                                                     |
-| ------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Lint                     | typescript-eslint flat config + eslint-plugin-import + eslint-plugin-n | Per-package `tsc --noEmit && eslint src`                           |
-| Knip                     | knip                                                                   | Dead deps, unlisted deps, unresolved imports, orphaned files       |
-| Format                   | prettier                                                               | `prettier --check .`                                               |
-| Build                    | tsc (via Turborepo)                                                    | Every package compiles                                             |
-| Test + per-file coverage | vitest                                                                 | Per-file 80% lines / functions / branches / statements             |
-| Aggregate coverage       | [scripts/check-coverage.js](scripts/check-coverage.js)                 | Per-package and workspace-wide 90% lines / functions / branches    |
-| Pack shape               | publint + arethetypeswrong (`lint:pack`)                               | npm tarball / `exports` / types are valid                          |
-| README data dates        | [scripts/check-readme-dates.js](scripts/check-readme-dates.js)         | Each data package README's cycle date matches its bundled snapshot |
+| Gate                     | Tool                                                                   | What it covers                                                                            |
+| ------------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Lint                     | typescript-eslint flat config + eslint-plugin-import + eslint-plugin-n | Per-package `tsc --noEmit && eslint src`                                                  |
+| Knip                     | knip                                                                   | Dead deps, unlisted deps, unresolved imports, orphaned files                              |
+| Format                   | prettier                                                               | `prettier --check .`                                                                      |
+| Build                    | tsc (via Turborepo)                                                    | Every package compiles                                                                    |
+| Test + per-file coverage | vitest                                                                 | Per-file 80% lines / functions / branches / statements                                    |
+| Aggregate coverage       | [scripts/check-coverage.js](scripts/check-coverage.js)                 | Per-package and workspace-wide 90% lines / functions / branches                           |
+| Pack shape               | publint + arethetypeswrong (`lint:pack`)                               | npm tarball / `exports` / types are valid                                                 |
+| README data dates        | [scripts/check-readme-dates.js](scripts/check-readme-dates.js)         | Each data package README's cycle date matches its bundled snapshot                        |
+| MCP pinned version       | [scripts/check-mcp-pin.js](scripts/check-mcp-pin.js)                   | `packages/libs/mcp/README.md` pin matches the projected publish version (changeset-aware) |
 
 Two properties of the gate set:
 
@@ -209,7 +210,7 @@ Two reasons the publish flow uses `squawk-release-bot` instead of the default `G
 1. **Downstream workflow triggering.** PRs opened by the default `github-actions[bot]` don't retrigger workflows when merged - GitHub blocks that path to prevent recursion. PRs opened with a custom App's installation token do. The App's token is what allows the merged "Version Packages" PR to retrigger CI, which then retriggers Publish, which then runs `npm publish`.
 2. **Auditable scoped permissions.** App permissions (read/write on contents, pull-requests, etc.) are explicit in the App settings and easy to audit, vs. the broader umbrella permission of the default token.
 
-The App's credentials live in two repo secrets, `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`. The Publish workflow mints a short-lived installation token from them via [actions/create-github-app-token](https://github.com/actions/create-github-app-token).
+The App's credentials are split between a repo variable and a repo secret: `RELEASE_APP_CLIENT_ID` (variable, since the Client ID is the public half of the OAuth pair) and `RELEASE_APP_PRIVATE_KEY` (secret). The Publish workflow mints a short-lived installation token from them via [actions/create-github-app-token](https://github.com/actions/create-github-app-token).
 
 Even though the App opens the "Version Packages" PR, the commits inside that PR show `github-actions[bot]` as author. The changesets/action library hardcodes the commit author independent of the token used; this is cosmetic.
 
@@ -217,7 +218,7 @@ Even though the App opens the "Version Packages" PR, the commits inside that PR 
 
 ```
 [1] Dev opens a feature PR
-        |- Adds a .changeset/<random-name>.md describing the change
+        |- Adds a .changeset/<some-name>.md describing the change
         |- CI runs (lint, build, test, coverage, etc.)
         '- Reviewer merges to main
 
@@ -261,7 +262,7 @@ The full configuration is in [.changeset/config.json](.changeset/config.json). A
 
 ### CHANGELOG.md is generated
 
-`CHANGELOG.md` files are not edited manually - changesets/action owns them. Manual edits get overwritten on the next bot run.
+`CHANGELOG.md` files are not edited manually - changesets/action owns them.
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -93,7 +93,7 @@ See any existing lib's `src/index.ts` for the canonical shape.
 
 ## Data package pattern
 
-Each data package bundles a single gzipped JSON snapshot under `data/<name>.json.gz`. The JSON wire format is `{ meta: {...}, records: FullRecord[] }` - records are stored in their full typed shape, no compaction or expansion step. Two entry points expose the same `<Name>Dataset` shape:
+Each data package bundles a single gzipped snapshot under `data/<name>.{json,geojson}.gz`. The wire format depends on the dataset shape: record-array packages use `{ meta: {...}, records: FullRecord[] }`, while `@squawk/airspace-data` uses a GeoJSON `FeatureCollection` with a top-level `properties` object carrying the metadata. Either way, records are stored in their full typed shape (no compaction or expansion step), and two entry points expose the same `<Name>Dataset` shape:
 
 - **`src/node.ts`** (re-exported by `src/index.ts`): synchronous read at module load via `node:fs` + `node:zlib`, exposed as a single eager constant `usBundled<X>`. This is the default entry consumed by Node lib tests, mcp tool modules, and any Node consumer.
 - **`src/browser.ts`** (exposed via the `/browser` exports subpath): async function `loadUsBundled<X>(options?)` that uses `fetch` + `DecompressionStream('gzip')`. Returns the same `<Name>Dataset` shape. Handles servers that advertise `Content-Encoding: gzip` (fetch decodes automatically) as well as servers that serve `.gz` as opaque bytes.
@@ -106,7 +106,7 @@ Each data package's metadata includes at least `generatedAt` (ISO timestamp), `r
 
 ## Logic package browser entries
 
-Query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/icao-registry`) ship a `/browser` exports subpath alongside the default entry. For pure-logic packages with no Node-specific imports, the `/browser` subpath aliases the same compiled `dist/index.js`; the separate entry exists so browser support is an explicit, `publint`-verified part of the public API surface and a future Node-only import has to split the surface intentionally.
+Query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/icao-registry`) ship a `/browser` exports subpath alongside the default entry. For pure-logic packages with no Node-specific imports, the `/browser` subpath aliases the same compiled `dist/index.js`; the separate entry exists so browser support is an explicit, `publint`-verified part of the public API surface and a future Node-only import has to split the surface intentionally.
 
 Packages that mix pure-logic with a Node-only helper (e.g. `@squawk/icao-registry`'s `parseFaaRegistryZip`) instead expose a thin `src/browser.ts` re-exporting only the browser-safe symbols, with the `/browser` subpath pointing at its compiled output. The Node-only helper stays exported from the default entry.
 
@@ -232,7 +232,7 @@ Examples: `@squawk/weather` (`types/metar.ts`, `types/taf.ts`, etc.), `@squawk/n
 4. Data packages depend on `@squawk/types` only.
 5. Query libraries that pair with a data package list that data package as a `devDependency` for testing.
 6. Query libraries and their companion data packages never depend on each other at runtime.
-7. Library packages may depend on other library packages when there is a clear logical dependency (e.g. `@squawk/airports` depending on `@squawk/flight-math` for wind component calculations). Avoid circular or gratuitous cross-dependencies.
+7. Domain libraries do not depend on each other at runtime. Cross-dependencies are limited to the foundational tier (`@squawk/types`, `@squawk/units`, `@squawk/geo`); see the [Architectural principles](ARCHITECTURE.md#architectural-principles) section of `ARCHITECTURE.md`. If a logical dependency between two domain libraries appears necessary, raise it in review rather than introducing it directly - the foundational-tier rule is the principle, and any exception needs to be deliberate.
 8. Once a type has 2+ consumers across the library / data / build-script boundary, consider promoting it to `@squawk/types`. The 2+ threshold is a suggestion, not a hard requirement - context matters. Reasons to leave a 2-consumer type in its owning package: the type is still in flux and likely to churn, the second consumer is incidental (a build script or one-off tool rather than another domain library), or the second consumer already lives close enough that direct dependency is cleaner than a `@squawk/types` round-trip. Conversely, promote earlier than 2 consumers if the type is foundational and a third consumer is clearly imminent. Domain-specific types that are produced and consumed by a single package belong in that package (e.g. weather types in `@squawk/weather`, NOTAM types in `@squawk/notams`). This keeps `@squawk/types` focused on genuinely shared domain models and avoids unnecessary coupling when domain-specific types change.
 
 ---

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The repo splits into three top-level directories:
 | [`@squawk/procedure-data`](packages/libs/procedure-data)         | Pre-processed FAA CIFP procedure snapshot for use with `@squawk/procedures`        |
 | [`@squawk/flightplan`](packages/libs/flightplan)                 | Flight plan route string parsing and resolution using composed resolvers           |
 | [`@squawk/weather`](packages/libs/weather)                       | Parse raw aviation weather strings (METAR, SPECI, TAF, SIGMET, AIRMET, PIREP)      |
-| [`@squawk/notams`](packages/libs/notams)                         | Parse raw ICAO-format NOTAM strings into structured objects                        |
+| [`@squawk/notams`](packages/libs/notams)                         | Parse raw ICAO-format and FAA domestic NOTAM strings into structured objects       |
 | [`@squawk/mcp`](packages/libs/mcp)                               | Model Context Protocol server exposing the squawk libraries as tools for LLMs      |
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@changesets/cli": "^2.31.0",
+        "@changesets/get-release-plan": "^4.0.0",
         "@eslint/js": "^9.39.4",
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs": "typedoc",
     "build:data": "node scripts/build-data.js",
     "check-coverage": "node scripts/check-coverage.js",
+    "check-mcp-pin": "node scripts/check-mcp-pin.js",
     "clean": "node scripts/clean.js",
     "publish": "changeset publish",
     "version-packages": "changeset version && npm install --package-lock-only",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@changesets/cli": "^2.31.0",
+    "@changesets/get-release-plan": "^4.0.0",
     "@eslint/js": "^9.39.4",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.5",

--- a/packages/libs/flightplan/README.md
+++ b/packages/libs/flightplan/README.md
@@ -50,6 +50,42 @@ const resolver = createFlightplanResolver({ airports: myAirportResolver });
 const route = resolver.parse('KJFK DCT KLAX');
 ```
 
+## Browser / SPA usage
+
+The resolver factory has no Node-specific imports and ships an explicit `/browser` subpath for SPAs and edge runtimes. Pair it with the `/browser` entries of the resolvers you want to compose:
+
+```typescript
+import { loadUsBundledAirports } from '@squawk/airport-data/browser';
+import { loadUsBundledNavaids } from '@squawk/navaid-data/browser';
+import { loadUsBundledFixes } from '@squawk/fix-data/browser';
+import { loadUsBundledAirways } from '@squawk/airway-data/browser';
+import { loadUsBundledProcedures } from '@squawk/procedure-data/browser';
+import { createAirportResolver } from '@squawk/airports/browser';
+import { createNavaidResolver } from '@squawk/navaids/browser';
+import { createFixResolver } from '@squawk/fixes/browser';
+import { createAirwayResolver } from '@squawk/airways/browser';
+import { createProcedureResolver } from '@squawk/procedures/browser';
+import { createFlightplanResolver } from '@squawk/flightplan/browser';
+
+const [airports, navaids, fixes, airways, procedures] = await Promise.all([
+  loadUsBundledAirports(),
+  loadUsBundledNavaids(),
+  loadUsBundledFixes(),
+  loadUsBundledAirways(),
+  loadUsBundledProcedures(),
+]);
+
+const resolver = createFlightplanResolver({
+  airports: createAirportResolver({ data: airports.records }),
+  navaids: createNavaidResolver({ data: navaids.records }),
+  fixes: createFixResolver({ data: fixes.records }),
+  airways: createAirwayResolver({ data: airways.records }),
+  procedures: createProcedureResolver({ data: procedures.records }),
+});
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath exists so browser support is an explicit, `publint`-verified part of the public API surface.
+
 ## API
 
 ### `createFlightplanResolver(options)`

--- a/packages/libs/flightplan/package.json
+++ b/packages/libs/flightplan/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/libs/icao-registry/README.md
+++ b/packages/libs/icao-registry/README.md
@@ -66,4 +66,11 @@ const registry = createIcaoRegistry({ data: dataset.records });
 
 Browser consumers that need fresh FAA data should fetch and parse the ZIP server-side (where `parseFaaRegistryZip` is available) and feed the resulting records into the browser via their own API.
 
+## API
+
+- `createIcaoRegistry({ data })` - builds a registry from an array of `AircraftRegistration` records.
+- `registry.lookup(icaoHex)` - resolves a 24-bit ICAO hex address to a record, or `undefined`.
+- `registry.recordCount` - total number of records in the loaded dataset.
+- `parseFaaRegistryZip(buffer)` - parses a downloaded FAA `ReleasableAircraft.zip` into the `AircraftRegistration[]` shape that `createIcaoRegistry` expects. Node-only; not exported from the `/browser` entry.
+
 > Under active development. See the [docs](https://neilcochran.github.io/squawk/modules/_squawk_icao-registry.html) for current API status.

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.8.8"]
+      "args": ["-y", "@squawk/mcp@0.8.11"]
     }
   }
 }

--- a/packages/libs/notams/README.md
+++ b/packages/libs/notams/README.md
@@ -2,11 +2,12 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](../../../LICENSE.md) [![npm](https://img.shields.io/npm/v/@squawk/notams)](https://www.npmjs.com/package/@squawk/notams) ![TypeScript](https://img.shields.io/badge/TypeScript-blue?logo=typescript&logoColor=white)
 
-Pure parsing library for ICAO-format NOTAM (Notice to Air Missions) strings.
-Parses raw NOTAMs into fully typed, structured objects. Contains no network
-calls or data fetching - consumers provide raw NOTAM strings however they
-obtain them (FAA NOTAM API, ICAO API, local feed, file dump) and the package
-returns structured results.
+Pure parsing library for NOTAM (Notice to Air Missions) strings. Supports
+both ICAO-format and FAA domestic (legacy) format NOTAMs. Parses raw NOTAMs
+into fully typed, structured objects. Contains no network calls or data
+fetching - consumers provide raw NOTAM strings however they obtain them (FAA
+NOTAM API, ICAO API, local feed, file dump) and the package returns
+structured results.
 
 Part of the [@squawk](https://www.npmjs.com/org/squawk) aviation library suite. See all packages on npm.
 
@@ -58,6 +59,13 @@ Parses the Q-line qualifier and items A through G:
 
 Accepts both multi-line and single-line NOTAM input. Gracefully handles
 NOTAMs without a Q-line when items A through E are present.
+
+### `parseFaaNotam(raw)`
+
+Parses a raw FAA domestic (legacy) NOTAM string into a structured `FaaNotam`
+object. FAA domestic NOTAMs use a keyword-prefixed body format (RWY, TWY,
+OBST, AD, etc.) rather than the ICAO Q-line + items A through G structure.
+The recognized keywords are enumerated by the `FaaNotamKeyword` type.
 
 ## Types
 

--- a/packages/libs/types/README.md
+++ b/packages/libs/types/README.md
@@ -2,7 +2,7 @@
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](../../../LICENSE.md) [![npm](https://img.shields.io/npm/v/@squawk/types)](https://www.npmjs.com/package/@squawk/types) ![TypeScript](https://img.shields.io/badge/TypeScript-blue?logo=typescript&logoColor=white)
 
-Shared TypeScript type definitions used across multiple `@squawk` packages. Contains types for core domain models that cross the logic/data/build-script boundary: aircraft, position, airports, navaids, fixes, airways, procedures, airspace, and flight-math results.
+Shared TypeScript type definitions used across multiple `@squawk` packages. Contains types for core domain models that cross the logic/data/build-script boundary: aircraft, position, airports, navaids, fixes, airways, procedures, airspace, and aircraft registration.
 
 Domain-specific types that are produced and consumed by a single package live in that package instead:
 

--- a/scripts/check-mcp-pin.js
+++ b/scripts/check-mcp-pin.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * CI check: verifies that the pinned-version snippet in
+ * `packages/libs/mcp/README.md` (under "Picking an install version")
+ * matches the version of `@squawk/mcp` that will publish from the
+ * current state of the repo. Uses changesets' release planner to
+ * project the version forward through any pending `.changeset/*.md`
+ * entries (including transitive bumps applied by
+ * `updateInternalDependencies` when an mcp dependency bumps).
+ *
+ * Works correctly across all three lifecycle states: feature PRs with
+ * pending changesets that bump mcp directly or transitively, the
+ * Version Packages PR (no pending changesets, package.json already
+ * reflects the bump), and main post-publish. Exits 0 on match, 1 on
+ * drift.
+ *
+ * Usage: node scripts/check-mcp-pin.js
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import getReleasePlan from '@changesets/get-release-plan';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const mcpPackagePath = resolve(root, 'packages/libs/mcp/package.json');
+const mcpReadmePath = resolve(root, 'packages/libs/mcp/README.md');
+
+const PICKING_HEADING = '### Picking an install version';
+const NEXT_HEADING_PATTERN = /\n###\s/;
+const PINNED_VERSION_PATTERN = /@squawk\/mcp@(\d+\.\d+\.\d+)/;
+
+const readme = readFileSync(mcpReadmePath, 'utf-8');
+const sectionStart = readme.indexOf(PICKING_HEADING);
+if (sectionStart === -1) {
+  console.error(
+    `check-mcp-pin: could not find "${PICKING_HEADING}" section in packages/libs/mcp/README.md.`,
+  );
+  process.exit(1);
+}
+const sectionTail = readme.slice(sectionStart + PICKING_HEADING.length);
+const nextHeadingMatch = sectionTail.match(NEXT_HEADING_PATTERN);
+const section = nextHeadingMatch ? sectionTail.slice(0, nextHeadingMatch.index) : sectionTail;
+const pinMatch = section.match(PINNED_VERSION_PATTERN);
+if (!pinMatch) {
+  console.error(
+    `check-mcp-pin: could not find a pinned \`@squawk/mcp@<version>\` snippet under "${PICKING_HEADING}".`,
+  );
+  process.exit(1);
+}
+const pinnedVersion = pinMatch[1];
+
+const mcpPkg = JSON.parse(readFileSync(mcpPackagePath, 'utf-8'));
+const currentVersion = mcpPkg.version;
+
+const releasePlan = await getReleasePlan(root);
+const mcpRelease = releasePlan.releases.find((r) => r.name === '@squawk/mcp');
+const projectedVersion = mcpRelease ? mcpRelease.newVersion : currentVersion;
+const bumpType = mcpRelease ? mcpRelease.type : null;
+
+if (pinnedVersion === projectedVersion) {
+  const source = bumpType == null ? 'current' : 'projected';
+  console.log(
+    `check-mcp-pin: OK. README pins @squawk/mcp@${pinnedVersion}, matching ${source} version.`,
+  );
+  process.exit(0);
+}
+
+const reason =
+  bumpType == null
+    ? `current @squawk/mcp version is ${currentVersion}`
+    : `pending changesets project @squawk/mcp will bump from ${currentVersion} to ${projectedVersion} (${bumpType})`;
+console.error(
+  `check-mcp-pin: README pins @squawk/mcp@${pinnedVersion} but ${reason}.\n` +
+    `Update the snippet under "${PICKING_HEADING}" in packages/libs/mcp/README.md to @squawk/mcp@${projectedVersion}.`,
+);
+process.exit(1);

--- a/tools/build-airport-data/README.md
+++ b/tools/build-airport-data/README.md
@@ -30,8 +30,7 @@ The default output path is `packages/libs/airport-data/data/airports.json.gz`.
    `FRQ.csv`
 3. Joins runways and runway ends by site number, frequencies by facility ID
 4. Filters to open facilities only (closed facilities are excluded)
-5. Compacts records into short-key JSON format for size reduction
-6. Gzip compresses and writes the output (~1.8 MB)
+5. Serializes records as JSON, gzip compresses, and writes the output (~1.8 MB)
 
 ## Input files
 

--- a/tools/build-fix-data/README.md
+++ b/tools/build-fix-data/README.md
@@ -16,7 +16,7 @@ with FIX_BASE.csv, FIX_CHRT.csv, and FIX_NAV.csv.
 4. Builds typed Fix objects from CSV fields
 5. Enriches fixes with chart type associations from FIX_CHRT.csv
 6. Enriches fixes with navaid associations from FIX_NAV.csv
-7. Compacts records into short-key JSON and gzip compresses
+7. Serializes records as JSON, gzip compresses, and writes the output
 
 ## Output
 

--- a/tools/build-icao-registry-data/README.md
+++ b/tools/build-icao-registry-data/README.md
@@ -28,8 +28,7 @@ The default output path is `packages/libs/icao-registry-data/data/icao-registry.
 2. Delegates parsing to `parseFaaRegistryZip()` from `@squawk/icao-registry`,
    which extracts `MASTER.txt` and `ACFTREF.txt`, parses both CSVs, and joins
    them by manufacturer/model code
-3. Compacts records into short-key JSON format for size reduction
-4. Gzip compresses and writes the output
+3. Serializes records as JSON, gzip compresses, and writes the output
 
 ## Dependencies
 

--- a/tools/build-navaid-data/README.md
+++ b/tools/build-navaid-data/README.md
@@ -14,7 +14,7 @@ with NAV_BASE.csv.
 2. Parses NAV_BASE.csv into navaid records
 3. Filters out shutdown navaids
 4. Builds typed Navaid objects from CSV fields
-5. Compacts records into short-key JSON and gzip compresses
+5. Serializes records as JSON, gzip compresses, and writes the output
 
 ## Output
 

--- a/tools/build-procedure-data/README.md
+++ b/tools/build-procedure-data/README.md
@@ -42,10 +42,9 @@ The build does two passes over the file:
 
 ## Output
 
-Writes a gzipped compact-key JSON file containing every decoded procedure to
-`packages/libs/procedure-data/data/procedures.json.gz`. The output is consumed by
-`@squawk/procedure-data`, which eagerly expands the records into the public
-`Procedure` interface at import time.
+Writes a gzipped JSON file containing every decoded procedure to
+`packages/libs/procedure-data/data/procedures.json.gz`. The output is consumed
+by `@squawk/procedure-data`.
 
 ## Notes on ODPs
 


### PR DESCRIPTION
## Summary

- Reconcile audit-surfaced doc drifts: stale "compacts records into short-key JSON" claims in five build-tool READMEs, CONVENTIONS dep rule 7 vs the ARCHITECTURE foundational-tier principle, scope-narrow `@squawk/notams` description (plus a missing `parseFaaNotam` API section), inaccurate `flight-math results` entry in `@squawk/types` README, and undocumented `IcaoRegistry.recordCount`.
- Promote `@squawk/flightplan` to the `/browser` convention used by every other query library: new exports subpath aliasing the main entry, Browser / SPA usage README section, ARCHITECTURE/CONVENTIONS list updates, minor-bump changeset. Pre-bumped the mcp pinned-version snippet to `0.8.11` to match the cascading patch bump.
- Add `scripts/check-mcp-pin.js` as a CI gate that uses `@changesets/get-release-plan` to fail when the mcp README pin drifts from the projected publish version. Wired into `ci.yml` and the Quality gates table.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use \`Closes #N\` to auto-close the issue on merge, or \`Refs #N\` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; this PR is documentation corrections, a new `/browser` exports alias on `@squawk/flightplan`, and a CI gate script (`scripts/check-mcp-pin.js`) that has been manually verified in both green and red paths.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `@squawk/flightplan: minor` - new `/browser` exports subpath aliasing the main entry.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->