### PR TITLE
Move @squawk/icao-registry-data to optional peer dependency in @squawk/mcp

### DIFF
--- a/.changeset/mcp-optional-icao-registry-peer.md
+++ b/.changeset/mcp-optional-icao-registry-peer.md
@@ -1,0 +1,7 @@
+---
+'@squawk/mcp': minor
+---
+
+### Changed
+
+- `@squawk/icao-registry-data` is now declared as an optional peer dependency of `@squawk/mcp` instead of a required dependency. Default installs of `@squawk/mcp` no longer pull in the ~8 MB FAA aircraft-registry snapshot, shrinking the cold-install footprint for users who do not query ICAO hex codes. To restore the previous behavior and enable `lookup_aircraft_by_icao_hex`, install the data package alongside `@squawk/mcp`: `npm install @squawk/icao-registry-data` for local installs, or add `-p @squawk/icao-registry-data` to the `npx` args in your MCP client config (e.g. `npx -y -p @squawk/icao-registry-data @squawk/mcp`). When the data package is missing, the tool stays listed in the catalog and returns a structured `isError: true` result naming the dataset, package, and exact install command so the LLM client can surface the action to the user; the rest of the server keeps running normally.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,12 +104,13 @@ Why: self-documenting call sites without polluting the import namespace with doz
 
 ### MCP as the aggregator
 
-[`@squawk/mcp`](packages/libs/mcp/) is the Model Context Protocol server that exposes every other package as tools for LLM clients. Tool modules live under `packages/libs/mcp/src/tools/<domain>.ts`; resolvers are constructed once by `src/resolvers.ts` and reused. The bundled aircraft registry is loaded lazily on first lookup to keep cold-start cheap. Live weather fetching is the only tool surface that performs network I/O at invocation time.
+[`@squawk/mcp`](packages/libs/mcp/) is the Model Context Protocol server that exposes every other package as tools for LLM clients. Tool modules live under `packages/libs/mcp/src/tools/<domain>.ts`; resolvers are constructed once by `src/resolvers.ts` and reused. The aircraft registry is loaded lazily on first lookup to keep cold-start cheap, and `@squawk/icao-registry-data` is declared as an optional peer dependency so default installs stay lean - the tool catalog still lists `lookup_aircraft_by_icao_hex` when the peer is absent and returns a structured "data not installed" error pointing at the install command. Live weather fetching is the only tool surface that performs network I/O at invocation time.
 
-Two non-obvious maintenance patterns hold here:
+Three non-obvious maintenance patterns hold here:
 
 - **MCP stays in sync with its dependencies.** Any change to a package mcp consumes (or a new package that should be exposed through mcp) lands together with updates to the matching tool module, resolver wiring, README, and `packages/libs/mcp/package.json` in the same change. Intentional non-propagation is called out explicitly rather than silently skipped.
 - **The pinned-version README snippet tracks the upcoming release.** When a change bumps `@squawk/mcp` to a new published version (even transitively), the pinned-version snippet in [packages/libs/mcp/README.md](packages/libs/mcp/README.md) under "Picking an install version" reflects the version that will publish from that change.
+- **Optional peer datasets follow the lazy-import + structured-error pattern.** A data package exposed through mcp may be declared `optional: true` under `peerDependenciesMeta` when its size is disproportionate to the audience that needs it. Tool handlers for those datasets `await import(...)` the data package inside the handler (not at module top level), catch `ERR_MODULE_NOT_FOUND`, and surface a structured `MissingDataPackageError` carrying the dataset name, package name, and install command. The tool stays listed in the catalog so the LLM can offer the install instructions to the user; the rest of the server keeps running. `@squawk/icao-registry-data` is the first dataset on this path.
 
 ---
 

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.8.13"]
+      "args": ["-y", "@squawk/mcp@0.9.0"]
     }
   }
 }
@@ -129,6 +129,50 @@ server still serves the old behavior after a host restart, clear the cache direc
 again, or fall back to a pinned version. The host process itself also has to restart for any
 update to take effect, since each MCP server is a long-running stdio subprocess that loads its
 code once at spawn time.
+
+### Enabling the aircraft registry (optional peer)
+
+`@squawk/icao-registry-data` is the largest snapshot in the suite (roughly 8 MB on disk after
+gzip). Most sessions never need a tail-number lookup, so the package is declared as an optional
+**peer dependency** of `@squawk/mcp` rather than a required dep - npm 7+ does not auto-install
+optional peers, which keeps the default `npx @squawk/mcp` install lean.
+
+When the data package is not installed, `lookup_aircraft_by_icao_hex` is still listed in the tool
+catalog. The first invocation returns a structured `isError: true` result whose
+`structuredContent.missingDataPackage.installCommand` field names the exact command to run; the
+rest of the server keeps working normally. If you do not need aircraft lookups, no further action
+is required.
+
+To enable lookups, install the data package alongside `@squawk/mcp`. Through `npx` the cleanest
+option is the `-p` flag, which adds extra packages to the temporary install npx builds:
+
+```json
+{
+  "mcpServers": {
+    "squawk": {
+      "command": "npx",
+      "args": ["-y", "-p", "@squawk/icao-registry-data", "@squawk/mcp"]
+    }
+  }
+}
+```
+
+Pinning works the same way:
+
+```json
+{
+  "mcpServers": {
+    "squawk": {
+      "command": "npx",
+      "args": ["-y", "-p", "@squawk/icao-registry-data@0.8.3", "@squawk/mcp@0.9.0"]
+    }
+  }
+}
+```
+
+For non-`npx` setups (a local install, a global install, a Docker image), add
+`@squawk/icao-registry-data` to the same dependency manifest that pulls in `@squawk/mcp` and the
+runtime will resolve it through ordinary Node module resolution.
 
 ### Pinning a specific Node binary
 
@@ -262,8 +306,11 @@ Covers SIDs, STARs, and Instrument Approach Procedures (IAPs) from FAA CIFP.
 | ----------------------------- | ------------------------------------------------------------- |
 | `lookup_aircraft_by_icao_hex` | Resolve a 24-bit ICAO hex address to an aircraft registration |
 
-The registry data (~40 MB raw) is loaded lazily on the first lookup so sessions that never need it
-do not pay the decompression cost.
+`@squawk/icao-registry-data` is an optional peer dependency. Default installs of `@squawk/mcp` do
+not include it; the tool reports a structured "data not installed" error with the exact install
+command until the peer is added. See [Enabling the aircraft registry](#enabling-the-aircraft-registry-optional-peer)
+for how to add it. Once present, the registry (~40 MB raw) is decompressed lazily on the first
+lookup so sessions that never need it do not pay the cost.
 
 ### Weather (`@squawk/weather` + `@squawk/weather/fetch`)
 
@@ -351,5 +398,6 @@ left to the model itself.
   override above). They are the only tools that touch the network at invocation time; everything
   else operates against bundled snapshots in memory.
 - The bundled snapshots are decompressed and indexed once when the server starts. Expect a few
-  hundred milliseconds of startup time. The aircraft registration snapshot (the largest) is loaded
-  lazily on the first `lookup_aircraft_by_icao_hex` call.
+  hundred milliseconds of startup time. The aircraft registration snapshot (the largest, and an
+  optional peer dependency) is decompressed lazily on the first `lookup_aircraft_by_icao_hex` call,
+  if the package is installed.

--- a/packages/libs/mcp/package.json
+++ b/packages/libs/mcp/package.json
@@ -51,7 +51,6 @@
     "@squawk/flightplan": "^0.5.1",
     "@squawk/geo": "^0.4.3",
     "@squawk/icao-registry": "^0.5.1",
-    "@squawk/icao-registry-data": "^0.8.3",
     "@squawk/navaid-data": "^0.6.3",
     "@squawk/navaids": "^0.4.1",
     "@squawk/notams": "^0.3.5",
@@ -61,7 +60,16 @@
     "@squawk/weather": "^0.5.5",
     "zod": "^4.4.3"
   },
+  "peerDependencies": {
+    "@squawk/icao-registry-data": "^0.8.3"
+  },
+  "peerDependenciesMeta": {
+    "@squawk/icao-registry-data": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@squawk/icao-registry-data": "^0.8.3",
     "@types/node": "^25.6.0"
   },
   "keywords": [

--- a/packages/libs/mcp/src/missing-peer.spec.ts
+++ b/packages/libs/mcp/src/missing-peer.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests covering the optional peer dependency story for
+ * `@squawk/icao-registry-data`. Three paths under test:
+ *
+ * 1. The {@link MissingDataPackageError} class formats its message and
+ *    surfaces the install command on dedicated properties.
+ * 2. {@link getIcaoRegistry} catches `ERR_MODULE_NOT_FOUND` from the lazy
+ *    import, wraps it in a {@link MissingDataPackageError}, and stays
+ *    sticky on subsequent calls so the import is not retried.
+ * 3. The `lookup_aircraft_by_icao_hex` tool surfaces a structured
+ *    `isError: true` result with the install command when the peer is
+ *    missing, while still appearing in the catalog.
+ *
+ * The data package import is swapped at the resolver level via
+ * {@link __setIcaoRegistryDataLoaderForTest} rather than via vitest module
+ * mocking, because vitest cannot easily make a dynamic import throw with
+ * `ERR_MODULE_NOT_FOUND` at module-load time. Routing through the seam
+ * exercises the real {@link getIcaoRegistry} body and the tool handler so
+ * coverage reflects the production path.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import {
+  MissingDataPackageError,
+  __setIcaoRegistryDataLoaderForTest,
+  getIcaoRegistry,
+  getIcaoRegistryMetadata,
+  isIcaoRegistryLoaded,
+} from './resolvers.js';
+import { createSquawkMcpServer } from './server.js';
+
+/**
+ * Builds a loader that mimics Node's `ERR_MODULE_NOT_FOUND` rejection,
+ * matching the shape `getIcaoRegistry` keys off when deciding whether to
+ * surface a {@link MissingDataPackageError}.
+ */
+function rejectingLoader(): () => Promise<never> {
+  return () => {
+    const err = Object.assign(new Error("Cannot find package '@squawk/icao-registry-data'"), {
+      code: 'ERR_MODULE_NOT_FOUND',
+    });
+    return Promise.reject(err);
+  };
+}
+
+describe('MissingDataPackageError', () => {
+  it('formats the message and exposes the install command on its properties', () => {
+    const err = new MissingDataPackageError('icao-registry', '@squawk/icao-registry-data');
+    expect(err.name).toBe('MissingDataPackageError');
+    expect(err.datasetName).toBe('icao-registry');
+    expect(err.packageName).toBe('@squawk/icao-registry-data');
+    expect(err.installCommand).toBe('npm install @squawk/icao-registry-data');
+    expect(err.message).toBe(
+      'icao-registry data is not installed. Run: npm install @squawk/icao-registry-data',
+    );
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('getIcaoRegistry when the optional peer is missing', () => {
+  beforeEach(() => {
+    __setIcaoRegistryDataLoaderForTest(rejectingLoader());
+  });
+
+  afterEach(() => {
+    __setIcaoRegistryDataLoaderForTest(undefined);
+  });
+
+  it('throws MissingDataPackageError on first call', async () => {
+    await expect(getIcaoRegistry()).rejects.toBeInstanceOf(MissingDataPackageError);
+  });
+
+  it('keeps throwing MissingDataPackageError without retrying the import', async () => {
+    await expect(getIcaoRegistry()).rejects.toBeInstanceOf(MissingDataPackageError);
+    await expect(getIcaoRegistry()).rejects.toBeInstanceOf(MissingDataPackageError);
+  });
+
+  it('reports the registry as not loaded and exposes no metadata', () => {
+    expect(isIcaoRegistryLoaded()).toBe(false);
+    expect(getIcaoRegistryMetadata()).toBeUndefined();
+  });
+
+  it('rethrows non-ERR_MODULE_NOT_FOUND errors unchanged', async () => {
+    const otherError = new Error('boom');
+    __setIcaoRegistryDataLoaderForTest(() => Promise.reject(otherError));
+    await expect(getIcaoRegistry()).rejects.toBe(otherError);
+  });
+});
+
+describe('lookup_aircraft_by_icao_hex when the optional peer is missing', () => {
+  beforeEach(() => {
+    __setIcaoRegistryDataLoaderForTest(rejectingLoader());
+  });
+
+  afterEach(() => {
+    __setIcaoRegistryDataLoaderForTest(undefined);
+  });
+
+  it('returns isError with the install command in the structured payload', async () => {
+    const server = createSquawkMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'squawk-mcp-missing-peer-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: 'lookup_aircraft_by_icao_hex',
+        arguments: { icaoHex: 'AC82EC' },
+      });
+      expect(result.isError).toBe(true);
+      const parsed = z
+        .object({
+          aircraft: z.null(),
+          missingDataPackage: z.object({
+            datasetName: z.literal('icao-registry'),
+            packageName: z.literal('@squawk/icao-registry-data'),
+            installCommand: z.literal('npm install @squawk/icao-registry-data'),
+          }),
+        })
+        .parse(result.structuredContent);
+      expect(parsed.aircraft).toBe(null);
+      expect(parsed.missingDataPackage.installCommand).toBe(
+        'npm install @squawk/icao-registry-data',
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('still lists the tool in the catalog so the LLM can surface the error', async () => {
+    const server = createSquawkMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'squawk-mcp-missing-peer-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      const names = new Set(tools.map((tool) => tool.name));
+      expect(names.has('lookup_aircraft_by_icao_hex')).toBe(true);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
+describe('lookup_aircraft_by_icao_hex when the loader throws an unrelated error', () => {
+  beforeEach(() => {
+    __setIcaoRegistryDataLoaderForTest(() => Promise.reject(new Error('boom')));
+  });
+
+  afterEach(() => {
+    __setIcaoRegistryDataLoaderForTest(undefined);
+  });
+
+  it('rethrows so the SDK marks the call as isError without the missing-peer shape', async () => {
+    const server = createSquawkMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'squawk-mcp-missing-peer-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({
+        name: 'lookup_aircraft_by_icao_hex',
+        arguments: { icaoHex: 'AC82EC' },
+      });
+      expect(result.isError).toBe(true);
+      // The missing-peer payload must only fire for MissingDataPackageError;
+      // unrelated failures fall through to the SDK's default error shape.
+      const structured = result.structuredContent as Record<string, unknown> | undefined;
+      expect(structured?.missingDataPackage).toBeUndefined();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/libs/mcp/src/resolvers.ts
+++ b/packages/libs/mcp/src/resolvers.ts
@@ -4,10 +4,13 @@
  * resolver is constructed once at module load time so the bundled FAA data
  * snapshots are decoded and indexed exactly once per server process.
  *
- * The ICAO registry is the only resolver that loads lazily: its bundled data
- * package decompresses ~40 MB of records on import, which is wasted work for
- * sessions that never call the tail-number lookup. The registry is built on
- * the first {@link getIcaoRegistry} call and cached for subsequent calls.
+ * The ICAO registry is the only resolver that loads lazily, and its data
+ * package (`@squawk/icao-registry-data`) is declared as an optional peer
+ * dependency rather than a required dep. The registry is built on the first
+ * {@link getIcaoRegistry} call (decompressing ~40 MB on first access) and
+ * cached for subsequent calls. When the peer is not installed, the import
+ * throws `ERR_MODULE_NOT_FOUND` and {@link getIcaoRegistry} surfaces a
+ * {@link MissingDataPackageError} for the tool handler to format.
  */
 
 import { usBundledAirports } from '@squawk/airport-data';
@@ -52,6 +55,36 @@ export const procedureResolver: ProcedureResolver = createProcedureResolver({
   data: usBundledProcedures.records,
 });
 
+/**
+ * Error thrown when a tool tries to load an optional data package peer that
+ * has not been installed alongside `@squawk/mcp`. Tool handlers catch this
+ * and surface the install command to the MCP client so the user can resolve
+ * the missing dependency without inspecting the server logs.
+ */
+export class MissingDataPackageError extends Error {
+  /** Short dataset name shown to users (e.g. `"icao-registry"`). */
+  readonly datasetName: string;
+  /** npm package name the user must install (e.g. `"@squawk/icao-registry-data"`). */
+  readonly packageName: string;
+  /** Suggested install command, e.g. `"npm install @squawk/icao-registry-data"`. */
+  readonly installCommand: string;
+
+  /**
+   * Constructs a new error describing a missing optional data peer.
+   *
+   * @param datasetName - Short dataset name for the user-facing message.
+   * @param packageName - npm package name that needs to be installed.
+   */
+  constructor(datasetName: string, packageName: string) {
+    const installCommand = `npm install ${packageName}`;
+    super(`${datasetName} data is not installed. Run: ${installCommand}`);
+    this.name = 'MissingDataPackageError';
+    this.datasetName = datasetName;
+    this.packageName = packageName;
+    this.installCommand = installCommand;
+  }
+}
+
 /** Cached ICAO registry instance, populated on the first {@link getIcaoRegistry} call. */
 let icaoRegistryInstance: IcaoRegistry | undefined;
 
@@ -63,19 +96,73 @@ let icaoRegistryInstance: IcaoRegistry | undefined;
 let icaoRegistryMetadata: { generatedAt: string; recordCount: number } | undefined;
 
 /**
+ * Sticky flag set once the optional `@squawk/icao-registry-data` peer is
+ * confirmed missing. Subsequent {@link getIcaoRegistry} calls short-circuit
+ * to a {@link MissingDataPackageError} without retrying the import; running
+ * `npm install` while the server is live is not a supported workflow.
+ */
+let icaoRegistryMissing = false;
+
+/** Loader signature for the optional `@squawk/icao-registry-data` peer. */
+type IcaoRegistryDataLoader = () => Promise<typeof import('@squawk/icao-registry-data')>;
+
+/** Default loader: a dynamic import of the actual peer package. */
+const defaultIcaoRegistryDataLoader: IcaoRegistryDataLoader = () =>
+  import('@squawk/icao-registry-data');
+
+/**
+ * Active loader used by {@link getIcaoRegistry}. Replaceable in tests via
+ * {@link __setIcaoRegistryDataLoaderForTest} so the missing-peer code path
+ * can be exercised without uninstalling the workspace-symlinked package.
+ */
+let icaoRegistryDataLoader: IcaoRegistryDataLoader = defaultIcaoRegistryDataLoader;
+
+/**
+ * Returns `true` when the given thrown value is Node's
+ * `ERR_MODULE_NOT_FOUND`, which the ESM loader raises both when the package
+ * specifier cannot be resolved and when a transitive resolution within the
+ * package fails. The latter is rare but should still surface as the missing-
+ * peer error so the user gets a single actionable message.
+ *
+ * @param err - The value caught from a dynamic import.
+ * @returns `true` when the value is an `ERR_MODULE_NOT_FOUND` error.
+ */
+function isModuleNotFoundError(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ERR_MODULE_NOT_FOUND';
+}
+
+/**
  * Returns the shared {@link IcaoRegistry} instance, decompressing and indexing
  * the bundled FAA aircraft registration snapshot on the first call. Subsequent
  * calls reuse the cached instance.
  *
- * The registry is initialized lazily because the underlying bundled data
- * package is the largest snapshot in the suite (roughly 40 MB raw). Sessions
- * that never look up an aircraft by ICAO hex avoid the cost entirely.
+ * The registry is initialized lazily because the underlying data package is
+ * the largest snapshot in the suite (roughly 40 MB raw) and is declared as an
+ * optional peer dependency rather than a required dep. Sessions that never
+ * look up an aircraft by ICAO hex avoid the cost entirely, and consumers who
+ * never install the peer see only the structured missing-package error
+ * surfaced by the tool handler.
  *
  * @returns The shared registry instance.
+ * @throws {MissingDataPackageError} when `@squawk/icao-registry-data` is not
+ *         installed alongside `@squawk/mcp`.
  */
 export async function getIcaoRegistry(): Promise<IcaoRegistry> {
+  if (icaoRegistryMissing) {
+    throw new MissingDataPackageError('icao-registry', '@squawk/icao-registry-data');
+  }
   if (icaoRegistryInstance === undefined) {
-    const { usBundledRegistry } = await import('@squawk/icao-registry-data');
+    let registryDataModule: typeof import('@squawk/icao-registry-data');
+    try {
+      registryDataModule = await icaoRegistryDataLoader();
+    } catch (err) {
+      if (isModuleNotFoundError(err)) {
+        icaoRegistryMissing = true;
+        throw new MissingDataPackageError('icao-registry', '@squawk/icao-registry-data');
+      }
+      throw err;
+    }
+    const { usBundledRegistry } = registryDataModule;
     icaoRegistryInstance = createIcaoRegistry({ data: usBundledRegistry.records });
     icaoRegistryMetadata = {
       generatedAt: usBundledRegistry.properties.generatedAt,
@@ -83,6 +170,25 @@ export async function getIcaoRegistry(): Promise<IcaoRegistry> {
     };
   }
   return icaoRegistryInstance;
+}
+
+/**
+ * @internal
+ *
+ * Test-only seam for swapping the optional data package loader. Production
+ * code must not call this. Pass `undefined` to restore the default loader
+ * and clear all cached state (instance, metadata, and the missing-peer
+ * sticky flag) so subsequent tests start from a clean slate.
+ *
+ * @param loader - Replacement loader, or `undefined` to reset.
+ */
+export function __setIcaoRegistryDataLoaderForTest(
+  loader: IcaoRegistryDataLoader | undefined,
+): void {
+  icaoRegistryDataLoader = loader ?? defaultIcaoRegistryDataLoader;
+  icaoRegistryInstance = undefined;
+  icaoRegistryMetadata = undefined;
+  icaoRegistryMissing = false;
 }
 
 /**

--- a/packages/libs/mcp/src/tools/icao-registry.ts
+++ b/packages/libs/mcp/src/tools/icao-registry.ts
@@ -4,16 +4,18 @@
  * lookup, backed by the FAA ReleasableAircraft snapshot in
  * `@squawk/icao-registry-data`.
  *
- * Unlike the other domain modules, the registry data is loaded lazily on the
- * first tool invocation through {@link getIcaoRegistry}. The bundled data
- * package decompresses ~40 MB of records on import, which is wasteful for
- * sessions that never look up an aircraft.
+ * The registry data package is an **optional peer dependency** of
+ * `@squawk/mcp`. The tool is always registered with the MCP server so it
+ * appears in the catalog, but the data is loaded lazily on the first tool
+ * invocation through {@link getIcaoRegistry}. When the peer is not installed
+ * the tool returns a structured `isError: true` result naming the package and
+ * the install command, rather than crashing the server.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import { getIcaoRegistry } from '../resolvers.js';
+import { MissingDataPackageError, getIcaoRegistry } from '../resolvers.js';
 
 /** Pattern matching a valid 24-bit ICAO hex address (1-6 hex digits). */
 const ICAO_HEX_PATTERN = /^[0-9A-Fa-f]{1,6}$/;
@@ -29,7 +31,7 @@ export function registerIcaoRegistryTools(server: McpServer): void {
     {
       title: 'Look up an aircraft by ICAO hex address',
       description:
-        'Looks up a US-registered aircraft by its 24-bit ICAO hex address (the same identifier transmitted by Mode S and ADS-B). Returns registration, make, model, operator, aircraft type, engine type, and year of manufacture when known. Returns null when no match is found. The first call may take a few hundred milliseconds while the bundled FAA registration snapshot decompresses.',
+        'Looks up a US-registered aircraft by its 24-bit ICAO hex address (the same identifier transmitted by Mode S and ADS-B). Returns registration, make, model, operator, aircraft type, engine type, and year of manufacture when known. Returns null when no match is found. Backed by `@squawk/icao-registry-data`, which is an optional peer dependency of `@squawk/mcp`; if the package is not installed the tool returns an actionable error including the install command. The first successful call may take a few hundred milliseconds while the bundled FAA registration snapshot decompresses.',
       inputSchema: {
         icaoHex: z
           .string()
@@ -38,18 +40,36 @@ export function registerIcaoRegistryTools(server: McpServer): void {
       },
     },
     async ({ icaoHex }) => {
-      const registry = await getIcaoRegistry();
-      const aircraft = registry.lookup(icaoHex);
-      if (aircraft === undefined) {
+      try {
+        const registry = await getIcaoRegistry();
+        const aircraft = registry.lookup(icaoHex);
+        if (aircraft === undefined) {
+          return {
+            content: [{ type: 'text', text: `No aircraft found for ICAO hex "${icaoHex}".` }],
+            structuredContent: { aircraft: null },
+          };
+        }
         return {
-          content: [{ type: 'text', text: `No aircraft found for ICAO hex "${icaoHex}".` }],
-          structuredContent: { aircraft: null },
+          content: [{ type: 'text', text: JSON.stringify(aircraft, null, 2) }],
+          structuredContent: { aircraft },
         };
+      } catch (err) {
+        if (err instanceof MissingDataPackageError) {
+          return {
+            content: [{ type: 'text', text: err.message }],
+            structuredContent: {
+              aircraft: null,
+              missingDataPackage: {
+                datasetName: err.datasetName,
+                packageName: err.packageName,
+                installCommand: err.installCommand,
+              },
+            },
+            isError: true,
+          };
+        }
+        throw err;
       }
-      return {
-        content: [{ type: 'text', text: JSON.stringify(aircraft, null, 2) }],
-        structuredContent: { aircraft },
-      };
     },
   );
 }


### PR DESCRIPTION
## Summary

- Move `@squawk/icao-registry-data` from a required dep of `@squawk/mcp` to an optional peer dependency, dropping the ~8 MB FAA registry from the default install for users who do not query ICAO hex codes. Previous behavior is restored with `npm install @squawk/icao-registry-data` (or `-p @squawk/icao-registry-data` in the npx args).
- When the peer is missing, `lookup_aircraft_by_icao_hex` stays listed in the tool catalog and returns a structured `isError: true` result naming the dataset, package, and exact install command so the LLM client can surface the install action; the rest of the server keeps running normally. `packages/libs/mcp/README.md` and `ARCHITECTURE.md` document the new install model and the lazy-import + structured-error pattern, and the README pinned-version snippet is bumped to `0.9.0` to match the projected publish version.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

Closes #218

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added `packages/libs/mcp/src/missing-peer.spec.ts` covering the `MissingDataPackageError` class, the resolver missing-peer paths (sticky flag, non-`ERR_MODULE_NOT_FOUND` rethrow), and the tool handler integration through MCP.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `.changeset/mcp-optional-icao-registry-peer.md` bumps `@squawk/mcp` minor (0.8.13 -> 0.9.0); the changeset body carries the upgrade install command.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->