### PR TITLE
Add GitLab mirror workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,38 @@
+name: Mirror to GitLab
+
+# Reflects this repo (all branches and tags) onto the GitLab backup mirror.
+# Runs on every push for immediacy, plus a daily schedule as a safety net for
+# changes made on GitHub directly (e.g. PRs merged in the web UI).
+on:
+  push:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-to-gitlab
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror-clone from GitHub
+        run: >
+          git clone --mirror
+          "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          repo.git
+
+      - name: Push to GitLab
+        working-directory: repo.git
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        # Push branches and tags only (not --mirror): GitHub exposes refs/pull/*
+        # PR refs that GitLab refuses. --prune deletes branches/tags on GitLab
+        # that no longer exist on GitHub, keeping it an exact branch + tag mirror.
+        run: |
+          git push --prune "https://oauth2:${GITLAB_TOKEN}@gitlab.com/neilcochran/squawk.git" \
+            "+refs/heads/*:refs/heads/*" "+refs/tags/*:refs/tags/*"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -182,7 +182,7 @@ CodeQL runs as a separate workflow; it's a required check on `main`.
 
 ## CI/CD overview
 
-Five workflows in [.github/workflows/](.github/workflows/). Every `uses:` is a full commit SHA pinned with a trailing version comment, maintained by Dependabot.
+Six workflows in [.github/workflows/](.github/workflows/). Every `uses:` is a full commit SHA pinned with a trailing version comment, maintained by Dependabot.
 
 | Workflow                                     | Trigger                                                 | Purpose                                                                                |
 | -------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------- |
@@ -191,6 +191,7 @@ Five workflows in [.github/workflows/](.github/workflows/). Every `uses:` is a f
 | [lychee.yml](.github/workflows/lychee.yml)   | PR (paths-filtered to `**/*.md`) + weekly cron + manual | Markdown link checker. Report-only; surfaces broken links in the job summary.          |
 | [docs.yml](.github/workflows/docs.yml)       | After CI succeeds on `main`                             | Generate TypeDoc and deploy to GitHub Pages.                                           |
 | [publish.yml](.github/workflows/publish.yml) | After CI succeeds on `main` + manual                    | Run the changesets-driven release flow (see next section).                             |
+| [mirror.yml](.github/workflows/mirror.yml)   | Every push + daily cron + manual                        | Mirror all branches and tags to the GitLab backup mirror. Uses no marketplace actions. |
 
 A few non-obvious properties of these workflows that the YAML doesn't make immediately clear:
 


### PR DESCRIPTION
## Summary

Adds a `mirror.yml` workflow that reflects this repository onto the GitLab backup at `gitlab.com/neilcochran/squawk`. It mirror-clones from GitHub and force-pushes `refs/heads/*` and `refs/tags/*` with `--prune`, keeping GitLab an exact branch-and-tag copy. It runs on every push (for immediacy), a daily cron (safety net for changes made directly on GitHub, e.g. PRs merged in the web UI), and manual dispatch.

The job runs only `git` on the runner with no marketplace actions, so it needs no Actions-allowlist entry or SHA pin. Auth uses the built-in `github.token` for the read-side clone and a `GITLAB_TOKEN` repository secret for the push.

The ARCHITECTURE.md CI/CD table is updated to list the new workflow.

## Related issue

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; this adds a GitHub Actions workflow plus a documentation table row, neither of which is unit-testable.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; CI tooling and docs only, no published `@squawk/*` package is affected.
