### PR TITLE
Bump icao-registry-data to 0.8.9 to skip burned versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14139,7 +14139,7 @@
     },
     "packages/libs/icao-registry-data": {
       "name": "@squawk/icao-registry-data",
-      "version": "0.8.4",
+      "version": "0.8.9",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"

--- a/packages/libs/icao-registry-data/CHANGELOG.md
+++ b/packages/libs/icao-registry-data/CHANGELOG.md
@@ -1,11 +1,13 @@
 # @squawk/icao-registry-data
 
-## 0.8.4
+## 0.8.9
 
 ### Patch Changes
 
 - f7a97cd: ### Changed
   - Refreshed bundled FAA ReleasableAircraft snapshot to the 2026-05-14 release (312,706 records, up from 312,230).
+
+> Versions 0.8.4 through 0.8.8 were skipped. Those patch numbers were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.8.3 is 0.8.9.
 
 ## 0.8.3
 

--- a/packages/libs/icao-registry-data/package.json
+++ b/packages/libs/icao-registry-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/icao-registry-data",
-  "version": "0.8.4",
+  "version": "0.8.9",
   "type": "module",
   "description": "Pre-processed FAA ReleasableAircraft snapshot for use with @squawk/icao-registry",
   "author": "Neil Cochran",


### PR DESCRIPTION
## Summary

- Publish of `@squawk/icao-registry-data@0.8.4` (the version the bot bumped to from the [#260](https://github.com/neilcochran/squawk/pull/260) data refresh) failed with `E400 Cannot publish over previously published version 0.8.4`. Versions 0.8.4 - 0.8.8 are tombstoned on npm from the 2026-05-11 supply-chain incident cleanup; the registry permanently reserves unpublished version numbers. Manually bumps `package.json` to 0.8.9 (next clean patch) and renames the existing `## 0.8.4` CHANGELOG entry to `## 0.8.9` with a one-line skip note.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; version bump + CHANGELOG rename only.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; the data-refresh changeset was consumed by the prior Version Packages PR. This PR redirects the already-applied version bump from the burned 0.8.4 to 0.8.9.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->