### PR TITLE
Add 7-day release-age cooldown for dependency updates and installs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
     groups:
       dev-dependencies:
         dependency-type: development
@@ -27,6 +29,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Supply-chain cooldown: do not resolve onto a dependency version published
+# less than 7 days ago, giving a malicious publish time to be detected and
+# yanked. Mirrors the Dependabot cooldown for the local `npm install` path.
+# Requires npm >= 11.10.0 (older npm ignores it); no-op for `npm ci`.
+# Override a single install with `npm install <pkg> --min-release-age=0`.
+min-release-age=7

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,10 +288,14 @@ Two GitHub Rulesets target `main`:
 
 ## Dependency management
 
-[Dependabot](.github/dependabot.yml) runs weekly on two ecosystems:
+[Dependabot](.github/dependabot.yml) runs daily on two ecosystems:
 
-- **npm** - one PR per package, `open-pull-requests-limit: 20` so backlog flushes (e.g. after a `dependabot.yml` edit) don't get truncated to the default cap of 5.
-- **github-actions** - all action SHA bumps grouped into one PR per week, since dribbling them out individually is noise.
+- **npm** - patch and minor updates grouped into `dev-dependencies` and `production-dependencies` PRs; majors open per package. `open-pull-requests-limit: 20` so backlog flushes (e.g. after a `dependabot.yml` edit) don't get truncated to the default cap of 5.
+- **github-actions** - all action SHA bumps grouped into one PR, since dribbling them out individually is noise.
+
+Both ecosystems carry a 7-day `cooldown`: Dependabot withholds an update until the release is at least a week old, giving a malicious publish time to be detected and yanked before it can reach a PR. Security updates are exempt from the cooldown and still open immediately.
+
+The same window is enforced at install time by `min-release-age=7` in the root [.npmrc](.npmrc): npm 11.10+ refuses to resolve onto a dependency version published less than a week ago, covering the manual `npm install` path on a developer machine that the Dependabot cooldown does not reach. It is a no-op for `npm ci` (which installs the locked tree without resolving) and is silently ignored by older npm, so CI and the publish flow are unaffected. A single install can opt out with `npm install <pkg> --min-release-age=0`.
 
 Every workflow `uses:` is a full commit SHA followed by a trailing `# v<x.y.z>` comment. Dependabot keeps both in sync; manual edits to one without the other drift the comment from the SHA.
 
@@ -302,7 +306,7 @@ Every workflow `uses:` is a full commit SHA followed by a trailing `# v<x.y.z>` 
 Findings reach the repo through three channels:
 
 - **CodeQL** - PR + push to `main` + weekly cron (`.github/workflows/codeql.yml`). Required check on `main`.
-- **Dependabot vulnerability alerts** - native GitHub feature, opens PRs for vulnerable transitive deps alongside the regular weekly update cycle.
+- **Dependabot vulnerability alerts** - native GitHub feature, opens PRs for vulnerable transitive deps alongside the regular daily update cycle.
 - **Manual issue tracking** - the security-finding template at [.github/ISSUE_TEMPLATE/security-finding.md](.github/ISSUE_TEMPLATE/security-finding.md).
 
 Published packages ship with npm provenance attestations: the Publish workflow sets `NPM_CONFIG_PROVENANCE: true` and grants `id-token: write`, so each tarball on npm carries a verifiable link back to the GitHub Actions run that produced it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ npm run build
 
 Node `>=22` and npm `11` are required. The repo is an npm-workspaces monorepo orchestrated by Turborepo.
 
+The root [.npmrc](.npmrc) sets `min-release-age=7`, a supply-chain cooldown: npm 11.10+ will not install a dependency version published less than a week ago. If you intentionally need a freshly published version, override it for that one command with `npm install <pkg> --min-release-age=0`. Older npm ignores the setting.
+
 ## Orientation
 
 Before opening a non-trivial PR, skim:


### PR DESCRIPTION
## Summary

- Adds a 7-day release-age cooldown for dependencies, so a newly published version is not adopted until it has had a week to be vetted - defense-in-depth against malicious-publish supply-chain attacks.
- Dependabot (`cooldown: default-days: 7` on both the npm and github-actions entries) holds update PRs until a release is at least a week old. Security updates are exempt and still open immediately.
- Root `.npmrc` (`min-release-age=7`) extends the same window to the local `npm install` path that the Dependabot cooldown does not reach. It is a no-op for `npm ci` and ignored by npm < 11.10.0, so CI and the publish flow are unaffected.
- Documents both layers in ARCHITECTURE.md (with a `--min-release-age=0` override note in CONTRIBUTING.md) and corrects stale wording: Dependabot runs daily, and npm bumps are grouped by dev/prod for patch/minor with majors opening individually.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; the change is Dependabot config, a root `.npmrc`, and Markdown docs - no testable code paths.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; internal tooling/config and documentation only, no published `@squawk/*` package changed.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->