### PR TITLE
Add type guards for user-facing string-literal unions in @squawk/types

### DIFF
--- a/.changeset/types-string-literal-guards.md
+++ b/.changeset/types-string-literal-guards.md
@@ -1,0 +1,7 @@
+---
+'@squawk/types': minor
+---
+
+### Added
+
+- `is<Name>` type guards and `<NAME>S` const arrays for the user-facing string-literal union types: `AirspaceType`, `ArtccStratum`, `FacilityType`, `AirwayType`, `NavaidType`, `FixUseCode`. Each guard narrows an external string into the union, and each const array is the single source of truth for value-side iteration. Useful when consuming URL params, config files, or MCP tool inputs that need validation before being used as a typed filter; centralizing the membership list here means each consumer no longer hand-rolls its own predicate that silently drifts when a new union member is added. The arrays are branded with `as const satisfies readonly <Type>[]` so dropping a member or adding one to the type without updating the array fails the build.

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.8.11"]
+      "args": ["-y", "@squawk/mcp@0.8.12"]
     }
   }
 }

--- a/packages/libs/types/README.md
+++ b/packages/libs/types/README.md
@@ -26,3 +26,47 @@ import type { Aircraft, Position, Airport, Navaid, Fix } from '@squawk/types';
 ```
 
 All types are re-exported from the package root. See the [documentation](https://neilcochran.github.io/squawk/modules/_squawk_types.html) for the full reference.
+
+## Exported types by domain
+
+| Domain                | Types                                                                                                                                                                                                                                                                                                                 |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Aircraft (ADS-B)      | `Aircraft`, `AircraftCategory`                                                                                                                                                                                                                                                                                        |
+| Position              | `Position`, `Coordinates`                                                                                                                                                                                                                                                                                             |
+| Airport               | `Airport`, `Runway`, `RunwayEnd`, `IlsSystem`, `AirportFrequency`, `FacilityType`, `OwnershipType`, `FacilityUseType`, `FacilityStatus`, `SurfaceCondition`, `SurfaceTreatment`, `RunwayLighting`, `RunwayMarkingType`, `RunwayMarkingCondition`, `VgsiType`, `IlsCategory`, `IlsSystemType`                          |
+| Navaid                | `Navaid`, `NavaidType`, `NavaidStatus`                                                                                                                                                                                                                                                                                |
+| Fix                   | `Fix`, `FixUseCode`, `FixCompulsory`, `FixNavaidAssociation`                                                                                                                                                                                                                                                          |
+| Airway                | `Airway`, `AirwayWaypoint`, `AirwayType`, `AirwayRegion`, `AirwayWaypointType`                                                                                                                                                                                                                                        |
+| Airspace              | `AirspaceFeature`, `AirspaceType`, `ArtccStratum`, `AltitudeBound`, `AltitudeReference`                                                                                                                                                                                                                               |
+| Procedure             | `Procedure`, `ProcedureType`, `ApproachType`, `ProcedureLeg`, `ProcedureLegPathTerminator`, `ProcedureLegFixCategory`, `ProcedureTransition`, `ProcedureCommonRoute`, `MissedApproachSequence`, `AltitudeConstraint`, `AltitudeConstraintDescriptor`, `SpeedConstraint`, `SpeedConstraintDescriptor`, `TurnDirection` |
+| Aircraft registration | `AircraftRegistration`, `AircraftType`, `EngineType`                                                                                                                                                                                                                                                                  |
+
+The package also re-exports source-code lookup maps (`FACILITY_TYPE_MAP`, `NAVAID_TYPE_MAP`, `AWY_TYPE_MAP`, `ATS_TYPE_MAP`, `AIRWAY_REGION_MAP`, `FIX_USE_CODE_MAP`, `FIX_COMPULSORY_MAP`, `NAVAID_STATUS_MAP`, `ILS_CATEGORY_MAP`, `ILS_SYSTEM_TYPE_MAP`) used by the FAA NASR build pipelines to translate raw source-data values to the typed unions above. See the [TypeDoc reference](https://neilcochran.github.io/squawk/modules/_squawk_types.html) for full per-type signatures and field-level documentation.
+
+## Type guards
+
+For the user-facing string-literal union types - the ones that flow in from URL params, config files, or MCP tool inputs - the package ships an `is<Name>` predicate paired with a `<NAME>S` const array as the single source of truth. Use the predicate to narrow an external string into the union without hand-rolling the membership list per consumer; use the const array as the value-side iteration target (e.g. building a lookup table keyed by the union):
+
+```ts
+import {
+  AIRSPACE_TYPES,
+  ARTCC_STRATA,
+  FACILITY_TYPES,
+  AIRWAY_TYPES,
+  NAVAID_TYPES,
+  FIX_USE_CODES,
+  isAirspaceType,
+  isArtccStratum,
+  isFacilityType,
+  isAirwayType,
+  isNavaidType,
+  isFixUseCode,
+} from '@squawk/types';
+
+const raw = new URLSearchParams(window.location.search).get('type') ?? '';
+if (isAirspaceType(raw)) {
+  // raw is now narrowed to AirspaceType
+}
+```
+
+The arrays are branded with `as const satisfies readonly <Type>[]`, so adding a new union member without updating the array fails the build.

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -29,6 +29,8 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit && eslint src",
     "lint:pack": "publint && attw --pack . --profile esm-only"
   },

--- a/packages/libs/types/src/aircraft.spec.ts
+++ b/packages/libs/types/src/aircraft.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { AircraftCategory } from './aircraft.js';
+
+describe('AircraftCategory', () => {
+  it('maps every documented ICAO/FAA code to a label', () => {
+    const expected: Record<string, string> = {
+      A0: 'unknown',
+      A1: 'light',
+      A2: 'small',
+      A3: 'large',
+      A4: 'highVortexLarge',
+      A5: 'heavy',
+      A6: 'highPerformance',
+      A7: 'rotorcraft',
+      B1: 'glider',
+      B2: 'lighterThanAir',
+      B3: 'parachutist',
+      B4: 'ultralight',
+      B6: 'uav',
+      B7: 'spaceVehicle',
+      C1: 'surfaceEmergencyVehicle',
+      C2: 'surfaceServiceVehicle',
+      C3: 'pointObstacle',
+      C4: 'clusterObstacle',
+      C5: 'lineObstacle',
+    };
+    expect({ ...AircraftCategory }).toEqual(expected);
+  });
+});

--- a/packages/libs/types/src/airport.spec.ts
+++ b/packages/libs/types/src/airport.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { FACILITY_TYPES, isFacilityType } from './airport.js';
+
+describe('FACILITY_TYPES / isFacilityType', () => {
+  it('isFacilityType accepts every member of FACILITY_TYPES', () => {
+    for (const member of FACILITY_TYPES) {
+      expect(isFacilityType(member)).toBe(true);
+    }
+  });
+
+  it('isFacilityType rejects strings outside the union', () => {
+    const nonMembers = ['', 'airport', 'AIRPORT ', 'TOWER', 'SEAPLANE', 'A', 'unknown'];
+    for (const value of nonMembers) {
+      expect(isFacilityType(value)).toBe(false);
+    }
+  });
+
+  it('FACILITY_TYPES contains no duplicates', () => {
+    expect(new Set(FACILITY_TYPES).size).toBe(FACILITY_TYPES.length);
+  });
+});

--- a/packages/libs/types/src/airport.ts
+++ b/packages/libs/types/src/airport.ts
@@ -10,6 +10,39 @@ export type FacilityType =
   | 'BALLOONPORT';
 
 /**
+ * The full set of {@link FacilityType} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration (e.g. building a
+ * lookup table keyed by facility type) or with {@link isFacilityType} to
+ * narrow an external string into the union. The `as const satisfies` brand
+ * keeps this array in sync with the type at compile time.
+ */
+export const FACILITY_TYPES = [
+  'AIRPORT',
+  'HELIPORT',
+  'SEAPLANE_BASE',
+  'GLIDERPORT',
+  'ULTRALIGHT',
+  'BALLOONPORT',
+] as const satisfies readonly FacilityType[];
+
+const FACILITY_TYPE_SET: ReadonlySet<string> = new Set(FACILITY_TYPES);
+
+/**
+ * Type guard that narrows a string to {@link FacilityType} when it matches a
+ * member of {@link FACILITY_TYPES}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as a facility type.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `FacilityType`.
+ */
+export function isFacilityType(value: string): value is FacilityType {
+  return FACILITY_TYPE_SET.has(value);
+}
+
+/**
  * Maps FAA SITE_TYPE_CODE values to FacilityType.
  */
 export const FACILITY_TYPE_MAP: Record<string, FacilityType> = {

--- a/packages/libs/types/src/airspace.spec.ts
+++ b/packages/libs/types/src/airspace.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { AIRSPACE_TYPES, ARTCC_STRATA, isAirspaceType, isArtccStratum } from './airspace.js';
+
+describe('AIRSPACE_TYPES / isAirspaceType', () => {
+  it('isAirspaceType accepts every member of AIRSPACE_TYPES', () => {
+    for (const member of AIRSPACE_TYPES) {
+      expect(isAirspaceType(member)).toBe(true);
+    }
+  });
+
+  it('isAirspaceType rejects strings outside the union', () => {
+    const nonMembers = [
+      '',
+      'class_b',
+      'CLASS_A',
+      'CLASS_E1',
+      'CLASS_E8',
+      'TFR',
+      'CLASS_B ',
+      'unknown',
+    ];
+    for (const value of nonMembers) {
+      expect(isAirspaceType(value)).toBe(false);
+    }
+  });
+
+  it('AIRSPACE_TYPES contains no duplicates', () => {
+    expect(new Set(AIRSPACE_TYPES).size).toBe(AIRSPACE_TYPES.length);
+  });
+});
+
+describe('ARTCC_STRATA / isArtccStratum', () => {
+  it('isArtccStratum accepts every member of ARTCC_STRATA', () => {
+    for (const member of ARTCC_STRATA) {
+      expect(isArtccStratum(member)).toBe(true);
+    }
+  });
+
+  it('isArtccStratum rejects strings outside the union', () => {
+    const nonMembers = ['', 'low', 'HIGH ', 'CTA-FIR', 'OCEANIC', 'UTA/CTA'];
+    for (const value of nonMembers) {
+      expect(isArtccStratum(value)).toBe(false);
+    }
+  });
+
+  it('ARTCC_STRATA contains no duplicates', () => {
+    expect(new Set(ARTCC_STRATA).size).toBe(ARTCC_STRATA.length);
+  });
+});

--- a/packages/libs/types/src/airspace.ts
+++ b/packages/libs/types/src/airspace.ts
@@ -61,6 +61,50 @@ export type AirspaceType =
   | 'ARTCC';
 
 /**
+ * The full set of {@link AirspaceType} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration (e.g. building a
+ * lookup table keyed by airspace type) or with {@link isAirspaceType} to
+ * narrow an external string into the union. The `as const satisfies` brand
+ * keeps this array in sync with the type at compile time - adding a new
+ * union member without updating the array fails the build.
+ */
+export const AIRSPACE_TYPES = [
+  'CLASS_B',
+  'CLASS_C',
+  'CLASS_D',
+  'CLASS_E2',
+  'CLASS_E3',
+  'CLASS_E4',
+  'CLASS_E5',
+  'CLASS_E6',
+  'CLASS_E7',
+  'MOA',
+  'RESTRICTED',
+  'PROHIBITED',
+  'WARNING',
+  'ALERT',
+  'NSA',
+  'ARTCC',
+] as const satisfies readonly AirspaceType[];
+
+const AIRSPACE_TYPE_SET: ReadonlySet<string> = new Set(AIRSPACE_TYPES);
+
+/**
+ * Type guard that narrows a string to {@link AirspaceType} when it matches a
+ * member of {@link AIRSPACE_TYPES}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as an airspace type.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `AirspaceType`.
+ */
+export function isAirspaceType(value: string): value is AirspaceType {
+  return AIRSPACE_TYPE_SET.has(value);
+}
+
+/**
  * The boundary stratum of an ARTCC feature, derived from NASR ARB_SEG
  * `ALTITUDE` and `TYPE` columns.
  *
@@ -79,6 +123,41 @@ export type AirspaceType =
  * Set to `null` for non-ARTCC features.
  */
 export type ArtccStratum = 'LOW' | 'HIGH' | 'UTA' | 'CTA' | 'FIR' | 'CTA/FIR';
+
+/**
+ * The full set of {@link ArtccStratum} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration over ARTCC
+ * stratum kinds (e.g. building a lookup table keyed by stratum) or with
+ * {@link isArtccStratum} to narrow an external string into the union. The
+ * `as const satisfies` brand keeps this array in sync with the type at
+ * compile time.
+ */
+export const ARTCC_STRATA = [
+  'LOW',
+  'HIGH',
+  'UTA',
+  'CTA',
+  'FIR',
+  'CTA/FIR',
+] as const satisfies readonly ArtccStratum[];
+
+const ARTCC_STRATUM_SET: ReadonlySet<string> = new Set(ARTCC_STRATA);
+
+/**
+ * Type guard that narrows a string to {@link ArtccStratum} when it matches a
+ * member of {@link ARTCC_STRATA}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as an ARTCC stratum
+ * filter.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `ArtccStratum`.
+ */
+export function isArtccStratum(value: string): value is ArtccStratum {
+  return ARTCC_STRATUM_SET.has(value);
+}
 
 /**
  * A single airspace designation feature derived from FAA NASR data.

--- a/packages/libs/types/src/airway.spec.ts
+++ b/packages/libs/types/src/airway.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { AIRWAY_TYPES, isAirwayType } from './airway.js';
+
+describe('AIRWAY_TYPES / isAirwayType', () => {
+  it('isAirwayType accepts every member of AIRWAY_TYPES', () => {
+    for (const member of AIRWAY_TYPES) {
+      expect(isAirwayType(member)).toBe(true);
+    }
+  });
+
+  it('isAirwayType rejects strings outside the union', () => {
+    const nonMembers = ['', 'victor', 'V', 'J', 'Q', 'JET ', 'PUERTORICO', 'OCEANIC', 'unknown'];
+    for (const value of nonMembers) {
+      expect(isAirwayType(value)).toBe(false);
+    }
+  });
+
+  it('AIRWAY_TYPES contains no duplicates', () => {
+    expect(new Set(AIRWAY_TYPES).size).toBe(AIRWAY_TYPES.length);
+  });
+});

--- a/packages/libs/types/src/airway.ts
+++ b/packages/libs/types/src/airway.ts
@@ -29,6 +29,45 @@ export type AirwayType =
   | 'PUERTO_RICO';
 
 /**
+ * The full set of {@link AirwayType} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration (e.g. building a
+ * lookup table keyed by airway type) or with {@link isAirwayType} to narrow
+ * an external string into the union. The `as const satisfies` brand keeps
+ * this array in sync with the type at compile time.
+ */
+export const AIRWAY_TYPES = [
+  'VICTOR',
+  'JET',
+  'RNAV_Q',
+  'RNAV_T',
+  'GREEN',
+  'RED',
+  'AMBER',
+  'BLUE',
+  'ATLANTIC',
+  'BAHAMA',
+  'PACIFIC',
+  'PUERTO_RICO',
+] as const satisfies readonly AirwayType[];
+
+const AIRWAY_TYPE_SET: ReadonlySet<string> = new Set(AIRWAY_TYPES);
+
+/**
+ * Type guard that narrows a string to {@link AirwayType} when it matches a
+ * member of {@link AIRWAY_TYPES}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as an airway type.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `AirwayType`.
+ */
+export function isAirwayType(value: string): value is AirwayType {
+  return AIRWAY_TYPE_SET.has(value);
+}
+
+/**
  * Maps the first character of an AWY.txt airway designation to its AirwayType.
  */
 export const AWY_TYPE_MAP: Record<string, AirwayType> = {

--- a/packages/libs/types/src/fix.spec.ts
+++ b/packages/libs/types/src/fix.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { FIX_USE_CODES, isFixUseCode } from './fix.js';
+
+describe('FIX_USE_CODES / isFixUseCode', () => {
+  it('isFixUseCode accepts every member of FIX_USE_CODES', () => {
+    for (const member of FIX_USE_CODES) {
+      expect(isFixUseCode(member)).toBe(true);
+    }
+  });
+
+  it('isFixUseCode rejects strings outside the union', () => {
+    const nonMembers = ['', 'wp', 'WP ', 'XX', 'WAYPOINT', 'FIX', 'unknown'];
+    for (const value of nonMembers) {
+      expect(isFixUseCode(value)).toBe(false);
+    }
+  });
+
+  it('FIX_USE_CODES contains no duplicates', () => {
+    expect(new Set(FIX_USE_CODES).size).toBe(FIX_USE_CODES.length);
+  });
+});

--- a/packages/libs/types/src/fix.ts
+++ b/packages/libs/types/src/fix.ts
@@ -13,6 +13,41 @@
 export type FixUseCode = 'WP' | 'RP' | 'MW' | 'MR' | 'CN' | 'VFR' | 'NRS' | 'RADAR';
 
 /**
+ * The full set of {@link FixUseCode} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration (e.g. building a
+ * lookup table keyed by use code) or with {@link isFixUseCode} to narrow an
+ * external string into the union. The `as const satisfies` brand keeps this
+ * array in sync with the type at compile time.
+ */
+export const FIX_USE_CODES = [
+  'WP',
+  'RP',
+  'MW',
+  'MR',
+  'CN',
+  'VFR',
+  'NRS',
+  'RADAR',
+] as const satisfies readonly FixUseCode[];
+
+const FIX_USE_CODE_SET: ReadonlySet<string> = new Set(FIX_USE_CODES);
+
+/**
+ * Type guard that narrows a string to {@link FixUseCode} when it matches a
+ * member of {@link FIX_USE_CODES}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as a fix use code.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `FixUseCode`.
+ */
+export function isFixUseCode(value: string): value is FixUseCode {
+  return FIX_USE_CODE_SET.has(value);
+}
+
+/**
  * Maps FAA FIX_USE_CODE values from NASR data to FixUseCode.
  * FAA values may have trailing whitespace so trimmed values are mapped here.
  */

--- a/packages/libs/types/src/navaid.spec.ts
+++ b/packages/libs/types/src/navaid.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNavaidType, NAVAID_TYPES } from './navaid.js';
+
+describe('NAVAID_TYPES / isNavaidType', () => {
+  it('isNavaidType accepts every member of NAVAID_TYPES', () => {
+    for (const member of NAVAID_TYPES) {
+      expect(isNavaidType(member)).toBe(true);
+    }
+  });
+
+  it('isNavaidType rejects strings outside the union', () => {
+    const nonMembers = [
+      '',
+      'vor',
+      'VOR ',
+      'VOR-DME',
+      'GPS',
+      'WAAS',
+      'FAN MARKER',
+      'MARINE NDB',
+      'unknown',
+    ];
+    for (const value of nonMembers) {
+      expect(isNavaidType(value)).toBe(false);
+    }
+  });
+
+  it('NAVAID_TYPES contains no duplicates', () => {
+    expect(new Set(NAVAID_TYPES).size).toBe(NAVAID_TYPES.length);
+  });
+});

--- a/packages/libs/types/src/navaid.ts
+++ b/packages/libs/types/src/navaid.ts
@@ -14,6 +14,43 @@ export type NavaidType =
   | 'VOT';
 
 /**
+ * The full set of {@link NavaidType} values, in declaration order.
+ *
+ * Use as the single source of truth for value-side iteration (e.g. building a
+ * lookup table keyed by navaid type) or with {@link isNavaidType} to narrow
+ * an external string into the union. The `as const satisfies` brand keeps
+ * this array in sync with the type at compile time.
+ */
+export const NAVAID_TYPES = [
+  'VOR',
+  'VORTAC',
+  'VOR/DME',
+  'TACAN',
+  'DME',
+  'NDB',
+  'NDB/DME',
+  'FAN_MARKER',
+  'MARINE_NDB',
+  'VOT',
+] as const satisfies readonly NavaidType[];
+
+const NAVAID_TYPE_SET: ReadonlySet<string> = new Set(NAVAID_TYPES);
+
+/**
+ * Type guard that narrows a string to {@link NavaidType} when it matches a
+ * member of {@link NAVAID_TYPES}.
+ *
+ * Useful when consuming external strings (URL params, config files, MCP tool
+ * inputs) that should be validated before being used as a navaid type.
+ *
+ * @param value - The string to test.
+ * @returns `true` if `value` is a valid `NavaidType`.
+ */
+export function isNavaidType(value: string): value is NavaidType {
+  return NAVAID_TYPE_SET.has(value);
+}
+
+/**
  * Maps FAA NAV_TYPE values from NASR data to NavaidType.
  */
 export const NAVAID_TYPE_MAP: Record<string, NavaidType> = {

--- a/packages/libs/types/vitest.config.ts
+++ b/packages/libs/types/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+import { sharedVitestConfig } from '../../../vitest.shared.js';
+
+export default mergeConfig(
+  sharedVitestConfig,
+  defineProject({
+    test: {
+      name: '@squawk/types',
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- Add `is<Name>` type guards and `<NAME>S` const arrays for the user-facing string-literal unions in `@squawk/types`: `AirspaceType`, `ArtccStratum`, `FacilityType`, `AirwayType`, `NavaidType`, `FixUseCode`. Each guard narrows an external string into the union; each const array is the single source of truth for value-side iteration. Arrays are branded with `as const satisfies readonly <Type>[]` so adding or removing a union member without updating the array fails the build.
- Centralizes the membership list so consumers (atlas URL parsing, MCP tool inputs, config-file readers) no longer hand-roll predicates that silently drift when a new member is added.
- Adds vitest infrastructure to `@squawk/types` for the first time: `vitest.config.ts`, `test` / `test:coverage` scripts, and per-domain spec files plus a smoke spec for the existing `AircraftCategory` const so the package joins the per-file 80% / aggregate 90% coverage gates at 100%.
- README gains an "Exported types by domain" table and a "Type guards" usage section. `packages/libs/mcp/README.md` pin bumped to the projected publish version since the `@squawk/types` minor triggers a transitive `@squawk/mcp` patch.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use \`Closes #N\` to auto-close the issue on merge, or \`Refs #N\` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #205

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added `airspace.spec.ts`, `airport.spec.ts`, `airway.spec.ts`, `navaid.spec.ts`, `fix.spec.ts` covering each new guard's accept-all-members / reject-non-members behavior, plus `aircraft.spec.ts` smoke test for `AircraftCategory` so the per-file 80% gate clears now that the package is in the coverage gate set.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `.changeset/types-string-literal-guards.md` bumps `@squawk/types` minor.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->