### PR TITLE
Split publish workflow into separate build and publish jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,43 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+permissions: {}
 
 jobs:
-  publish:
+  build:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - run: npm run build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: packages/libs/*/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
@@ -35,7 +63,11 @@ jobs:
 
       - run: npm ci --ignore-scripts
 
-      - run: npm run build
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: packages/libs
 
       - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:


### PR DESCRIPTION
## Summary

PR #253 disabled install scripts in CI via `--ignore-scripts`. This PR adds structural defense in depth by splitting publish.yml into two jobs:

- **build** (`contents: read`, no secrets): runs `npm ci --ignore-scripts` and `npm run build`. Uploads `packages/libs/*/dist` as an artifact.
- **publish** (`contents: write`, `pull-requests: write`, `id-token: write`, `NPM_TOKEN`): re-installs node_modules (again with `--ignore-scripts`), downloads the dist artifact, runs `changesets/action`.

Workflow-level `permissions: {}` removes default token scope; each job opts in to only what it needs.

Even if `--ignore-scripts` ever regresses, the build job has neither `NPM_TOKEN` nor write access to the repo, so the historical exfil path (install-script to pivot to push malicious workflows or publish malicious versions) has no destination from the build job. The publish job, which has those credentials, never installs untrusted code with scripts active.

The duplicate `npm ci --ignore-scripts` in publish is intentional: changesets/action requires `node_modules`; re-installing with scripts off is safer than uploading a 200-500MB `node_modules` artifact that has workspace symlinks that may not round-trip cleanly. Cost is roughly 15s per publish run.

New actions pinned to commit SHAs per repo policy: `actions/upload-artifact@v7.0.1`, `actions/download-artifact@v8.0.1`. Both covered by the existing `actions/*` allowlist.

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A: workflow-only change. The required `ci` and `CodeQL` status checks will exercise the modified workflows on this PR. End-to-end publish-pipeline validation happens on the first merge to `main` after this PR.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A: internal CI tooling change, no published-package impact.