### PR TITLE
Update Atlas basemap to use the Protomaps Hosted API

### DIFF
--- a/apps/atlas/README.md
+++ b/apps/atlas/README.md
@@ -5,7 +5,7 @@
 The official Squawk viewer - a chart-first web app for browsing aeronautical data, built on the [@squawk/\*](https://github.com/neilcochran/squawk) packages.
 
 > [!NOTE]
-> Atlas is functional but not polished. Chart mode is the first mode and currently the only one shipped. Rough edges remain (the basemap is hosted on Protomaps' public dev bucket, some camera artifacts are unsmoothed at high pitch, mobile copy is still being tuned).
+> Atlas is functional but not polished. Chart mode is the first mode and currently the only one shipped. Rough edges remain (some camera artifacts are unsmoothed at high pitch, mobile copy is still being tuned).
 
 ## Chart mode
 
@@ -43,16 +43,26 @@ Data flows through the data packages' `/browser` entries, which use `fetch` + `D
 - TanStack Router with file-based routes and zod-validated URL search params
 - Tailwind CSS v4
 - MapLibre GL via `@vis.gl/react-maplibre`
-- Protomaps + PMTiles for basemap tiles
+- Protomaps hosted vector tiles for the basemap
 - Radix UI primitives (dropdown menus)
 - Vitest + jsdom + `@testing-library/react`
 
 ## Local development
 
+The basemap tiles come from the [Protomaps Hosted API](https://protomaps.com/api), which requires an API key. Create a free key and restrict its allowed CORS origins to `http://localhost:5173` (the Vite dev server), then provide it via a `VITE_PROTOMAPS_API_KEY` environment variable. The simplest place is a local `apps/atlas/.env.local` file (gitignored):
+
+```sh
+VITE_PROTOMAPS_API_KEY=your_key_here
+```
+
+Then install dependencies and start the dev server:
+
 ```sh
 npm install
 npm run dev
 ```
+
+Without a key the app still runs and the chart overlays render, but the basemap stays blank.
 
 ## Scripts
 

--- a/apps/atlas/package.json
+++ b/apps/atlas/package.json
@@ -45,7 +45,6 @@
     "@tanstack/react-router": "^1.168.24",
     "@vis.gl/react-maplibre": "^8.1.1",
     "maplibre-gl": "^5.24.0",
-    "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "zod": "^4.4.3"

--- a/apps/atlas/src/shared/map/map-canvas.tsx
+++ b/apps/atlas/src/shared/map/map-canvas.tsx
@@ -1,9 +1,7 @@
 import { layers, namedFlavor } from '@protomaps/basemaps';
 import { Map, useMap } from '@vis.gl/react-maplibre';
 import type { MapLayerMouseEvent, ViewStateChangeEvent } from '@vis.gl/react-maplibre';
-import maplibregl from 'maplibre-gl';
 import type { StyleSpecification } from 'maplibre-gl';
-import { Protocol } from 'pmtiles';
 import type { ReactElement, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -19,23 +17,24 @@ import type { ResolvedTheme } from '../styles/theme-context.ts';
  */
 const ATLAS_LAYER_ID_PREFIX = 'atlas-';
 
-maplibregl.addProtocol('pmtiles', new Protocol().tile);
+/**
+ * Protomaps Hosted API key for the basemap tile source, read from the
+ * `VITE_PROTOMAPS_API_KEY` build-time env var. Supplied per environment:
+ * a localhost-restricted key in a gitignored local env file for `npm run
+ * dev`, and a deploy-injected key in production. When unset, the basemap
+ * tile requests are rejected and the basemap renders blank - the chart
+ * overlays still draw.
+ */
+const PROTOMAPS_API_KEY = import.meta.env.VITE_PROTOMAPS_API_KEY ?? '';
 
 /**
- * Protomaps' public dev demo PMTiles bucket - no API key required, but
- * rate-limited and intended for development only. Used as a fallback
- * when {@link PMTILES_URL} is not set, so local `npm run dev` works
- * without any env configuration.
+ * TileJSON URL for the Protomaps Hosted API basemap source. MapLibre
+ * fetches this document to resolve the vector tile template, zoom range,
+ * and attribution; the key is passed as a query parameter. The hosted API
+ * serves the v4 tile schema, which matches the layer set emitted by
+ * `@protomaps/basemaps` `layers()`.
  */
-const PROTOMAPS_DEMO_PMTILES = 'pmtiles://https://demo-bucket.protomaps.com/v4.pmtiles';
-
-/**
- * Resolved PMTiles URL for the basemap source. Reads from the
- * `VITE_PMTILES_URL` build-time env var (set in the production deploy
- * to point at a self-hosted PMTiles file or Protomaps' commercial CDN)
- * and falls back to {@link PROTOMAPS_DEMO_PMTILES} when unset.
- */
-const PMTILES_URL = import.meta.env.VITE_PMTILES_URL ?? PROTOMAPS_DEMO_PMTILES;
+const PROTOMAPS_TILEJSON_URL = `https://api.protomaps.com/tiles/v4.json?key=${PROTOMAPS_API_KEY}`;
 
 const PROTOMAPS_GLYPHS =
   'https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf';
@@ -84,7 +83,7 @@ function buildMapStyle(theme: ResolvedTheme): StyleSpecification {
     sources: {
       protomaps: {
         type: 'vector',
-        url: PMTILES_URL,
+        url: PROTOMAPS_TILEJSON_URL,
         attribution:
           '<a href="https://openstreetmap.org/copyright">© OpenStreetMap</a> · <a href="https://protomaps.com">Protomaps</a>',
       },

--- a/apps/atlas/src/vite-env.d.ts
+++ b/apps/atlas/src/vite-env.d.ts
@@ -2,12 +2,13 @@
 
 interface ImportMetaEnv {
   /**
-   * PMTiles URL for the basemap source, set in the production deploy to
-   * point at a self-hosted PMTiles file or Protomaps' commercial CDN.
-   * When unset (e.g. during `npm run dev`), the map falls back to
-   * Protomaps' public demo bucket.
+   * Protomaps Hosted API key for the basemap tile source. Supplied per
+   * environment - a localhost-restricted key in a gitignored local env
+   * file for `npm run dev`, and a deploy-injected key in production. When
+   * unset, basemap tile requests are rejected and the basemap renders
+   * blank (chart overlays are unaffected).
    */
-  readonly VITE_PMTILES_URL?: string;
+  readonly VITE_PROTOMAPS_API_KEY?: string;
 }
 
 interface ImportMeta {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "@tanstack/react-router": "^1.168.24",
         "@vis.gl/react-maplibre": "^8.1.1",
         "maplibre-gl": "^5.24.0",
-        "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "zod": "^4.4.3"
@@ -7921,6 +7920,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -10889,15 +10889,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
-      }
-    },
-    "node_modules/pmtiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.1.tgz",
-      "integrity": "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "fflate": "^0.8.2"
       }
     },
     "node_modules/point-in-polygon-hao": {


### PR DESCRIPTION
## Summary

- The Protomaps public PMTiles demo bucket the basemap pointed at was permanently removed (tile requests 404'd), and Protomaps discourages hotlinking it. This migrates the basemap to the supported Protomaps Hosted API (key-based TileJSON at `api.protomaps.com/tiles/v4.json`).
- The key is read at build time from a new `VITE_PROTOMAPS_API_KEY` env var (replacing `VITE_PMTILES_URL`). It is a public, origin-restricted key that ships in the client bundle, so CORS origin restriction rather than secrecy is what protects it; see the Atlas README for local setup.
- Removes the now-unused `pmtiles` dependency and its protocol registration.
- With no key set, the app still runs and chart overlays render - only the basemap is blank. CI needs no key: the build tolerates a missing value and the tests mock the map.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; no new logic, just an env-driven swap of the basemap tile-source URL. The existing map tests mock the map and the full suite (527 tests) still passes; basemap tile load was verified manually in the dev server.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; `apps/atlas` is `private: true` and not published.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->