### PR TITLE
Expand AirspaceResolver with centroid, identifier, and bbox queries

### DIFF
--- a/.changeset/airspace-resolver-queries.md
+++ b/.changeset/airspace-resolver-queries.md
@@ -1,0 +1,7 @@
+---
+'@squawk/airspace': minor
+---
+
+### Added
+
+- Four new query shapes on `AirspaceResolver`: `byCentroid({ lon, lat, toleranceDeg? })` resolves features whose polygon centroid is within tolerance of the query point (the URL-handle fallback for empty-identifier features); `byIdentifier(identifier, options?)` is a type-agnostic identifier lookup that spans both ARTCC and non-ARTCC partitions in one call; `withinBbox(bbox)` returns features whose pre-indexed bounding box overlaps a query bbox using the bounding box cached at resolver init; and `forEachIndexed(callback)` exposes a read-only iteration over the indexed corpus with positional `(feature, ring, boundingBox)` arguments. The existing `query`, `byAirport`, and `byArtcc` methods stay as ergonomic shortcuts; the new methods are additive. Two supporting types (`AirspaceCentroidQuery`, `AirspaceByIdentifierOptions`) are also exported from the package root.

--- a/apps/atlas/src/shared/inspector/airspace-feature.ts
+++ b/apps/atlas/src/shared/inspector/airspace-feature.ts
@@ -1,6 +1,6 @@
-import type { Feature, GeoJsonProperties, Geometry, Polygon } from 'geojson';
+import type { GeoJsonProperties } from 'geojson';
 
-import type { AirspaceFeature, AltitudeBound } from '@squawk/types';
+import type { AltitudeBound } from '@squawk/types';
 
 /**
  * Synthetic per-feature property added at airspace source-projection
@@ -75,38 +75,6 @@ export function compareAirspaceByAltitudeDesc(
   b: AirspaceAltitudeKey,
 ): number {
   return b.ceilingFt - a.ceilingFt || b.floorFt - a.floorFt;
-}
-
-/**
- * GeoJSON feature carrying the airspace property bag the
- * `@squawk/airspace-data` bundle ships. The geometry is always a
- * `Polygon`; the properties are the full {@link AirspaceFeature} record
- * (type, identifier, floor, ceiling, etc.).
- */
-export type AirspacePolygonFeature = Feature<Polygon, AirspaceFeature>;
-
-/**
- * Type-narrows a generic GeoJSON feature to {@link AirspacePolygonFeature}.
- * Checks the geometry kind and the presence of the discriminating property
- * fields, so subsequent reads of `feature.properties.type` /
- * `feature.properties.identifier` are typed directly without `as`
- * assertions.
- *
- * @param feature - Candidate GeoJSON feature pulled from the airspace dataset.
- * @returns `true` when `feature` is an airspace polygon; the type predicate
- *          narrows the input in callers' control flow.
- */
-export function isAirspacePolygonFeature(
-  feature: Feature<Geometry, GeoJsonProperties>,
-): feature is AirspacePolygonFeature {
-  if (feature.geometry.type !== 'Polygon') {
-    return false;
-  }
-  const props = feature.properties;
-  if (props === null) {
-    return false;
-  }
-  return 'type' in props && 'identifier' in props && 'floor' in props && 'ceiling' in props;
 }
 
 /**

--- a/apps/atlas/src/shared/inspector/chip-builders.ts
+++ b/apps/atlas/src/shared/inspector/chip-builders.ts
@@ -10,12 +10,9 @@ import {
 import type { InspectableFeature } from '../../modes/chart/click-to-select.ts';
 import { AIRSPACE_CLASS_FOR_TYPE } from '../../modes/chart/url-state.ts';
 import type { AirspaceClass } from '../../modes/chart/url-state.ts';
+import { getAirspaceResolver } from '../data/airspace-dataset.ts';
 
-import {
-  compareAirspaceByAltitudeDesc,
-  isAirspacePolygonFeature,
-  readAirspaceAltitudeKey,
-} from './airspace-feature.ts';
+import { compareAirspaceByAltitudeDesc, readAirspaceAltitudeKey } from './airspace-feature.ts';
 import type { AirspaceAltitudeKey } from './airspace-feature.ts';
 import { resolveSelectionFromState } from './entity-resolver.ts';
 import type { ChartDatasetStates, ResolvedEntityState } from './entity-resolver.ts';
@@ -157,19 +154,25 @@ export function* buildOverlappingAirspaceChips(
     return;
   }
   const activeClassSet = new Set<string>(activeClasses);
-  for (const feature of datasets.airspace.dataset.features) {
-    if (!isAirspacePolygonFeature(feature)) {
-      continue;
-    }
-    const props = feature.properties;
-    if (!activeClassSet.has(AIRSPACE_CLASS_FOR_TYPE[props.type])) {
+  // The resolver's withinBbox query reuses the bounding box pre-computed at
+  // resolver-creation time, so the per-feature bounding-box recomputation
+  // the chip walk used to do is gone. Each candidate is already a parsed
+  // AirspaceFeature with its `boundary` polygon, so the GeoJSON narrowing
+  // guard and the property-bag access disappear too.
+  const resolver = getAirspaceResolver(datasets.airspace.dataset);
+  for (const feature of resolver.withinBbox(footprint.bbox)) {
+    if (!activeClassSet.has(AIRSPACE_CLASS_FOR_TYPE[feature.type])) {
       continue;
     }
     // Build the encoded selection. Empty-identifier features use a
     // centroid-based disambiguator so they still get a stable URL
     // handle (and thus a clickable chip) - same convention the click
     // path uses.
-    const selection = encodeAirspaceChipSelection(props.type, props.identifier, feature.geometry);
+    const selection = encodeAirspaceChipSelection(
+      feature.type,
+      feature.identifier,
+      feature.boundary,
+    );
     if (selection === undefined) {
       continue;
     }
@@ -179,14 +182,7 @@ export function* buildOverlappingAirspaceChips(
     if (seen.has(selection)) {
       continue;
     }
-    const featureBbox = polygonGeoJson.polygonBoundingBox(feature.geometry);
-    // Cheap bbox pre-filter against the selected footprint, then a
-    // per-feature centroid for both the viewport check and (for
-    // airspace selections) the substantial-overlap check below.
-    if (!polygonGeoJson.boundingBoxesOverlap(footprint.bbox, featureBbox)) {
-      continue;
-    }
-    const featureCentroid = polygonGeoJson.polygonCentroid(feature.geometry);
+    const featureCentroid = polygonGeoJson.polygonCentroid(feature.boundary);
     if (featureCentroid === undefined) {
       continue;
     }
@@ -205,7 +201,7 @@ export function* buildOverlappingAirspaceChips(
       let overlaps = false;
       for (const polygon of footprint.polygons) {
         if (
-          polygonGeoJson.polygonsSubstantiallyOverlap(feature.geometry, polygon, featureCentroid)
+          polygonGeoJson.polygonsSubstantiallyOverlap(feature.boundary, polygon, featureCentroid)
         ) {
           overlaps = true;
           break;
@@ -217,8 +213,8 @@ export function* buildOverlappingAirspaceChips(
     }
     yield {
       selection,
-      label: formatAirspaceLabel(props.type, props.identifier, props.name),
-      altitudeKey: { ceilingFt: props.ceiling.valueFt, floorFt: props.floor.valueFt },
+      label: formatAirspaceLabel(feature.type, feature.identifier, feature.name),
+      altitudeKey: { ceilingFt: feature.ceiling.valueFt, floorFt: feature.floor.valueFt },
     };
   }
 }

--- a/apps/atlas/src/shared/inspector/entity-resolver.ts
+++ b/apps/atlas/src/shared/inspector/entity-resolver.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { polygonGeoJson } from '@squawk/geo';
 import type { Airport, Airway, AirspaceFeature, Fix, Navaid } from '@squawk/types';
 
 import { getAirportResolver, useAirportDataset } from '../data/airport-dataset.ts';
@@ -14,8 +13,7 @@ import type { FixDatasetState } from '../data/fix-dataset.ts';
 import { getNavaidResolver, useNavaidDataset } from '../data/navaid-dataset.ts';
 import type { NavaidDatasetState } from '../data/navaid-dataset.ts';
 
-import { compareAirspaceByAltitudeDesc, isAirspacePolygonFeature } from './airspace-feature.ts';
-import type { AirspacePolygonFeature } from './airspace-feature.ts';
+import { compareAirspaceByAltitudeDesc } from './airspace-feature.ts';
 import { parseSelected } from './entity.ts';
 import type { EntityRef } from './entity.ts';
 
@@ -120,48 +118,6 @@ export interface ChartDatasetStates {
   airway: AirwayDatasetState;
   /** Airspace dataset fetch state. */
   airspace: AirspaceDatasetState;
-}
-
-/**
- * Match tolerance (in degrees lon/lat) used when looking up an airspace
- * feature by polygon centroid. The chip walk encodes centroids to 5
- * decimal places (~1m precision); 0.0001 (~11m) is generous enough to
- * absorb floating-point round-trips through URL parsing.
- */
-const CENTROID_MATCH_TOLERANCE = 0.0001;
-
-/**
- * Builds a matcher that returns true iff a candidate airspace feature
- * has the given type AND its polygon centroid is within
- * {@link CENTROID_MATCH_TOLERANCE} of the target coordinates. Returns
- * undefined when the encoded coords cannot be parsed.
- */
-function buildAirspaceCentroidMatcher(
-  encoded: string,
-  airspaceTypeStr: string,
-): ((feature: AirspacePolygonFeature) => boolean) | undefined {
-  const parts = encoded.split(',');
-  if (parts.length !== 2) {
-    return undefined;
-  }
-  const targetLon = Number(parts[0]);
-  const targetLat = Number(parts[1]);
-  if (!Number.isFinite(targetLon) || !Number.isFinite(targetLat)) {
-    return undefined;
-  }
-  return (feature) => {
-    if (feature.properties.type !== airspaceTypeStr) {
-      return false;
-    }
-    const centroid = polygonGeoJson.polygonCentroid(feature.geometry);
-    if (centroid === undefined) {
-      return false;
-    }
-    return (
-      Math.abs(centroid[0] - targetLon) < CENTROID_MATCH_TOLERANCE &&
-      Math.abs(centroid[1] - targetLat) < CENTROID_MATCH_TOLERANCE
-    );
-  };
 }
 
 /**
@@ -320,12 +276,10 @@ export function resolveSelectionFromState(
 }
 
 /**
- * Resolves an `(airspaceType, identifier)` URL key against the airspace
- * resolver's identifier indexes. Dispatches between `byArtcc` and
- * `byAirport` because the two methods partition the identifier index
- * (ARTCC vs everything else); after the bucket lookup, features are
- * filtered to the exact `airspaceType` requested so a single identifier
- * shared across types (rare but possible) only returns the URL-pinned one.
+ * Resolves an `(airspaceType, identifier)` URL key via the airspace
+ * resolver's type-agnostic identifier lookup, then post-filters to the
+ * exact `airspaceType` requested so a single identifier shared across
+ * types (rare but possible) only returns the URL-pinned one.
  *
  * Returns undefined when the airspace dataset is not loaded; otherwise
  * returns the matched features (possibly empty - the caller treats
@@ -340,17 +294,16 @@ function resolveAirspaceByIdentifier(
     return undefined;
   }
   const resolver = getAirspaceResolver(state.dataset);
-  const bucket =
-    airspaceTypeStr === 'ARTCC' ? resolver.byArtcc(identifier) : resolver.byAirport(identifier);
-  return bucket.filter((feature) => feature.type === airspaceTypeStr);
+  return resolver.byIdentifier(identifier).filter((feature) => feature.type === airspaceTypeStr);
 }
 
 /**
- * Resolves an `airspace:TYPE/c:LON,LAT` URL by walking the source
- * dataset's features and matching every airspace polygon whose centroid
- * lies within {@link CENTROID_MATCH_TOLERANCE} of the encoded coordinates.
- * Returns undefined when the dataset is not loaded or the encoded
- * coordinates cannot be parsed.
+ * Resolves an `airspace:TYPE/c:LON,LAT` URL by parsing the centroid encoding
+ * and delegating to the resolver's `byCentroid` query. Post-filters the
+ * matches to the exact `airspaceType` requested so distinct features whose
+ * centroids happen to coincide only return the URL-pinned type. Returns
+ * undefined when the dataset is not loaded or the encoded coordinates
+ * cannot be parsed.
  */
 function resolveAirspaceByCentroid(
   state: AirspaceDatasetState,
@@ -360,21 +313,17 @@ function resolveAirspaceByCentroid(
   if (state.status !== 'loaded') {
     return undefined;
   }
-  const matcher = buildAirspaceCentroidMatcher(encoded, airspaceTypeStr);
-  if (matcher === undefined) {
+  const parts = encoded.split(',');
+  if (parts.length !== 2) {
     return undefined;
   }
-  const features: AirspaceFeature[] = [];
-  for (const feature of state.dataset.features) {
-    if (isAirspacePolygonFeature(feature) && matcher(feature)) {
-      // The dataset write step puts the boundary on the GeoJSON
-      // geometry, not the properties bag. Re-attach it here so the
-      // resolved AirspaceFeature carries the polygon downstream
-      // (the inspector reads it for bbox-overlap chip computation).
-      features.push({ ...feature.properties, boundary: feature.geometry });
-    }
+  const lon = Number(parts[0]);
+  const lat = Number(parts[1]);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+    return undefined;
   }
-  return features;
+  const resolver = getAirspaceResolver(state.dataset);
+  return resolver.byCentroid({ lon, lat }).filter((feature) => feature.type === airspaceTypeStr);
 }
 
 /**

--- a/packages/libs/airspace/README.md
+++ b/packages/libs/airspace/README.md
@@ -67,7 +67,7 @@ The `/browser` entry is identical to the main entry; the separate subpath exists
 ## How it works
 
 `createAirspaceResolver` parses the GeoJSON FeatureCollection at initialization and
-returns a resolver object with three methods:
+returns a resolver object with the following methods:
 
 - `query(AirspaceQuery)` - returns features containing the given position and
   altitude, via a ray casting point-in-polygon test combined with a vertical
@@ -79,6 +79,19 @@ returns a resolver object with three methods:
 - `byArtcc(identifier, stratum?)` - returns every ARTCC feature for the given
   3-letter center code (e.g. `"ZNY"`), optionally filtered to a single
   stratum (`LOW`, `HIGH`, `UTA`, `CTA`, `FIR`, or `CTA/FIR`).
+- `byIdentifier(identifier, options?)` - type-agnostic identifier lookup that
+  spans both partitions in one call, with an optional `types` inclusion
+  filter and `includeArtcc` toggle.
+- `byCentroid({ lon, lat, toleranceDeg? })` - returns features whose polygon
+  centroid lies within tolerance of the query coordinates. Useful for
+  resolving features whose `identifier` is empty (some Class E5 surfaces),
+  where the centroid is the only stable handle.
+- `withinBbox(bbox)` - returns features whose pre-indexed bounding box
+  overlaps the query bbox. Reuses the bounding box cached at init time
+  rather than recomputing per call.
+- `forEachIndexed(callback)` - read-only iteration over the indexed corpus
+  with positional `(feature, ring, boundingBox)` arguments, for callers
+  that need to filter the corpus without reparsing the source GeoJSON.
 
 All matching features are returned as `AirspaceFeature` objects (from `@squawk/types`),
 including the full polygon boundary coordinates.
@@ -116,7 +129,9 @@ Creates a resolver from a GeoJSON dataset.
 - `options.data` - a GeoJSON `FeatureCollection` with airspace features
 
 **Returns:** `AirspaceResolver` - an object exposing `query(AirspaceQuery)`,
-`byAirport(identifier, types?)`, and `byArtcc(identifier, stratum?)` methods.
+`byAirport(identifier, types?)`, `byArtcc(identifier, stratum?)`,
+`byIdentifier(identifier, options?)`, `byCentroid(query)`, `withinBbox(bbox)`,
+and `forEachIndexed(callback)` methods.
 
 ### `AirspaceQuery`
 
@@ -167,6 +182,81 @@ const zny = resolver.byArtcc('ZNY');
 
 // Just the high-altitude boundary for the Boston center
 const zbwHigh = resolver.byArtcc('ZBW', 'HIGH');
+```
+
+### `resolver.byIdentifier(identifier, options?)`
+
+Type-agnostic identifier lookup. Returns every feature whose `identifier`
+matches, spanning both the ARTCC and non-ARTCC partitions in one call.
+Reach for this when the airspace type is not known up-front (e.g. parsed
+from a URL); for ergonomic shortcuts, the partition-specific `byAirport` /
+`byArtcc` wrappers stay available.
+
+| Option         | Type                       | Description                                                                                     |
+| -------------- | -------------------------- | ----------------------------------------------------------------------------------------------- |
+| `types`        | ReadonlySet\<AirspaceType> | Optional. When provided, acts as the authoritative inclusion filter; `includeArtcc` is ignored. |
+| `includeArtcc` | boolean                    | Defaults to `true`. When `false` and `types` is omitted, ARTCC features are excluded.           |
+
+```typescript
+// Every feature for the identifier, ARTCC included
+const all = resolver.byIdentifier('ZNY');
+
+// Only the non-ARTCC partition
+const nonArtcc = resolver.byIdentifier('ZNY', { includeArtcc: false });
+
+// Only matching types
+const onlyClassB = resolver.byIdentifier('JFK', { types: new Set(['CLASS_B']) });
+```
+
+### `resolver.byCentroid(query)`
+
+Returns every feature whose polygon centroid is within `toleranceDeg` of
+`(lon, lat)`. The centroid is computed per call (not cached) so this is
+O(n) over the corpus - suitable for occasional URL-driven lookups, not
+hot loops. Useful for resolving features with an empty `identifier` (some
+Class E5 surfaces), where the centroid is the fallback URL handle.
+
+| Property       | Type   | Description                                                                                              |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------- |
+| `lon`          | number | Longitude in decimal degrees (WGS84)                                                                     |
+| `lat`          | number | Latitude in decimal degrees (WGS84)                                                                      |
+| `toleranceDeg` | number | Optional. Centroid match tolerance in degrees, applied independently to lon and lat. Defaults to 0.0001. |
+
+```typescript
+const matches = resolver.byCentroid({ lon: -118.4081, lat: 33.9425 });
+```
+
+### `resolver.withinBbox(bbox)`
+
+Returns every feature whose pre-indexed bounding box overlaps the query
+bbox. Reuses the bounding box cached at init time, so this is suitable
+for tight loops over the corpus. Bounding-box overlap is a coarse spatial
+filter: callers that need true polygon-polygon intersection should follow
+up with their own geometry test on the returned features.
+
+```typescript
+const overlapping = resolver.withinBbox({
+  minLon: -119,
+  minLat: 33,
+  maxLon: -118,
+  maxLat: 35,
+});
+```
+
+### `resolver.forEachIndexed(callback)`
+
+Read-only iteration over the indexed corpus, invoking `callback` once per
+feature with positional `(feature, ring, boundingBox)`. Exposes the
+resolver's pre-parsed shape so callers that need to filter the corpus
+themselves do not have to reparse the source GeoJSON or recompute geometry
+per call. The `ring` and `boundingBox` arguments are the resolver's
+internal caches and must not be mutated.
+
+```typescript
+resolver.forEachIndexed((feature, ring, boundingBox) => {
+  // ring is the parsed exterior ring (number[][]).
+  // boundingBox is the pre-computed axis-aligned bbox.
+});
 ```
 
 ### ARTCC altitude bounds

--- a/packages/libs/airspace/src/index.ts
+++ b/packages/libs/airspace/src/index.ts
@@ -1,2 +1,8 @@
 export { createAirspaceResolver } from './resolver.js';
-export type { AirspaceResolver, AirspaceResolverOptions, AirspaceQuery } from './resolver.js';
+export type {
+  AirspaceResolver,
+  AirspaceResolverOptions,
+  AirspaceQuery,
+  AirspaceCentroidQuery,
+  AirspaceByIdentifierOptions,
+} from './resolver.js';

--- a/packages/libs/airspace/src/resolver.spec.ts
+++ b/packages/libs/airspace/src/resolver.spec.ts
@@ -2,6 +2,7 @@ import type { FeatureCollection, Feature } from 'geojson';
 import { describe, it, beforeAll, expect, assert } from 'vitest';
 
 import { usBundledAirspace } from '@squawk/airspace-data';
+import { polygonGeoJson, type BoundingBox } from '@squawk/geo';
 import type { AirspaceType } from '@squawk/types';
 
 import { createAirspaceResolver } from './resolver.js';
@@ -573,5 +574,197 @@ describe('createAirspaceResolver with malformed features', () => {
     const r = createAirspaceResolver({ data });
     const results = r.query({ lat: 5, lon: 5, altitudeFt: 0 });
     expect(results.length).toBe(0);
+  });
+});
+
+describe('byCentroid', () => {
+  it('returns the feature whose centroid matches the query within tolerance', () => {
+    const laxShells = resolve_.byAirport('LAX');
+    assert(laxShells.length > 0, 'expected LAX shells in fixture data');
+    const target = laxShells[0]!;
+    const centroid = polygonGeoJson.polygonCentroid(target.boundary);
+    assert(centroid !== undefined, 'expected a computable centroid for LAX shell');
+    const matched = resolve_.byCentroid({ lon: centroid[0], lat: centroid[1] });
+    assert(
+      matched.some(
+        (f) => f.type === target.type && f.identifier === target.identifier && f === target,
+      ),
+      'expected byCentroid to return the same indexed feature',
+    );
+  });
+
+  it('returns an empty array for a position with no matching centroid', () => {
+    const matched = resolve_.byCentroid({ lon: 0, lat: 0 });
+    expect(matched.length, 'expected no centroids near (0, 0)').toBe(0);
+  });
+
+  it('honours the tolerance parameter', () => {
+    const laxShells = resolve_.byAirport('LAX');
+    const target = laxShells[0]!;
+    const centroid = polygonGeoJson.polygonCentroid(target.boundary);
+    assert(centroid !== undefined);
+    // 0.001 deg offset is far outside the default 0.0001 tolerance
+    // but inside an explicit 0.01 tolerance.
+    const offsetLon = centroid[0] + 0.001;
+    const offsetLat = centroid[1] + 0.001;
+    const tightMiss = resolve_.byCentroid({ lon: offsetLon, lat: offsetLat });
+    expect(
+      tightMiss.some((f) => f === target),
+      'tight default tolerance should miss the offset query',
+    ).toBe(false);
+    const looseHit = resolve_.byCentroid({
+      lon: offsetLon,
+      lat: offsetLat,
+      toleranceDeg: 0.01,
+    });
+    assert(
+      looseHit.some((f) => f === target),
+      'loose tolerance should match the offset query',
+    );
+  });
+});
+
+describe('byIdentifier', () => {
+  it('returns ARTCC and non-ARTCC features for the same identifier when both exist', () => {
+    // R-2508 (Edwards/China Lake) and ZLA share airspace, but identifiers differ;
+    // for the cross-partition test we exercise an identifier known to map to
+    // both via the bundled fixture by combining results: anything queried via
+    // byArtcc('ZNY') is in byIdentifier('ZNY').
+    const znyAll = resolve_.byIdentifier('ZNY');
+    const znyArtcc = resolve_.byArtcc('ZNY');
+    assert(znyArtcc.length > 0, 'expected ZNY ARTCC features in fixture');
+    assert(
+      znyArtcc.every((f) => znyAll.includes(f)),
+      'byIdentifier should include every ARTCC feature from byArtcc',
+    );
+  });
+
+  it('returns the same features as byAirport for a non-ARTCC identifier (default options)', () => {
+    const laxAll = resolve_.byIdentifier('LAX');
+    const laxAirport = resolve_.byAirport('LAX');
+    assert(laxAirport.length > 0);
+    expect(laxAll.length).toBe(laxAirport.length);
+    assert(laxAirport.every((f) => laxAll.includes(f)));
+  });
+
+  it('excludes ARTCC features when includeArtcc is false', () => {
+    const znyAll = resolve_.byIdentifier('ZNY');
+    assert(
+      znyAll.some((f) => f.type === 'ARTCC'),
+      'fixture precondition: ZNY identifier maps to at least one ARTCC feature',
+    );
+    const znyNoArtcc = resolve_.byIdentifier('ZNY', { includeArtcc: false });
+    expect(
+      znyNoArtcc.filter((f) => f.type === 'ARTCC').length,
+      'includeArtcc:false must drop ARTCC features',
+    ).toBe(0);
+  });
+
+  it('treats types filter as the authoritative inclusion list', () => {
+    const onlyClassB = resolve_.byIdentifier('LAX', { types: new Set<AirspaceType>(['CLASS_B']) });
+    assert(onlyClassB.length > 0);
+    assert(
+      onlyClassB.every((f) => f.type === 'CLASS_B'),
+      'types filter should include only the requested types',
+    );
+  });
+
+  it('honours types filter even when includeArtcc is false', () => {
+    // types is the inclusion list; includeArtcc is ignored when types is set.
+    const types = new Set<AirspaceType>(['ARTCC']);
+    const result = resolve_.byIdentifier('ZNY', { types, includeArtcc: false });
+    assert(result.length > 0, 'types:[ARTCC] should still return ARTCC features');
+    assert(
+      result.every((f) => f.type === 'ARTCC'),
+      'all results should be ARTCC',
+    );
+  });
+
+  it('is case-insensitive', () => {
+    const upper = resolve_.byIdentifier('LAX');
+    const lower = resolve_.byIdentifier('lax');
+    expect(upper.length).toBe(lower.length);
+  });
+
+  it('returns an empty array for an unknown identifier', () => {
+    expect(resolve_.byIdentifier('NOTANID').length).toBe(0);
+  });
+});
+
+describe('withinBbox', () => {
+  it('returns features whose pre-indexed bounding box overlaps the query bbox', () => {
+    // A bbox tightly around LAX should pull in at least the LAX Class B shells.
+    const bbox: BoundingBox = {
+      minLon: -118.5,
+      minLat: 33.85,
+      maxLon: -118.3,
+      maxLat: 34.0,
+    };
+    const features = resolve_.withinBbox(bbox);
+    assert(
+      features.some((f) => f.type === 'CLASS_B' && f.identifier === 'LAX'),
+      'expected at least one LAX CLASS_B feature in the bbox',
+    );
+  });
+
+  it('returns an empty array when no feature bbox overlaps', () => {
+    // Tiny bbox in deep ocean far from any FAA airspace.
+    const bbox: BoundingBox = { minLon: 0.0, minLat: 0.0, maxLon: 0.001, maxLat: 0.001 };
+    const features = resolve_.withinBbox(bbox);
+    expect(features.length).toBe(0);
+  });
+});
+
+describe('forEachIndexed', () => {
+  it('invokes the callback once per indexed feature with positional args', () => {
+    let count = 0;
+    let firstFeature: ReturnType<typeof Object> | undefined;
+    let firstRingLength = 0;
+    let firstBoundingBox: BoundingBox | undefined;
+    resolve_.forEachIndexed((feature, ring, boundingBox) => {
+      if (count === 0) {
+        firstFeature = feature;
+        firstRingLength = ring.length;
+        firstBoundingBox = boundingBox;
+      }
+      count += 1;
+    });
+    assert(count > 0, 'expected at least one indexed feature in the bundled fixture');
+    assert(firstFeature !== undefined, 'first feature should be defined');
+    assert(firstRingLength >= 4, 'rings are closed and must have at least 4 vertices');
+    assert(firstBoundingBox !== undefined, 'bounding box should be defined');
+  });
+
+  it('skips malformed features that did not parse into the indexed corpus', () => {
+    const data: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        // Valid square polygon
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [10, 0],
+                [10, 10],
+                [0, 10],
+                [0, 0],
+              ],
+            ],
+          },
+          properties: { type: 'CLASS_B', name: 'TEST', identifier: 'TST' },
+        },
+        // Malformed: no geometry
+        { type: 'Feature', geometry: null, properties: { type: 'CLASS_B' } } as unknown as Feature,
+      ],
+    };
+    const r = createAirspaceResolver({ data });
+    let count = 0;
+    r.forEachIndexed(() => {
+      count += 1;
+    });
+    expect(count, 'only the valid feature should be indexed').toBe(1);
   });
 });

--- a/packages/libs/airspace/src/resolver.ts
+++ b/packages/libs/airspace/src/resolver.ts
@@ -1,6 +1,6 @@
 import type { FeatureCollection, Feature } from 'geojson';
 
-import { polygon, type BoundingBox } from '@squawk/geo';
+import { polygon, polygonGeoJson, type BoundingBox } from '@squawk/geo';
 import type { AirspaceFeature, AirspaceType, AltitudeBound, ArtccStratum } from '@squawk/types';
 
 import { altitudeMatches } from './vertical-filter.js';
@@ -25,6 +25,50 @@ export interface AirspaceQuery {
    * When omitted, all airspace types are included.
    */
   types?: ReadonlySet<AirspaceType>;
+}
+
+/**
+ * A query describing a geographic position and tolerance for a centroid-based
+ * airspace lookup.
+ */
+export interface AirspaceCentroidQuery {
+  /** Longitude in decimal degrees (WGS84). */
+  lon: number;
+  /** Latitude in decimal degrees (WGS84). */
+  lat: number;
+  /**
+   * Optional tolerance in degrees for the centroid match. A feature is
+   * returned when both `|centroidLon - lon|` and `|centroidLat - lat|`
+   * fall below this value. Defaults to `0.0001` (~11 m), generous enough to
+   * absorb floating-point round-trips through URL parsing for centroids
+   * encoded to ~5 decimal places.
+   */
+  toleranceDeg?: number;
+}
+
+/**
+ * Options accepted by {@link AirspaceResolver.byIdentifier}.
+ */
+export interface AirspaceByIdentifierOptions {
+  /**
+   * Optional set of airspace types to include in the results. When provided,
+   * acts as an inclusion filter and overrides the partition between ARTCC and
+   * non-ARTCC features: callers who want ARTCC results in addition to the
+   * usual partition include `'ARTCC'` in this set explicitly, and callers who
+   * want only non-ARTCC results pass a set of the non-ARTCC types. When
+   * omitted, every type is eligible (subject to {@link includeArtcc}).
+   */
+  types?: ReadonlySet<AirspaceType>;
+  /**
+   * When `true` (the default), ARTCC features for the identifier are included
+   * alongside the airport-associated and SUA features. When `false`, ARTCC
+   * features are excluded - useful when you only want the non-ARTCC partition
+   * for an identifier without enumerating every non-ARTCC type yourself.
+   *
+   * Ignored when {@link types} is provided: `types` is the authoritative
+   * inclusion list in that case.
+   */
+  includeArtcc?: boolean;
 }
 
 /**
@@ -86,6 +130,86 @@ export interface AirspaceResolver {
    * @returns All matching ARTCC features, or an empty array.
    */
   byArtcc(identifier: string, stratum?: ArtccStratum): AirspaceFeature[];
+
+  /**
+   * Returns every airspace feature whose polygon centroid lies within the
+   * given tolerance of the query coordinates. Useful for resolving features
+   * that have an empty `identifier` (some Class E5 surfaces) and therefore
+   * have no stable identifier-keyed lookup - the polygon centroid is the
+   * fallback handle.
+   *
+   * Reach for this when you have a centroid encoded into a URL or other
+   * external string and want to recover the original feature(s); for
+   * identifier-keyed lookups, prefer {@link byIdentifier} (or the more
+   * specific {@link byAirport} / {@link byArtcc}). Centroid is computed
+   * per call - no internal caching - so this is O(n) over the indexed
+   * corpus, suitable for occasional URL-driven lookups but not for
+   * tight loops.
+   *
+   * @param query - Query coordinates and optional tolerance.
+   * @returns All features whose centroid is within tolerance, in dataset order.
+   */
+  byCentroid(query: AirspaceCentroidQuery): AirspaceFeature[];
+
+  /**
+   * Returns every airspace feature for the given identifier across both the
+   * ARTCC and non-ARTCC partitions, independent of position or altitude.
+   * Lookup is case-insensitive.
+   *
+   * Reach for this when you have an identifier whose airspace type is not
+   * known up-front (e.g. parsed from a URL) and you want a single call that
+   * returns the matching feature(s) regardless of partition. For ergonomic
+   * shortcuts when the partition is known, prefer {@link byAirport} (returns
+   * non-ARTCC features only) or {@link byArtcc} (returns ARTCC features
+   * only) - those wrappers encode the common "shells for this airport" /
+   * "stratums for this center" questions and stay available alongside this
+   * type-agnostic form.
+   *
+   * @param identifier - FAA identifier, NASR designator, or ARTCC code.
+   * @param options - Optional `types` inclusion filter and `includeArtcc`
+   *                  toggle. See {@link AirspaceByIdentifierOptions}.
+   * @returns All matching features, or an empty array.
+   */
+  byIdentifier(identifier: string, options?: AirspaceByIdentifierOptions): AirspaceFeature[];
+
+  /**
+   * Returns every airspace feature whose pre-indexed bounding box overlaps
+   * the given bounding box. Reuses the bounding box computed once at
+   * resolver creation time rather than recomputing per call, so this is
+   * suitable for tight loops over the corpus (e.g. a chip rebuild against
+   * a selection footprint).
+   *
+   * Bounding-box overlap is a coarse spatial filter: it matches any feature
+   * whose axis-aligned rectangle intersects the query rectangle, including
+   * features whose actual polygon does not. Callers that need true
+   * polygon-polygon intersection should follow up with their own geometry
+   * test on the returned features.
+   *
+   * @param bbox - Query bounding box.
+   * @returns All features whose pre-indexed bounding box overlaps, in dataset order.
+   */
+  withinBbox(bbox: BoundingBox): AirspaceFeature[];
+
+  /**
+   * Iterates the indexed corpus in dataset order, invoking `callback` once
+   * per feature with the parsed feature, its exterior ring, and its
+   * pre-computed bounding box. Exposes the resolver's pre-parsed shape so
+   * callers that need to filter the corpus themselves do not have to
+   * reparse the source GeoJSON or recompute geometry per call.
+   *
+   * The `ring` and `boundingBox` arguments are the resolver's internal
+   * caches and must not be mutated by the callback - copy them first if a
+   * mutation is needed.
+   *
+   * @param callback - Function invoked once per indexed feature.
+   */
+  forEachIndexed(
+    callback: (
+      feature: AirspaceFeature,
+      ring: readonly number[][],
+      boundingBox: BoundingBox,
+    ) => void,
+  ): void;
 }
 
 /**
@@ -163,6 +287,9 @@ function parseFeature(geoFeature: Feature): IndexedFeature | null {
  * const overhead = resolver.query({ lat: 33.9425, lon: -118.4081, altitudeFt: 3000 });
  * const laxShells = resolver.byAirport('LAX');
  * const newYorkArtcc = resolver.byArtcc('ZNY');
+ * const anyZnyFeature = resolver.byIdentifier('ZNY');
+ * const nearbyByCentroid = resolver.byCentroid({ lon: -118.4, lat: 33.9 });
+ * const overlapping = resolver.withinBbox({ minLon: -119, minLat: 33, maxLon: -118, maxLat: 35 });
  * ```
  */
 export function createAirspaceResolver(options: AirspaceResolverOptions): AirspaceResolver {
@@ -230,6 +357,62 @@ export function createAirspaceResolver(options: AirspaceResolverOptions): Airspa
         return artccFeatures;
       }
       return artccFeatures.filter((f) => f.artccStratum === stratum);
+    },
+
+    byCentroid(query: AirspaceCentroidQuery): AirspaceFeature[] {
+      const tolerance = query.toleranceDeg ?? 0.0001;
+      const results: AirspaceFeature[] = [];
+      for (const { feature } of indexed) {
+        const centroid = polygonGeoJson.polygonCentroid(feature.boundary);
+        if (centroid === undefined) {
+          continue;
+        }
+        if (
+          Math.abs(centroid[0] - query.lon) < tolerance &&
+          Math.abs(centroid[1] - query.lat) < tolerance
+        ) {
+          results.push(feature);
+        }
+      }
+      return results;
+    },
+
+    byIdentifier(identifier: string, options?: AirspaceByIdentifierOptions): AirspaceFeature[] {
+      const bucket = byIdentifierMap.get(identifier.toUpperCase());
+      if (bucket === undefined) {
+        return [];
+      }
+      const types = options?.types;
+      if (types !== undefined) {
+        return bucket.filter((f) => types.has(f.type));
+      }
+      const includeArtcc = options?.includeArtcc ?? true;
+      if (includeArtcc) {
+        return bucket.slice();
+      }
+      return bucket.filter((f) => f.type !== 'ARTCC');
+    },
+
+    withinBbox(bbox: BoundingBox): AirspaceFeature[] {
+      const results: AirspaceFeature[] = [];
+      for (const { feature, boundingBox } of indexed) {
+        if (polygonGeoJson.boundingBoxesOverlap(bbox, boundingBox)) {
+          results.push(feature);
+        }
+      }
+      return results;
+    },
+
+    forEachIndexed(
+      callback: (
+        feature: AirspaceFeature,
+        ring: readonly number[][],
+        boundingBox: BoundingBox,
+      ) => void,
+    ): void {
+      for (const { feature, ring, boundingBox } of indexed) {
+        callback(feature, ring, boundingBox);
+      }
     },
   };
 }

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.8.12"]
+      "args": ["-y", "@squawk/mcp@0.8.13"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds four new methods to `AirspaceResolver`: `byCentroid({ lon, lat, toleranceDeg? })` for URL-handle-fallback lookup of empty-identifier features; `byIdentifier(identifier, options?)` as a type-agnostic identifier lookup that spans both ARTCC and non-ARTCC partitions; `withinBbox(bbox)` returning features whose pre-indexed bounding box overlaps the query bbox; and `forEachIndexed(callback)` exposing read-only iteration with positional `(feature, ring, boundingBox)` args. Existing `query` / `byAirport` / `byArtcc` keep their semantics.
- Migrates atlas off the raw GeoJSON walks. `apps/atlas/src/shared/inspector/entity-resolver.ts` drops `buildAirspaceCentroidMatcher` and the ARTCC-vs-airport dispatch in `resolveAirspaceByIdentifier`, both replaced by direct resolver calls. `apps/atlas/src/shared/inspector/chip-builders.ts::buildOverlappingAirspaceChips` swaps the dataset.features walk for `resolver.withinBbox(footprint.bbox)`, dropping the per-render `polygonBoundingBox` recomputation. The chip walk's centroid-computation set collapses from "every feature in the corpus" (thousands) to "features whose bbox overlaps the footprint bbox" (typically tens) on dense-airspace clicks.
- The atlas `isAirspacePolygonFeature` GeoJSON narrowing guard and its `AirspacePolygonFeature` type alias are no longer used after the migration; deleted alongside their now-orphaned imports.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use \`Closes #N\` to auto-close the issue on merge, or \`Refs #N\` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #204

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added per-method test blocks in \`packages/libs/airspace/src/resolver.spec.ts\` for \`byCentroid\`, \`byIdentifier\`, \`withinBbox\`, and \`forEachIndexed\`. Existing atlas specs (\`entity-resolver.spec.ts\`, \`chip-builders.spec.ts\`, \`airspace-feature.spec.ts\`) continue to pass without changes since the public shapes are unchanged.
- [x] Changeset added under \`.changeset/\` for any user-facing change to a published \`@squawk/*\` package (or N/A - internal-only / docs / tooling)
  - \`.changeset/airspace-resolver-queries.md\` bumps \`@squawk/airspace\` minor.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->