### PR TITLE
Migrate publish workflow to OIDC trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,8 @@ jobs:
           node-version: 22
           cache: npm
 
+      - run: npm install -g npm@11.5
+
       - run: npm ci --ignore-scripts
 
       - name: Download dist artifacts
@@ -75,5 +77,4 @@ jobs:
           publish: npm run publish
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

Replaces the long-lived `NPM_TOKEN` secret used by `changesets/action` with per-run OIDC token exchange ([npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)). After this lands and validates, no long-lived publishing credential exists anywhere; the OIDC token issued per workflow run lives roughly 15 minutes, cannot be exfiltrated for long-term use, and only authorizes publishing to packages whose Trusted Publisher config matches the originating workflow (`neilcochran/squawk` + `publish.yml`).

Two edits to `.github/workflows/publish.yml`'s publish job:

- Add `npm install -g npm@11.5` before `npm ci --ignore-scripts`. npm 11.5+ is required for OIDC token exchange; Node 22 ships with npm 10.x.
- Drop `NPM_TOKEN` from the `changesets/action` env block. The `id-token: write` permission already on the publish job (originally added for provenance) is what npm CLI auto-detects to exchange the GitHub OIDC token for a short-lived publish credential.

All 22 `@squawk/*` packages have Trusted Publisher entries configured on npm pointing at `neilcochran/squawk` + `publish.yml` (no environment). The "Publishing access" radio on each package is also set to "Require two-factor authentication and disallow tokens", which only blocks traditional access tokens; OIDC continues to work normally. Defense in depth: even if `NPM_TOKEN` were ever reissued by mistake, it could not publish.

Cleanup after validation (separate follow-up): delete the `NPM_TOKEN` repo secret and revoke the granular npm token issued 2026-05-12.

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A: workflow-only change. The required `ci` and `CodeQL` status checks will exercise the modified workflow on this PR; end-to-end OIDC publish validation happens on the first merge to `main` after this PR.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A: internal CI tooling change, no published-package impact.