### PR TITLE
Bump 15 packages past tombstoned npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13912,7 +13912,7 @@
     },
     "packages/libs/airports": {
       "name": "@squawk/airports",
-      "version": "0.6.1",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
@@ -13928,7 +13928,7 @@
     },
     "packages/libs/airspace": {
       "name": "@squawk/airspace",
-      "version": "0.8.0",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
@@ -13973,7 +13973,7 @@
     },
     "packages/libs/airways": {
       "name": "@squawk/airways",
-      "version": "0.4.1",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"
@@ -14002,7 +14002,7 @@
     },
     "packages/libs/fixes": {
       "name": "@squawk/fixes",
-      "version": "0.3.1",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
@@ -14018,7 +14018,7 @@
     },
     "packages/libs/flight-math": {
       "name": "@squawk/flight-math",
-      "version": "0.5.3",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
         "@squawk/units": "^0.4.2"
@@ -14029,7 +14029,7 @@
     },
     "packages/libs/flightplan": {
       "name": "@squawk/flightplan",
-      "version": "0.5.1",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
@@ -14054,7 +14054,7 @@
     },
     "packages/libs/geo": {
       "name": "@squawk/geo",
-      "version": "0.4.3",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0",
@@ -14070,7 +14070,7 @@
     },
     "packages/libs/icao-registry": {
       "name": "@squawk/icao-registry",
-      "version": "0.5.1",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0",
@@ -14100,7 +14100,7 @@
     },
     "packages/libs/mcp": {
       "name": "@squawk/mcp",
-      "version": "0.9.0",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -14160,7 +14160,7 @@
     },
     "packages/libs/navaids": {
       "name": "@squawk/navaids",
-      "version": "0.4.1",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
@@ -14176,7 +14176,7 @@
     },
     "packages/libs/notams": {
       "name": "@squawk/notams",
-      "version": "0.3.5",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"
@@ -14201,7 +14201,7 @@
     },
     "packages/libs/procedures": {
       "name": "@squawk/procedures",
-      "version": "0.5.1",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"
@@ -14216,7 +14216,7 @@
     },
     "packages/libs/types": {
       "name": "@squawk/types",
-      "version": "0.8.0",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.16"
@@ -14230,7 +14230,7 @@
     },
     "packages/libs/units": {
       "name": "@squawk/units",
-      "version": "0.4.2",
+      "version": "0.4.8",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.9.3"
@@ -14241,7 +14241,7 @@
     },
     "packages/libs/weather": {
       "name": "@squawk/weather",
-      "version": "0.5.5",
+      "version": "0.5.11",
       "license": "MIT",
       "dependencies": {
         "@squawk/types": "^0.8.0"

--- a/packages/libs/airports/CHANGELOG.md
+++ b/packages/libs/airports/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/airports
 
+## 0.6.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.6.2 through 0.6.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.6.1 is 0.6.7.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/libs/airports/package.json
+++ b/packages/libs/airports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/airports",
-  "version": "0.6.1",
+  "version": "0.6.7",
   "type": "module",
   "description": "Pure logic library for querying US airport data by identifier, location, or name",
   "author": "Neil Cochran",

--- a/packages/libs/airspace/CHANGELOG.md
+++ b/packages/libs/airspace/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/airspace
 
+## 0.8.6
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.8.1 through 0.8.5 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.8.0 is 0.8.6.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/libs/airspace/package.json
+++ b/packages/libs/airspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/airspace",
-  "version": "0.8.0",
+  "version": "0.8.6",
   "type": "module",
   "description": "Pure logic library for querying US airspace geometry by position and altitude",
   "author": "Neil Cochran",

--- a/packages/libs/airways/CHANGELOG.md
+++ b/packages/libs/airways/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/airways
 
+## 0.4.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.4.2 through 0.4.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.4.1 is 0.4.7.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/libs/airways/package.json
+++ b/packages/libs/airways/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/airways",
-  "version": "0.4.1",
+  "version": "0.4.7",
   "type": "module",
   "description": "Airway lookup, traversal, and expansion by designation, fix, or search",
   "author": "Neil Cochran",

--- a/packages/libs/fixes/CHANGELOG.md
+++ b/packages/libs/fixes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/fixes
 
+## 0.3.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.3.2 through 0.3.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.3.1 is 0.3.7.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/libs/fixes/package.json
+++ b/packages/libs/fixes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/fixes",
-  "version": "0.3.1",
+  "version": "0.3.7",
   "type": "module",
   "description": "Fix/waypoint queries by identifier, location, or name search",
   "author": "Neil Cochran",

--- a/packages/libs/flight-math/CHANGELOG.md
+++ b/packages/libs/flight-math/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/flight-math
 
+## 0.5.9
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.5.4 through 0.5.8 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.5.3 is 0.5.9.
+
 ## 0.5.3
 
 ### Patch Changes

--- a/packages/libs/flight-math/package.json
+++ b/packages/libs/flight-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/flight-math",
-  "version": "0.5.3",
+  "version": "0.5.9",
   "type": "module",
   "description": "Aviation flight computer calculations - the programmatic equivalent of an E6B",
   "author": "Neil Cochran",

--- a/packages/libs/flightplan/CHANGELOG.md
+++ b/packages/libs/flightplan/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/flightplan
 
+## 0.5.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.5.2 through 0.5.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.5.1 is 0.5.7.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/libs/flightplan/package.json
+++ b/packages/libs/flightplan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/flightplan",
-  "version": "0.5.1",
+  "version": "0.5.7",
   "type": "module",
   "description": "Flight plan route string parsing and resolution using composed navigation resolvers",
   "author": "Neil Cochran",

--- a/packages/libs/geo/CHANGELOG.md
+++ b/packages/libs/geo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/geo
 
+## 0.4.9
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.4.4 through 0.4.8 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.4.3 is 0.4.9.
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/libs/geo/package.json
+++ b/packages/libs/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/geo",
-  "version": "0.4.3",
+  "version": "0.4.9",
   "type": "module",
   "description": "Geospatial utilities: great-circle distance, bearing, midpoint, destination point, and polygon containment",
   "author": "Neil Cochran",

--- a/packages/libs/icao-registry/CHANGELOG.md
+++ b/packages/libs/icao-registry/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/icao-registry
 
+## 0.5.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.5.2 through 0.5.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.5.1 is 0.5.7.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/libs/icao-registry/package.json
+++ b/packages/libs/icao-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/icao-registry",
-  "version": "0.5.1",
+  "version": "0.5.7",
   "type": "module",
   "description": "FAA ICAO hex address to aircraft registration and info lookup",
   "author": "Neil Cochran",

--- a/packages/libs/mcp/CHANGELOG.md
+++ b/packages/libs/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/mcp
 
+## 0.9.6
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.9.1 through 0.9.5 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.9.0 is 0.9.6.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.9.0"]
+      "args": ["-y", "@squawk/mcp@0.9.6"]
     }
   }
 }
@@ -164,7 +164,7 @@ Pinning works the same way:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "-p", "@squawk/icao-registry-data@0.8.10", "@squawk/mcp@0.9.0"]
+      "args": ["-y", "-p", "@squawk/icao-registry-data@0.8.10", "@squawk/mcp@0.9.6"]
     }
   }
 }

--- a/packages/libs/mcp/package.json
+++ b/packages/libs/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/mcp",
-  "version": "0.9.0",
+  "version": "0.9.6",
   "type": "module",
   "description": "Model Context Protocol server exposing squawk's aviation libraries as tools for LLM clients",
   "author": "Neil Cochran",

--- a/packages/libs/navaids/CHANGELOG.md
+++ b/packages/libs/navaids/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/navaids
 
+## 0.4.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.4.2 through 0.4.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.4.1 is 0.4.7.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/libs/navaids/package.json
+++ b/packages/libs/navaids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/navaids",
-  "version": "0.4.1",
+  "version": "0.4.7",
   "type": "module",
   "description": "Navaid queries by identifier, frequency, type, location, or name search",
   "author": "Neil Cochran",

--- a/packages/libs/notams/CHANGELOG.md
+++ b/packages/libs/notams/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/notams
 
+## 0.3.11
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.3.6 through 0.3.10 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.3.5 is 0.3.11.
+
 ## 0.3.5
 
 ### Patch Changes

--- a/packages/libs/notams/package.json
+++ b/packages/libs/notams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/notams",
-  "version": "0.3.5",
+  "version": "0.3.11",
   "type": "module",
   "description": "Parse raw ICAO-format NOTAM strings into fully typed, structured objects",
   "author": "Neil Cochran",

--- a/packages/libs/procedures/CHANGELOG.md
+++ b/packages/libs/procedures/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/procedures
 
+## 0.5.7
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.5.2 through 0.5.6 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.5.1 is 0.5.7.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/libs/procedures/package.json
+++ b/packages/libs/procedures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/procedures",
-  "version": "0.5.1",
+  "version": "0.5.7",
   "type": "module",
   "description": "Instrument procedure lookup and expansion for SIDs, STARs, and Instrument Approach Procedures (IAPs)",
   "author": "Neil Cochran",

--- a/packages/libs/types/CHANGELOG.md
+++ b/packages/libs/types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/types
 
+## 0.8.6
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.8.1 through 0.8.5 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.8.0 is 0.8.6.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/types",
-  "version": "0.8.0",
+  "version": "0.8.6",
   "type": "module",
   "description": "Shared TypeScript type definitions for the @squawk aviation libraries",
   "author": "Neil Cochran",

--- a/packages/libs/units/CHANGELOG.md
+++ b/packages/libs/units/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/units
 
+## 0.4.8
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.4.3 through 0.4.7 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.4.2 is 0.4.8.
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/libs/units/package.json
+++ b/packages/libs/units/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/units",
-  "version": "0.4.2",
+  "version": "0.4.8",
   "type": "module",
   "description": "Aviation-aware unit conversion and formatting utilities",
   "author": "Neil Cochran",

--- a/packages/libs/weather/CHANGELOG.md
+++ b/packages/libs/weather/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @squawk/weather
 
+## 0.5.11
+
+### Changed
+
+- Administrative release to skip npm-tombstoned version numbers. No functional or API changes.
+
+> Versions 0.5.6 through 0.5.10 were tombstoned by npm during cleanup of the 2026-05-11 supply-chain incident (see [pinned Announcements discussion](https://github.com/neilcochran/squawk/discussions/251)) and cannot be republished. The next clean patch after 0.5.5 is 0.5.11.
+
 ## 0.5.5
 
 ### Patch Changes

--- a/packages/libs/weather/package.json
+++ b/packages/libs/weather/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squawk/weather",
-  "version": "0.5.5",
+  "version": "0.5.11",
   "type": "module",
   "description": "Parse raw aviation weather strings (METAR, SPECI, TAF, SIGMET, AIRMET, PIREP) into structured objects",
   "author": "Neil Cochran",


### PR DESCRIPTION
## Summary

- Every non-data `@squawk/*` package still sat on a pre-incident version whose next patch number was tombstoned during the 2026-05-11 supply-chain cleanup. The next real release of any of them would have failed to publish (`E400 Cannot publish over previously published version`) and raised a malware Dependabot alert - exactly what `@squawk/procedure-data` just hit.
- Bumps all 15 past their burned ranges to the next clean version, each with a changelog note documenting the skipped range. These are administrative version jumps with **no functional or API changes**.
- Not changesets: a changeset would compute the next sequential version, which is also tombstoned. These are direct `package.json` bumps; on merge, `changeset publish` ships them as no-op releases. `@squawk/mcp` README pin updated to `0.9.6`; `package-lock.json` reconciled (15 version entries, no other churn).

Version jumps: airports 0.6.1->0.6.7, airspace 0.8.0->0.8.6, airways 0.4.1->0.4.7, fixes 0.3.1->0.3.7, flight-math 0.5.3->0.5.9, flightplan 0.5.1->0.5.7, geo 0.4.3->0.4.9, icao-registry 0.5.1->0.5.7, mcp 0.9.0->0.9.6, navaids 0.4.1->0.4.7, notams 0.3.5->0.3.11, procedures 0.5.1->0.5.7, types 0.8.0->0.8.6, units 0.4.2->0.4.8, weather 0.5.5->0.5.11.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; version, changelog, and lockfile only - no source change.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; deliberate manual version jumps past npm-tombstoned numbers (a changeset would compute the next sequential, also-burned version). On merge, `changeset publish` ships these as no-op releases.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->