### PR TITLE
Sync package-lock.json to procedure-data 0.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14187,7 +14187,7 @@
     },
     "packages/libs/procedure-data": {
       "name": "@squawk/procedure-data",
-      "version": "0.7.3",
+      "version": "0.7.8",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"


### PR DESCRIPTION
## Summary

- Sync `package-lock.json` to `@squawk/procedure-data@0.7.8`. The bump in #294 updated `package.json` but not the lockfile, which still pins the tombstoned/malware-flagged `0.7.3` on `main` (Dependabot alert, GHSA-fjg7-hqrf-v48w).
- `npm ci` validates the dependency graph, not a workspace package's own `version` label, so the `package.json` (0.7.8) vs lockfile (0.7.3) mismatch passed CI undetected. This one-line change reconciles the lockfile, which clears the alert on `main` and lets the publish ship `procedure-data@0.7.8` (the clean 2026-06-11 snapshot - not the incident version).

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; lockfile reconciliation only, no source or test change.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; no version change here (`procedure-data` is already 0.7.8 on `main` from #294) - this only aligns the lockfile entry.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->