### PR TITLE
Resume Dependabot @tanstack/* updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,6 @@ updates:
         update-types:
           - patch
           - minor
-    # Pause @tanstack/* updates while the 2026-05-11 npm supply-chain
-    # compromise of those packages is being resolved upstream. Remove
-    # this entry once clean versions are confirmed and the lockfile has
-    # been re-pinned.
-    # Tracking: https://github.com/TanStack/router/issues/7383
-    ignore:
-      - dependency-name: '@tanstack/*'
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

- Removes the `@tanstack/*` `ignore` rule from `.github/dependabot.yml`, added 2026-05-11 to pause updates during the npm supply-chain compromise of those packages.
- Upstream is remediated: the malicious versions were deprecated and pulled from npm, TanStack confirms every currently-published version is safe, and our lockfile is already on clean pre-compromise releases.
- Resulting `@tanstack/*` update PRs stay gated by the existing 7-day `cooldown` and normal review before merge.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; removes a Dependabot `ignore` rule in CI config, which has no test surface.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; CI tooling only (`.github/dependabot.yml`); no published `@squawk/*` package is affected.