### PR TITLE
Pass --ignore-scripts to npm ci in all CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run lint
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - run: npm run build
 


### PR DESCRIPTION
## Summary

The 2026-05-11 supply-chain compromise exfiltrated `NPM_TOKEN` via a `prepare` script run during `npm ci`. This PR passes `--ignore-scripts` to every `npm ci` invocation across the four CI workflows (`ci.yml`, `codeql.yml`, `docs.yml`, `publish.yml`), neutralizing the install-script attack vector.

Local dep audit confirmed only two packages have install scripts, both safe to skip:

- `fsevents` - macOS-only via the `os` field, skipped at install time on the Linux runners CI uses; on macOS the prebuilt binary ships in the tarball and the `binding.gyp` rebuild is only needed when building from source.
- `unrs-resolver` - postinstall is a non-load-bearing verifier (`napi-postinstall ... check`); the actual platform binaries ship via `optionalDependencies` and do not need an install script.

Applied to all four workflows (not only `publish.yml`, where the exfil happened) for defense in depth.

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A: workflow-only change. The required `ci` and `CodeQL` status checks will exercise the modified workflows on this PR.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A: internal CI tooling change, no published-package impact.