### PR TITLE
Bump hono to 4.12.25 to clear four medium-severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8690,9 +8690,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Bumps `hono` from 4.12.18 to 4.12.25 in `package-lock.json` to resolve four medium-severity GitHub security advisories. `hono` is a transitive dependency (via `@modelcontextprotocol/sdk` and `@hono/node-server`) and is not declared directly in any `package.json`, so this is a lockfile-only change. The SDK's `^4.11.4` requirement and the `@hono/node-server` peer `^4` already permit 4.12.25, so no manifest or published dependency ranges change.

Resolved advisories (all fixed in 4.12.21):

| Advisory | Summary |
| --- | --- |
| GHSA-f577-qrjj-4474 (CVE-2026-47673) | JWT middleware accepts any Authorization scheme, not only Bearer |
| GHSA-xrhx-7g5j-rcj5 (CVE-2026-47674) | IP restriction deny rules bypassed by non-canonical IPv6 |
| GHSA-2gcr-mfcq-wcc3 (CVE-2026-47676) | `app.mount()` mis-routes percent-encoded paths using the undecoded prefix |
| GHSA-3hrh-pfw6-9m5x (CVE-2026-47675) | Cookie helper does not sanitize `sameSite`/`priority`, allowing Set-Cookie injection |

All four require hono's HTTP server features. `@squawk/mcp` connects only over `StdioServerTransport` and never loads hono's HTTP transport, so the vulnerable code paths are not reachable in squawk's current usage. This bump clears the alerts and keeps the version floor safe if an HTTP transport is ever added.

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; transitive lockfile-only dependency bump with no source change. `@squawk/mcp` build and full test suite (135 tests) pass unchanged.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; lockfile-only transitive bump. No `@squawk/*` package's published surface or declared dependency ranges change, so nothing publishes.
