### PR TITLE
Block dependency install scripts via .npmrc ignore-scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
+# Supply-chain hardening: never run dependency install/lifecycle scripts, so a
+# compromised (transitive) package can't fire a postinstall hook. CI mirrors this
+# with `npm ci --ignore-scripts`.
+ignore-scripts=true
+
 # Supply-chain cooldown: do not resolve onto a dependency version published
 # less than 7 days ago, giving a malicious publish time to be detected and
 # yanked. Mirrors the Dependabot cooldown for the local `npm install` path.

--- a/apps/atlas/package.json
+++ b/apps/atlas/package.json
@@ -20,8 +20,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "prebuild": "tsr generate",
-    "build": "tsc -b && vite build",
+    "build": "tsr generate && tsc -b && vite build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

Sets `ignore-scripts=true` in `.npmrc` so npm never runs dependency install/lifecycle hooks (e.g. `postinstall`) on local installs. A compromised or malicious transitive package can no longer execute arbitrary code at install time. This completes the supply-chain pair alongside the existing `min-release-age=7` cooldown; CI already enforces the same protection via `npm ci --ignore-scripts`.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

N/A - maintainer-driven tooling change; no related issue.

## Checklist

- [x] Tests added or updated (or N/A - explain why) - N/A: `.npmrc` config change, no testable code paths.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling) - N/A: repo tooling only, no published `@squawk/*` package affected.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->