### PR TITLE
Demote and trim README security notice a month after the incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 TypeScript libraries for building aviation applications - airspace geometry, weather parsing, flight planning, aircraft registry lookup, and more.
 
-> [!IMPORTANT]
-> **Security Notice (2026-05-11):** All `@squawk/*` packages were targeted by the mini-Shai-Hulud npm supply-chain compromise. All malicious versions have been removed from npm and `latest` dist-tags point at clean versions; new installs are safe. See the [full incident report](https://github.com/neilcochran/squawk/discussions/251) for the timeline, affected version list, and remediation details.
+> [!NOTE]
+> **Security Notice (2026-05-11):** A mini-Shai-Hulud npm supply-chain attack affected some `@squawk/*` versions; malicious versions have been pulled and new installs are safe. If you have an older version pinned, check it against the affected-version list in the [incident report](https://github.com/neilcochran/squawk/discussions/251).
 
 **[Documentation](https://neilcochran.github.io/squawk/)**
 


### PR DESCRIPTION
## Summary

- The 2026-05-11 mini-Shai-Hulud incident notice was a top-of-README `[!IMPORTANT]` banner. A month on, with remediation complete and new installs safe, it no longer warrants front-page prominence.
- Demotes it to a quieter `[!NOTE]` and trims it to a single pointer to the [incident report](https://github.com/neilcochran/squawk/discussions/251) for anyone still running a pinned affected version. The full timeline and remediation details remain there.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; docs-only README edit, no code or test surface touched.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; root README edit, no published `@squawk/*` package affected.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->