### PR TITLE
Republish procedure-data at 0.7.8 (skip tombstoned versions)

### DIFF
--- a/packages/libs/procedure-data/CHANGELOG.md
+++ b/packages/libs/procedure-data/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @squawk/procedure-data
 
-## 0.7.3
+## 0.7.8
 
 ### Patch Changes
 
@@ -10,6 +10,8 @@
 
   ### Removed
   - The two KEWR GLS (GBAS) approaches carried in prior cycles (`J22L`, `J22R`) were discontinued by the FAA in this cycle and are no longer present.
+
+> Versions 0.7.3 through 0.7.7 were skipped. Those patch numbers were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.7.2 is 0.7.8.
 
 ## 0.7.2
 

--- a/packages/libs/procedure-data/package.json
+++ b/packages/libs/procedure-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/procedure-data",
-  "version": "0.7.3",
+  "version": "0.7.8",
   "type": "module",
   "description": "Pre-processed FAA CIFP procedure snapshot (SIDs, STARs, IAPs) for use with @squawk/procedures",
   "author": "Neil Cochran",


### PR DESCRIPTION
## Summary

- The 2026-06-11 publish run ([27505002571](https://github.com/neilcochran/squawk/actions/runs/27505002571)) failed to publish `@squawk/procedure-data`: the patch bump landed on `0.7.3`, a version tombstoned during the 2026-05-11 supply-chain cleanup, and npm refuses to reissue burned version numbers. The other six data packages from #292 published successfully.
- Bump `procedure-data` to `0.7.8`, the next clean version (0.7.3 through 0.7.7 are all tombstoned), so the publish workflow can ship the already-committed 2026-06-11 snapshot.
- No other package is affected: `@squawk/mcp` stays at 0.9.0 (its `^0.7.2` floor already covers 0.7.8, and with no pending changeset the publish runs `changeset publish` only, with no version step).

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; version bump and changelog note only, no code change.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; release-recovery version jump past tombstoned numbers (a changeset would compute another burned patch). The data refresh's changeset shipped in #292.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->