### PR TITLE
Add chart feature search to Atlas with score-ranked results

### DIFF
--- a/apps/atlas/README.md
+++ b/apps/atlas/README.md
@@ -25,6 +25,8 @@ An interactive aeronautical map of the US. The data comes from the bundled `@squ
 
 **Entity inspector** opens on selection - right-side panel on desktop, bottom sheet on mobile. Per-type renderers cover airport, navaid, fix, airway, and airspace. An "Also here" chip strip lets the user switch between stacked features without re-clicking the map. Hovering a chip pans the camera so the picked feature stays visible behind the inspector.
 
+**Feature search** - a floating search box (top-left) fuzzy-matches across every visible feature type at once (airports, navaids, fixes, airways, airspace), ranking results by match score as the user types. Each result row is badged with its feature kind and emphasizes the matched characters. A filter menu narrows the search to specific types / subtypes (mirroring the Layers menu), and an include-hidden toggle widens it to features the Layers menu is currently hiding. Choosing a result frames the feature in the camera - zooming in to a useful level for a point feature, or fitting the whole bounding box for an airway or airspace - opens the inspector, and reveals whatever layer (and airway category or airspace class) is needed to actually draw it. The box is a fully keyboard-driven ARIA combobox: arrow keys move the active row, Enter selects, Escape clears.
+
 **URL-driven state** - map view (lat/lon/zoom/pitch), active layer set, airspace classes, airway categories, and the selected entity all live in the URL. Stale share-links with unknown values fall back to defaults rather than erroring.
 
 **Theme switcher** - light, dark, or follow OS, persisted in `localStorage`.

--- a/apps/atlas/src/modes/chart/chart-mode.spec.tsx
+++ b/apps/atlas/src/modes/chart/chart-mode.spec.tsx
@@ -8,6 +8,12 @@ import { AIRSPACE_FILL_LAYER_ID, AIRSPACE_LINE_LAYER_ID } from './layers/airspac
 import { AIRWAYS_LAYER_ID } from './layers/airways-layer.tsx';
 import { FIXES_LAYER_ID } from './layers/fixes-layer.tsx';
 import { NAVAIDS_LAYER_ID } from './layers/navaids-layer.tsx';
+import type {
+  AirspaceChartSearchResult,
+  AirwayChartSearchResult,
+  ChartSearchResult,
+  NavaidChartSearchResult,
+} from './search/search-features.ts';
 import type { ChartSearch } from './url-state.ts';
 
 /**
@@ -31,6 +37,13 @@ interface DisambiguationProps {
   onDismiss: () => void;
 }
 const disambiguationRef: { current: DisambiguationProps | undefined } = {
+  current: undefined,
+};
+
+interface SearchBoxMockProps {
+  onSelectResult: (result: ChartSearchResult) => void;
+}
+const searchBoxRef: { current: SearchBoxMockProps | undefined } = {
   current: undefined,
 };
 
@@ -92,6 +105,12 @@ vi.mock('./highlight-provider.tsx', () => ({
 vi.mock('./inspectable-cursor.tsx', () => ({ InspectableHoverCursor: () => null }));
 vi.mock('./view-reset-listener.tsx', () => ({ ChartViewResetListener: () => null }));
 vi.mock('./layer-toggle.tsx', () => ({ LayerToggle: () => null }));
+vi.mock('./search/search-box.tsx', () => ({
+  SearchBox: (props: SearchBoxMockProps): ReactElement => {
+    searchBoxRef.current = props;
+    return <div data-testid="search-box" />;
+  },
+}));
 vi.mock('./layers/airports-layer.tsx', async (importOriginal) => {
   const actual = (await importOriginal()) as typeof import('./layers/airports-layer.tsx');
   return { ...actual, AirportsLayer: () => null };
@@ -138,6 +157,59 @@ const DEFAULT_SEARCH: ChartSearch = {
     'ARTCC',
   ],
   airwayCategories: ['LOW', 'HIGH', 'OCEANIC'],
+  searchLayers: ['airports', 'navaids', 'fixes', 'airways', 'airspace'],
+  searchAirspaceClasses: [
+    'CLASS_B',
+    'CLASS_C',
+    'CLASS_D',
+    'CLASS_E',
+    'MOA',
+    'RESTRICTED',
+    'PROHIBITED',
+    'WARNING',
+    'ALERT',
+    'NSA',
+    'ARTCC',
+  ],
+  searchAirwayCategories: ['LOW', 'HIGH', 'OCEANIC'],
+  searchIncludeHidden: false,
+};
+
+/** Shared base for the search-result fixtures; per-kind objects override the discriminant fields. */
+const searchResultBase = {
+  label: 'X',
+  sublabel: undefined,
+  matchedText: 'X',
+  ranges: [],
+  score: 1,
+  center: { lng: -71, lat: 42 },
+  hidden: true,
+};
+
+const navaidResult: NavaidChartSearchResult = {
+  ...searchResultBase,
+  kind: 'navaid',
+  subtype: 'VOR',
+  matchedField: 'identifier',
+  selection: 'navaid:BOS',
+};
+
+const airspaceResult: AirspaceChartSearchResult = {
+  ...searchResultBase,
+  kind: 'airspace',
+  subtype: 'CLASS_B',
+  matchedField: 'identifier',
+  selection: 'airspace:CLASS_B/KBOS',
+  bbox: { minLon: -71, maxLon: -70, minLat: 42, maxLat: 43 },
+};
+
+const airwayResult: AirwayChartSearchResult = {
+  ...searchResultBase,
+  kind: 'airway',
+  subtype: 'VICTOR',
+  matchedField: 'designation',
+  selection: 'airway:V16',
+  bbox: { minLon: -71, maxLon: -70, minLat: 42, maxLat: 43 },
 };
 
 /**
@@ -379,6 +451,64 @@ describe('ChartMode', () => {
     expect(navigateMock).toHaveBeenCalledTimes(1);
     const search = navigateMock.mock.calls[0]?.[0]?.search;
     expect(search({ selected: undefined }).selected).toBe('airport:BOS');
+  });
+
+  it('writes the chosen search result to the URL as the new selection', () => {
+    render(<ChartMode />);
+    const searchBox = searchBoxRef.current;
+    expect(searchBox).toBeDefined();
+    act(() => {
+      searchBox?.onSelectResult(navaidResult);
+    });
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const search = navigateMock.mock.calls[0]?.[0]?.search;
+    expect(search(DEFAULT_SEARCH).selected).toBe('navaid:BOS');
+  });
+
+  it('reveals the owning layer for a hidden search result on selection', () => {
+    render(<ChartMode />);
+    act(() => {
+      searchBoxRef.current?.onSelectResult(navaidResult);
+    });
+    const search = navigateMock.mock.calls[0]?.[0]?.search;
+    const next = search({ ...DEFAULT_SEARCH, layers: ['airports'] });
+    // airports sorts before navaids in the canonical layer order.
+    expect(next.layers).toEqual(['airports', 'navaids']);
+  });
+
+  it('reveals the owning airspace class for a hidden airspace result on selection', () => {
+    render(<ChartMode />);
+    act(() => {
+      searchBoxRef.current?.onSelectResult(airspaceResult);
+    });
+    const search = navigateMock.mock.calls[0]?.[0]?.search;
+    const next = search({ ...DEFAULT_SEARCH, layers: ['airports'], airspaceClasses: [] });
+    expect(next.layers).toContain('airspace');
+    expect(next.airspaceClasses).toEqual(['CLASS_B']);
+    expect(next.selected).toBe('airspace:CLASS_B/KBOS');
+  });
+
+  it('reveals the owning airway category for a hidden airway result on selection', () => {
+    render(<ChartMode />);
+    act(() => {
+      searchBoxRef.current?.onSelectResult(airwayResult);
+    });
+    const search = navigateMock.mock.calls[0]?.[0]?.search;
+    const next = search({ ...DEFAULT_SEARCH, layers: ['airports'], airwayCategories: [] });
+    expect(next.layers).toContain('airways');
+    expect(next.airwayCategories).toEqual(['LOW']);
+    expect(next.selected).toBe('airway:V16');
+  });
+
+  it('leaves visible layers unchanged when selecting an already-visible result', () => {
+    render(<ChartMode />);
+    act(() => {
+      searchBoxRef.current?.onSelectResult(navaidResult);
+    });
+    const search = navigateMock.mock.calls[0]?.[0]?.search;
+    const next = search(DEFAULT_SEARCH);
+    expect(next.layers).toEqual(DEFAULT_SEARCH.layers);
+    expect(next.selected).toBe('navaid:BOS');
   });
 
   it('dismisses the disambiguation popover without changing the URL', () => {

--- a/apps/atlas/src/modes/chart/chart-mode.tsx
+++ b/apps/atlas/src/modes/chart/chart-mode.tsx
@@ -26,6 +26,9 @@ import {
 import { AirwayLegFocusLayer, AirwaysLayer } from './layers/airways-layer.tsx';
 import { FixesLayer } from './layers/fixes-layer.tsx';
 import { NavaidsLayer } from './layers/navaids-layer.tsx';
+import { revealLayersForResult } from './search/reveal-for-result.ts';
+import { SearchBox } from './search/search-box.tsx';
+import type { ChartSearchResult } from './search/search-features.ts';
 import type { AirspaceClass, LayerId } from './url-state.ts';
 import { CHART_ROUTE_PATH } from './url-state.ts';
 import { useAirspace3DAutoHide } from './use-airspace-3d-auto-hide.ts';
@@ -254,6 +257,41 @@ export function ChartMode(): ReactElement {
     setPendingDisambiguation(undefined);
   }, []);
 
+  const handleSearchSelect = useCallback(
+    (result: ChartSearchResult): void => {
+      // Choosing a search result is a fresh selection, not a map click:
+      // drop the previous click's "Also here" chip strip and any sticky
+      // hover/disambiguation preview so the inspector reflects only the
+      // chosen feature.
+      setHoveredChipSelection(undefined);
+      setPendingDisambiguation(undefined);
+      setFeaturesAtLastClick([]);
+      // Reveal the owning layer (and category / class) when the chosen
+      // feature is currently hidden, so the inspector is not pinned to
+      // something the map never draws. Already-visible types pass through
+      // untouched. The camera pan itself lives in the search box, which can
+      // reach the MapLibre instance via `useMap()`.
+      void navigate({
+        search: (prev) => {
+          const revealed = revealLayersForResult(result, {
+            layers: prev.layers,
+            airspaceClasses: prev.airspaceClasses,
+            airwayCategories: prev.airwayCategories,
+          });
+          return {
+            ...prev,
+            layers: [...revealed.layers],
+            airspaceClasses: [...revealed.airspaceClasses],
+            airwayCategories: [...revealed.airwayCategories],
+            selected: result.selection,
+          };
+        },
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
   // `<MapProvider>` lets the loading indicator (a sibling of MapCanvas)
   // reach the underlying MapLibre instance via `useMap()`, so it can
   // subscribe to the map's `idle` event and dismiss only after the
@@ -314,6 +352,7 @@ export function ChartMode(): ReactElement {
         </MapCanvas>
         <InspectableHoverCursor />
         <ChartViewResetListener />
+        <SearchBox onSelectResult={handleSearchSelect} />
         <LayerToggle />
         <ZoomControls />
         {pendingDisambiguation !== undefined ? (

--- a/apps/atlas/src/modes/chart/layer-options.ts
+++ b/apps/atlas/src/modes/chart/layer-options.ts
@@ -1,0 +1,64 @@
+import type { AirspaceClass, AirwayCategory, LayerId } from './url-state.ts';
+
+/** A single top-level layer option rendered in a layer-selection menu. */
+export interface LayerOption {
+  /** Stable id matching one of {@link LayerId}. */
+  id: LayerId;
+  /** User-visible label. */
+  label: string;
+}
+
+/**
+ * Top-level layer rows in display order, shared by the Layers menu and the
+ * search filter menu so both expose the same feature types in the same order.
+ * Order is independent of the map z-stack (JSX order in chart-mode) and of URL
+ * serialization order (which follows the url-state layer id order).
+ */
+export const LAYER_OPTIONS: readonly LayerOption[] = [
+  { id: 'airports', label: 'Airports' },
+  { id: 'navaids', label: 'Navaids' },
+  { id: 'fixes', label: 'Fixes' },
+  { id: 'airways', label: 'Airways' },
+  { id: 'airspace', label: 'Airspace' },
+];
+
+/** Set of layer ids that have an inline-expandable sub-class list. */
+export const EXPANDABLE_LAYERS: ReadonlySet<LayerId> = new Set<LayerId>(['airways', 'airspace']);
+
+/** A single airspace-class row rendered inside an airspace expansion. */
+export interface AirspaceClassOption {
+  /** Stable id matching one of {@link AirspaceClass}. */
+  id: AirspaceClass;
+  /** User-visible label. */
+  label: string;
+}
+
+/** Airspace-class rows in display order: classes first, then special-use, then ARTCC. */
+export const AIRSPACE_CLASS_OPTIONS: readonly AirspaceClassOption[] = [
+  { id: 'CLASS_B', label: 'Class B' },
+  { id: 'CLASS_C', label: 'Class C' },
+  { id: 'CLASS_D', label: 'Class D' },
+  { id: 'CLASS_E', label: 'Class E' },
+  { id: 'MOA', label: 'MOA' },
+  { id: 'RESTRICTED', label: 'Restricted' },
+  { id: 'PROHIBITED', label: 'Prohibited' },
+  { id: 'WARNING', label: 'Warning' },
+  { id: 'ALERT', label: 'Alert' },
+  { id: 'NSA', label: 'NSA' },
+  { id: 'ARTCC', label: 'ARTCC' },
+];
+
+/** A single airway-category row rendered inside an airways expansion. */
+export interface AirwayCategoryOption {
+  /** Stable id matching one of {@link AirwayCategory}. */
+  id: AirwayCategory;
+  /** User-visible label. */
+  label: string;
+}
+
+/** Airway-category rows in display order, low to high to oceanic-and-regional. */
+export const AIRWAY_CATEGORY_OPTIONS: readonly AirwayCategoryOption[] = [
+  { id: 'LOW', label: 'Low altitude' },
+  { id: 'HIGH', label: 'High altitude' },
+  { id: 'OCEANIC', label: 'Oceanic & regional' },
+];

--- a/apps/atlas/src/modes/chart/layer-toggle-rows.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle-rows.tsx
@@ -22,6 +22,12 @@ export interface SimpleParentRowProps {
    * already above the threshold).
    */
   hintMinZoom: number | undefined;
+  /**
+   * When true, render the row in a muted style to signal it currently has no
+   * effect - used by the search filter when the feature type is hidden on the
+   * map and hidden results are excluded. The row stays fully interactive.
+   */
+  dimmed?: boolean;
 }
 
 /**
@@ -34,13 +40,14 @@ export function SimpleParentRow({
   checked,
   onCheckedChange,
   hintMinZoom,
+  dimmed = false,
 }: SimpleParentRowProps): ReactElement {
   return (
     <MenuItemRow
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="px-2 py-2.5 md:py-1.5"
+      className={`px-2 py-2.5 md:py-1.5${dimmed ? ' opacity-60' : ''}`}
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -77,6 +84,12 @@ export interface ExpandableParentRowProps {
    * already above the threshold).
    */
   hintMinZoom: number | undefined;
+  /**
+   * When true, render the row in a muted style to signal it currently has no
+   * effect - used by the search filter when the feature type is hidden on the
+   * map and hidden results are excluded. The row stays fully interactive.
+   */
+  dimmed?: boolean;
 }
 
 /**
@@ -100,6 +113,7 @@ export function ExpandableParentRow({
   enabledCount,
   totalCount,
   hintMinZoom,
+  dimmed = false,
 }: ExpandableParentRowProps): ReactElement {
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === 'ArrowRight' && !expanded) {
@@ -116,7 +130,7 @@ export function ExpandableParentRow({
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
       onKeyDown={handleKeyDown}
-      className="px-2 py-2.5 md:py-1.5"
+      className={`px-2 py-2.5 md:py-1.5${dimmed ? ' opacity-60' : ''}`}
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>
@@ -193,6 +207,12 @@ export interface SubRowProps {
   checked: boolean;
   /** Called with the new checked state when the user toggles the row. */
   onCheckedChange: (checked: boolean) => void;
+  /**
+   * When true, render the row in a muted style to signal it currently has no
+   * effect - used by the search filter when the sub-class is hidden on the map
+   * and hidden results are excluded. The row stays fully interactive.
+   */
+  dimmed?: boolean;
 }
 
 /**
@@ -200,13 +220,18 @@ export interface SubRowProps {
  * Radix CheckboxItem semantics as {@link SimpleParentRow} but with extra
  * left padding so the visual hierarchy reads as nested.
  */
-export function SubRow({ label, checked, onCheckedChange }: SubRowProps): ReactElement {
+export function SubRow({
+  label,
+  checked,
+  onCheckedChange,
+  dimmed = false,
+}: SubRowProps): ReactElement {
   return (
     <MenuItemRow
       checked={checked}
       onCheckedChange={onCheckedChange}
       onSelect={(event) => event.preventDefault()}
-      className="py-2.5 pr-2 pl-8 md:py-1.5"
+      className={`py-2.5 pr-2 pl-8 md:py-1.5${dimmed ? ' opacity-60' : ''}`}
     >
       <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
         <DropdownMenu.ItemIndicator>

--- a/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.spec.tsx
@@ -175,6 +175,10 @@ function makePrev(overrides: Partial<ChartSearch> = {}): ChartSearch {
     layers: [...LAYER_IDS],
     airspaceClasses: [...AIRSPACE_CLASSES],
     airwayCategories: [...AIRWAY_CATEGORIES],
+    searchLayers: [...LAYER_IDS],
+    searchAirspaceClasses: [...AIRSPACE_CLASSES],
+    searchAirwayCategories: [...AIRWAY_CATEGORIES],
+    searchIncludeHidden: false,
     ...overrides,
   };
 }

--- a/apps/atlas/src/modes/chart/layer-toggle.tsx
+++ b/apps/atlas/src/modes/chart/layer-toggle.tsx
@@ -7,6 +7,12 @@ import { FLOATING_SURFACE_CLASSES, FOCUS_RING_CLASSES } from '../../shared/style
 import { MenuItemRow } from '../../shared/ui/menu-item-row.tsx';
 
 import { useAirspace3DAutoHidePreference } from './airspace-3d-preference.ts';
+import {
+  AIRSPACE_CLASS_OPTIONS,
+  AIRWAY_CATEGORY_OPTIONS,
+  EXPANDABLE_LAYERS,
+  LAYER_OPTIONS,
+} from './layer-options.ts';
 import { CheckIcon } from './layer-toggle-icons.tsx';
 import { ExpandableParentRow, SimpleParentRow, SubRow } from './layer-toggle-rows.tsx';
 import {
@@ -19,68 +25,6 @@ import {
 import type { AirspaceClass, AirwayCategory, LayerId } from './url-state.ts';
 
 const route = getRouteApi(CHART_ROUTE_PATH);
-
-/** A single layer option rendered in the top-level dropdown menu. */
-interface LayerOption {
-  /** Stable id matching one of {@link LAYER_IDS}. */
-  id: LayerId;
-  /** User-visible label. */
-  label: string;
-}
-
-/**
- * Top-level layer rows in display order. Order is independent of map z-stack
- * (which is controlled by JSX order in chart-mode) and of URL serialization
- * order (which follows {@link LAYER_IDS}).
- */
-const LAYER_OPTIONS: readonly LayerOption[] = [
-  { id: 'airports', label: 'Airports' },
-  { id: 'navaids', label: 'Navaids' },
-  { id: 'fixes', label: 'Fixes' },
-  { id: 'airways', label: 'Airways' },
-  { id: 'airspace', label: 'Airspace' },
-];
-
-/** Set of layer ids that have an inline-expandable sub-class list. */
-const EXPANDABLE_LAYERS = new Set<LayerId>(['airways', 'airspace']);
-
-/** A single airspace-class row rendered inside the airspace expansion. */
-interface AirspaceClassOption {
-  /** Stable id matching one of {@link AIRSPACE_CLASSES}. */
-  id: AirspaceClass;
-  /** User-visible label. */
-  label: string;
-}
-
-/** Airspace-class rows in display order: classes first, then special-use, then ARTCC. */
-const AIRSPACE_CLASS_OPTIONS: readonly AirspaceClassOption[] = [
-  { id: 'CLASS_B', label: 'Class B' },
-  { id: 'CLASS_C', label: 'Class C' },
-  { id: 'CLASS_D', label: 'Class D' },
-  { id: 'CLASS_E', label: 'Class E' },
-  { id: 'MOA', label: 'MOA' },
-  { id: 'RESTRICTED', label: 'Restricted' },
-  { id: 'PROHIBITED', label: 'Prohibited' },
-  { id: 'WARNING', label: 'Warning' },
-  { id: 'ALERT', label: 'Alert' },
-  { id: 'NSA', label: 'NSA' },
-  { id: 'ARTCC', label: 'ARTCC' },
-];
-
-/** A single airway-category row rendered inside the airways expansion. */
-interface AirwayCategoryOption {
-  /** Stable id matching one of {@link AIRWAY_CATEGORIES}. */
-  id: AirwayCategory;
-  /** User-visible label. */
-  label: string;
-}
-
-/** Airway-category rows in display order, low to high to oceanic-and-regional. */
-const AIRWAY_CATEGORY_OPTIONS: readonly AirwayCategoryOption[] = [
-  { id: 'LOW', label: 'Low altitude' },
-  { id: 'HIGH', label: 'High altitude' },
-  { id: 'OCEANIC', label: 'Oceanic & regional' },
-];
 
 /**
  * Layer-visibility dropdown for chart mode. Reads the active layer set and
@@ -247,7 +191,7 @@ export function LayerToggle(): ReactElement {
         <DropdownMenu.Content
           align="end"
           sideOffset={4}
-          className={`min-w-[14rem] rounded-md p-1 shadow-lg ${FLOATING_SURFACE_CLASSES}`}
+          className={`z-40 min-w-[14rem] rounded-md p-1 shadow-lg ${FLOATING_SURFACE_CLASSES}`}
         >
           {LAYER_OPTIONS.map((option) => {
             const isExpandable = EXPANDABLE_LAYERS.has(option.id);

--- a/apps/atlas/src/modes/chart/layers/airports-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/airports-layer.tsx
@@ -11,6 +11,8 @@ import { useAirportDataset } from '../../../shared/data/airport-dataset.ts';
 import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 
+import { isDrawableAirport } from './drawable-sets.ts';
+
 /**
  * Properties carried on each airport point feature in the GeoJSON source.
  * Kept narrow so the source payload stays small; richer fields are read
@@ -61,16 +63,17 @@ function longestRunwayFt(airport: Airport): number {
 
 /**
  * Projects the bundled airport records into a GeoJSON `FeatureCollection`
- * suitable for a MapLibre `geojson` source. Filters to `facilityType ===
- * 'AIRPORT'` so heliports, seaplane bases, and other facility types do not
- * appear on this layer; they will land in their own layers later.
+ * suitable for a MapLibre `geojson` source. Includes only records the chart
+ * draws, per {@link isDrawableAirport}: `AIRPORT`-type facilities. Heliports,
+ * seaplane bases, and other facility types do not appear on this layer; they
+ * will land in their own layers later.
  */
 function toFeatureCollection(
   records: Airport[],
 ): FeatureCollection<Point, AirportFeatureProperties> {
   const features: Feature<Point, AirportFeatureProperties>[] = [];
   for (const airport of records) {
-    if (airport.facilityType !== 'AIRPORT') {
+    if (!isDrawableAirport(airport)) {
       continue;
     }
     features.push({

--- a/apps/atlas/src/modes/chart/layers/drawable-sets.ts
+++ b/apps/atlas/src/modes/chart/layers/drawable-sets.ts
@@ -1,0 +1,63 @@
+import type { Airport, FacilityType, Navaid, NavaidType } from '@squawk/types';
+
+/**
+ * Navaid types the chart renders. `FAN_MARKER`, `MARINE_NDB`, and `VOT`
+ * are intentionally excluded: too niche for a general chart view, and they
+ * clutter at low zoom without informing typical IFR or VFR navigation.
+ *
+ * Single source of truth for the navaid corpus. The navaids layer projects
+ * exactly these types into its GeoJSON source, and chart-mode search scopes
+ * its navaid query to the same set, so a navaid is searchable iff it is
+ * drawable. Shutdown facilities are excluded separately by
+ * {@link isDrawableNavaid} because status is a per-record attribute, not a
+ * type.
+ */
+export const RENDERED_NAVAID_TYPES: ReadonlySet<NavaidType> = new Set<NavaidType>([
+  'VOR',
+  'VORTAC',
+  'VOR/DME',
+  'TACAN',
+  'DME',
+  'NDB',
+  'NDB/DME',
+]);
+
+/**
+ * Whether a navaid is part of the chart's drawable navaid corpus: an
+ * operational (non-shutdown) facility whose type is in
+ * {@link RENDERED_NAVAID_TYPES}. Shared by the navaids layer projection and
+ * chart-mode search so the rendered set and the searchable set never drift.
+ *
+ * @param navaid - The navaid record to test.
+ * @returns True when the chart's navaids layer renders this record.
+ */
+export function isDrawableNavaid(navaid: Navaid): boolean {
+  return navaid.status !== 'SHUTDOWN' && RENDERED_NAVAID_TYPES.has(navaid.type);
+}
+
+/**
+ * Facility types the chart's airports layer renders. Only `AIRPORT` for now:
+ * heliports, seaplane bases, and other facility types will land in their own
+ * layers later.
+ *
+ * Single source of truth for the airport corpus. The airports layer projects
+ * exactly these facility types into its GeoJSON source, and chart-mode search
+ * scopes its airport query to the same set, so an airport is searchable iff it
+ * is drawable.
+ */
+export const RENDERED_AIRPORT_FACILITY_TYPES: ReadonlySet<FacilityType> = new Set<FacilityType>([
+  'AIRPORT',
+]);
+
+/**
+ * Whether an airport is part of the chart's drawable airport corpus: a
+ * facility whose type is in {@link RENDERED_AIRPORT_FACILITY_TYPES}. Shared by
+ * the airports layer projection and chart-mode search so the rendered set and
+ * the searchable set never drift.
+ *
+ * @param airport - The airport record to test.
+ * @returns True when the chart's airports layer renders this record.
+ */
+export function isDrawableAirport(airport: Airport): boolean {
+  return RENDERED_AIRPORT_FACILITY_TYPES.has(airport.facilityType);
+}

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
@@ -12,6 +12,8 @@ import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { LAYER_MIN_ZOOM } from '../url-state.ts';
 
+import { isDrawableNavaid } from './drawable-sets.ts';
+
 /**
  * Properties carried on each navaid point feature in the GeoJSON source.
  * Kept narrow so the source payload stays small; richer fields are read
@@ -47,33 +49,15 @@ const MATCH_NONE_FILTER: ExpressionSpecification = [
 ];
 
 /**
- * Navaid types we render. `FAN_MARKER`, `MARINE_NDB`, and `VOT` are
- * intentionally excluded: too niche for a general chart view, and they
- * clutter at low zoom without informing typical IFR or VFR navigation.
- */
-const RENDERED_NAVAID_TYPES: ReadonlySet<NavaidType> = new Set<NavaidType>([
-  'VOR',
-  'VORTAC',
-  'VOR/DME',
-  'TACAN',
-  'DME',
-  'NDB',
-  'NDB/DME',
-]);
-
-/**
  * Projects the bundled navaid records into a GeoJSON `FeatureCollection`
- * suitable for a MapLibre `geojson` source. Filters to operational
- * navaids of types in {@link RENDERED_NAVAID_TYPES}; shutdown facilities
- * and niche types do not appear on this layer.
+ * suitable for a MapLibre `geojson` source. Includes only records the chart
+ * draws, per {@link isDrawableNavaid}: operational navaids of a rendered
+ * type. Shutdown facilities and niche types do not appear on this layer.
  */
 function toFeatureCollection(records: Navaid[]): FeatureCollection<Point, NavaidFeatureProperties> {
   const features: Feature<Point, NavaidFeatureProperties>[] = [];
   for (const navaid of records) {
-    if (navaid.status === 'SHUTDOWN') {
-      continue;
-    }
-    if (!RENDERED_NAVAID_TYPES.has(navaid.type)) {
+    if (!isDrawableNavaid(navaid)) {
       continue;
     }
     features.push({

--- a/apps/atlas/src/modes/chart/search/reveal-for-result.spec.ts
+++ b/apps/atlas/src/modes/chart/search/reveal-for-result.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+
+import { revealLayersForResult } from './reveal-for-result.ts';
+import type {
+  AirportChartSearchResult,
+  AirspaceChartSearchResult,
+  AirwayChartSearchResult,
+  FixChartSearchResult,
+  NavaidChartSearchResult,
+} from './search-features.ts';
+import type { LayerSelection } from './search-scope.ts';
+
+/** Fields shared by every result fixture; the helper only reads `kind`/`subtype`. */
+const base = {
+  selection: 'x',
+  label: 'X',
+  sublabel: undefined,
+  matchedText: 'X',
+  ranges: [],
+  score: 1,
+  center: { lng: 0, lat: 0 },
+  hidden: true,
+};
+
+const airport: AirportChartSearchResult = { ...base, kind: 'airport', matchedField: 'faaId' };
+const navaid: NavaidChartSearchResult = {
+  ...base,
+  kind: 'navaid',
+  subtype: 'VOR',
+  matchedField: 'identifier',
+};
+const fix: FixChartSearchResult = { ...base, kind: 'fix', matchedField: 'identifier' };
+const victorAirway: AirwayChartSearchResult = {
+  ...base,
+  kind: 'airway',
+  subtype: 'VICTOR',
+  matchedField: 'designation',
+  bbox: { minLon: 0, maxLon: 1, minLat: 0, maxLat: 1 },
+};
+const oceanicAirway: AirwayChartSearchResult = {
+  ...base,
+  kind: 'airway',
+  subtype: 'ATLANTIC',
+  matchedField: 'designation',
+  bbox: { minLon: 0, maxLon: 1, minLat: 0, maxLat: 1 },
+};
+const classBAirspace: AirspaceChartSearchResult = {
+  ...base,
+  kind: 'airspace',
+  subtype: 'CLASS_B',
+  matchedField: 'identifier',
+  bbox: { minLon: 0, maxLon: 1, minLat: 0, maxLat: 1 },
+};
+const classE5Airspace: AirspaceChartSearchResult = {
+  ...base,
+  kind: 'airspace',
+  subtype: 'CLASS_E5',
+  matchedField: 'name',
+  bbox: { minLon: 0, maxLon: 1, minLat: 0, maxLat: 1 },
+};
+
+/** Builds a Layers-menu selection with sensible empty defaults. */
+function selection(overrides: Partial<LayerSelection> = {}): LayerSelection {
+  return { layers: [], airspaceClasses: [], airwayCategories: [], ...overrides };
+}
+
+describe('revealLayersForResult', () => {
+  it('enables the airports layer for an airport result', () => {
+    const next = revealLayersForResult(airport, selection());
+    expect(next.layers).toEqual(['airports']);
+  });
+
+  it('enables the navaids layer for a navaid result', () => {
+    const next = revealLayersForResult(navaid, selection());
+    expect(next.layers).toEqual(['navaids']);
+  });
+
+  it('enables the fixes layer for a fix result', () => {
+    const next = revealLayersForResult(fix, selection());
+    expect(next.layers).toEqual(['fixes']);
+  });
+
+  it('enables the airways layer and the matching category for an airway result', () => {
+    const next = revealLayersForResult(victorAirway, selection());
+    expect(next.layers).toEqual(['airways']);
+    expect(next.airwayCategories).toEqual(['LOW']);
+  });
+
+  it('maps oceanic / colored airway types onto the OCEANIC category', () => {
+    const next = revealLayersForResult(oceanicAirway, selection());
+    expect(next.airwayCategories).toEqual(['OCEANIC']);
+  });
+
+  it('enables the airspace layer and the matching class for an airspace result', () => {
+    const next = revealLayersForResult(classBAirspace, selection());
+    expect(next.layers).toEqual(['airspace']);
+    expect(next.airspaceClasses).toEqual(['CLASS_B']);
+  });
+
+  it('collapses the Class E stratum onto the single CLASS_E class', () => {
+    const next = revealLayersForResult(classE5Airspace, selection());
+    expect(next.airspaceClasses).toEqual(['CLASS_E']);
+  });
+
+  it('preserves canonical layer order when inserting a revealed layer', () => {
+    const next = revealLayersForResult(airport, selection({ layers: ['airspace'] }));
+    // airports sorts before airspace in LAYER_IDS.
+    expect(next.layers).toEqual(['airports', 'airspace']);
+  });
+
+  it('preserves canonical class order when inserting a revealed airspace class', () => {
+    const next = revealLayersForResult(
+      classBAirspace,
+      selection({ layers: ['airspace'], airspaceClasses: ['CLASS_C'] }),
+    );
+    // CLASS_B sorts before CLASS_C in AIRSPACE_CLASSES.
+    expect(next.airspaceClasses).toEqual(['CLASS_B', 'CLASS_C']);
+  });
+
+  it('preserves canonical category order when inserting a revealed airway category', () => {
+    const next = revealLayersForResult(
+      victorAirway,
+      selection({ layers: ['airways'], airwayCategories: ['HIGH'] }),
+    );
+    // LOW sorts before HIGH in AIRWAY_CATEGORIES.
+    expect(next.airwayCategories).toEqual(['LOW', 'HIGH']);
+  });
+
+  it('leaves an already-visible layer untouched by identity', () => {
+    const current = selection({ layers: ['navaids'] });
+    const next = revealLayersForResult(navaid, current);
+    expect(next.layers).toBe(current.layers);
+  });
+
+  it('leaves an already-visible airspace class untouched by identity', () => {
+    const current = selection({ layers: ['airspace'], airspaceClasses: ['CLASS_B'] });
+    const next = revealLayersForResult(classBAirspace, current);
+    expect(next.layers).toBe(current.layers);
+    expect(next.airspaceClasses).toBe(current.airspaceClasses);
+  });
+
+  it('leaves an already-visible airway category untouched by identity', () => {
+    const current = selection({ layers: ['airways'], airwayCategories: ['LOW'] });
+    const next = revealLayersForResult(victorAirway, current);
+    expect(next.layers).toBe(current.layers);
+    expect(next.airwayCategories).toBe(current.airwayCategories);
+  });
+});

--- a/apps/atlas/src/modes/chart/search/reveal-for-result.ts
+++ b/apps/atlas/src/modes/chart/search/reveal-for-result.ts
@@ -1,0 +1,100 @@
+import {
+  AIRSPACE_CLASSES,
+  AIRSPACE_CLASS_FOR_TYPE,
+  AIRWAY_CATEGORIES,
+  AIRWAY_CATEGORY_FOR_TYPE,
+  LAYER_IDS,
+} from '../url-state.ts';
+import type { AirspaceClass, AirwayCategory, LayerId } from '../url-state.ts';
+
+import type { ChartSearchResult } from './search-features.ts';
+import type { LayerSelection } from './search-scope.ts';
+
+/**
+ * Returns `layers` with `id` enabled, preserving the canonical {@link LAYER_IDS}
+ * order. Returns the same array reference when `id` is already present, so an
+ * already-visible selection produces no layer-state churn.
+ */
+function withLayer(layers: readonly LayerId[], id: LayerId): readonly LayerId[] {
+  if (layers.includes(id)) {
+    return layers;
+  }
+  return LAYER_IDS.filter((layerId) => layers.includes(layerId) || layerId === id);
+}
+
+/**
+ * Returns `classes` with `cls` enabled, preserving the canonical
+ * {@link AIRSPACE_CLASSES} order. Returns the same array reference when `cls`
+ * is already present.
+ */
+function withAirspaceClass(
+  classes: readonly AirspaceClass[],
+  cls: AirspaceClass,
+): readonly AirspaceClass[] {
+  if (classes.includes(cls)) {
+    return classes;
+  }
+  return AIRSPACE_CLASSES.filter((c) => classes.includes(c) || c === cls);
+}
+
+/**
+ * Returns `categories` with `category` enabled, preserving the canonical
+ * {@link AIRWAY_CATEGORIES} order. Returns the same array reference when
+ * `category` is already present.
+ */
+function withAirwayCategory(
+  categories: readonly AirwayCategory[],
+  category: AirwayCategory,
+): readonly AirwayCategory[] {
+  if (categories.includes(category)) {
+    return categories;
+  }
+  return AIRWAY_CATEGORIES.filter((c) => categories.includes(c) || c === category);
+}
+
+/**
+ * Computes the Layers-menu selection needed to draw a chosen search result,
+ * starting from the current selection and enabling only what is missing.
+ *
+ * Selecting a result whose feature type is hidden would otherwise pin the
+ * inspector to something the map never draws. This ensures the owning
+ * top-level layer is on and, for airways and airspace, that the result's
+ * category / class is enabled too. Feature types that are already visible pass
+ * through untouched (same array identity), so choosing a visible result is a
+ * no-op on layer state.
+ *
+ * @param result - The chosen search result.
+ * @param current - The current Layers-menu selection.
+ * @returns The next Layers-menu selection with the result's owning layer revealed.
+ */
+export function revealLayersForResult(
+  result: ChartSearchResult,
+  current: LayerSelection,
+): LayerSelection {
+  switch (result.kind) {
+    case 'airport':
+      return { ...current, layers: withLayer(current.layers, 'airports') };
+    case 'navaid':
+      return { ...current, layers: withLayer(current.layers, 'navaids') };
+    case 'fix':
+      return { ...current, layers: withLayer(current.layers, 'fixes') };
+    case 'airway':
+      return {
+        ...current,
+        layers: withLayer(current.layers, 'airways'),
+        airwayCategories: withAirwayCategory(
+          current.airwayCategories,
+          AIRWAY_CATEGORY_FOR_TYPE[result.subtype],
+        ),
+      };
+    case 'airspace':
+      return {
+        ...current,
+        layers: withLayer(current.layers, 'airspace'),
+        airspaceClasses: withAirspaceClass(
+          current.airspaceClasses,
+          AIRSPACE_CLASS_FOR_TYPE[result.subtype],
+        ),
+      };
+  }
+}

--- a/apps/atlas/src/modes/chart/search/search-box.spec.tsx
+++ b/apps/atlas/src/modes/chart/search/search-box.spec.tsx
@@ -1,0 +1,324 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SearchBox } from './search-box.tsx';
+import type {
+  AirportChartSearchResult,
+  AirwayChartSearchResult,
+  ChartSearchResult,
+  FixChartSearchResult,
+  NavaidChartSearchResult,
+} from './search-features.ts';
+
+const { useChartSearchMock, useMapMock, getMapInstanceMock, panToMock, fitBoundsMock } = vi.hoisted(
+  () => ({
+    useChartSearchMock: vi.fn(),
+    useMapMock: vi.fn(),
+    getMapInstanceMock: vi.fn(),
+    panToMock: vi.fn(),
+    fitBoundsMock: vi.fn(),
+  }),
+);
+
+vi.mock('./use-chart-search.ts', () => ({
+  useChartSearch: useChartSearchMock,
+}));
+
+// SearchBox reaches the live MapLibre instance via `useMap()` to pan the
+// camera to a chosen result. Mock the provider hook and the pan helpers so the
+// component can mount and select outside a real MapProvider, and so the test
+// can assert the pan call without a live map.
+vi.mock('@vis.gl/react-maplibre', () => ({
+  useMap: useMapMock,
+}));
+
+vi.mock('../../../shared/inspector/use-chip-hover-pan.ts', () => ({
+  getMapInstance: getMapInstanceMock,
+  panToFeatureWithInspectorOffset: panToMock,
+  fitFeatureBoundsWithInspectorOffset: fitBoundsMock,
+}));
+
+// Stand-in for the underlying MapLibre map instance the framing helpers receive.
+// `getZoom` backs the point-result zoom floor; the helpers themselves are
+// mocked, so the fake needs nothing else.
+const fakeMap = { getZoom: (): number => 4 };
+
+// The filter menu reads/writes route state of its own; the search-box tests
+// only care that it renders beside the input, so stub it to an inert node.
+vi.mock('./search-filter-menu.tsx', () => ({
+  SearchFilterMenu(): null {
+    return null;
+  },
+}));
+
+// Airport matched on its city ("BOSTON"), so the row leads with the matched
+// city text and shows the FAA id as the muted secondary line. The match range
+// covers only "BOS" so the row has a matched run and an unmatched tail.
+const airport: AirportChartSearchResult = {
+  kind: 'airport',
+  matchedField: 'city',
+  selection: 'airport:KBOS',
+  label: 'KBOS',
+  sublabel: 'Logan Intl',
+  matchedText: 'BOSTON',
+  ranges: [{ start: 0, end: 3 }],
+  score: 0.9,
+  center: { lng: -71, lat: 42 },
+  hidden: false,
+};
+
+// Navaid matched on its identifier, so the row leads with the identifier and
+// shows the navaid name as the secondary line.
+const navaid: NavaidChartSearchResult = {
+  kind: 'navaid',
+  subtype: 'VOR',
+  matchedField: 'identifier',
+  selection: 'navaid:BOS',
+  label: 'BOS',
+  sublabel: 'Boston VORTAC',
+  matchedText: 'BOS',
+  ranges: [{ start: 0, end: 3 }],
+  score: 0.8,
+  center: { lng: -71, lat: 42 },
+  hidden: false,
+};
+
+// Fix matched on its identifier with no sublabel, so the row has no secondary
+// line at all.
+const fix: FixChartSearchResult = {
+  kind: 'fix',
+  matchedField: 'identifier',
+  selection: 'fix:MERIT',
+  label: 'MERIT',
+  sublabel: undefined,
+  matchedText: 'MERIT',
+  ranges: [{ start: 0, end: 5 }],
+  score: 0.7,
+  center: { lng: -70, lat: 42 },
+  hidden: false,
+};
+
+// Airway matched on its designation. Extent features carry a bounding box and
+// are framed with fitBounds rather than a point pan, so this fixture stays out
+// of the default `fixtures` list (which the point-row rendering tests count on).
+const airway: AirwayChartSearchResult = {
+  kind: 'airway',
+  subtype: 'VICTOR',
+  matchedField: 'designation',
+  selection: 'airway:V1',
+  label: 'V1',
+  sublabel: undefined,
+  matchedText: 'V1',
+  ranges: [{ start: 0, end: 2 }],
+  score: 0.6,
+  center: { lng: -72, lat: 43 },
+  bbox: { minLon: -73, maxLon: -71, minLat: 42, maxLat: 44 },
+  hidden: false,
+};
+
+const fixtures = [airport, navaid, fix];
+
+// Stable empty-result reference. The real useChartSearch memoizes its return,
+// so a blank query yields the same array identity across renders; SearchBox
+// relies on that to reset its active row only when the result set truly
+// changes. Returning a fresh `[]` per call here would defeat that and loop.
+const noResults: ChartSearchResult[] = [];
+
+/** Focuses the search input and types `value` so the dropdown opens. */
+function typeQuery(value: string): HTMLElement {
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value } });
+  return input;
+}
+
+/**
+ * Returns the option row at `index`, re-querying the live list each call and
+ * asserting the row exists so callers receive a non-optional element.
+ */
+function optionAt(index: number): HTMLElement {
+  const option = screen.getAllByRole('option')[index];
+  if (option === undefined) {
+    throw new Error(`No option at index ${index}`);
+  }
+  return option;
+}
+
+describe('SearchBox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChartSearchMock.mockImplementation((query: string) =>
+      query.trim().length > 0 ? fixtures : noResults,
+    );
+    useMapMock.mockReturnValue({ current: { getMap: (): object => fakeMap }, default: undefined });
+    getMapInstanceMock.mockReturnValue(fakeMap);
+  });
+
+  it('renders the combobox input but no dropdown until the user types', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('runs the live search with the typed query', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+    expect(useChartSearchMock).toHaveBeenLastCalledWith('bos');
+  });
+
+  it('renders one option per result with a feature-kind badge', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+    expect(within(optionAt(0)).getByText('Airport')).toBeInTheDocument();
+    expect(within(optionAt(1)).getByText('Navaid')).toBeInTheDocument();
+    expect(within(optionAt(2)).getByText('Fix')).toBeInTheDocument();
+  });
+
+  it('emphasizes the matched characters and leaves the rest plain', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    const airportOption = screen.getByRole('option', { name: /BOSTON/ });
+    const matched = within(airportOption).getByText('BOS');
+    expect(matched.tagName).toBe('MARK');
+    const unmatched = within(airportOption).getByText('TON');
+    expect(unmatched.tagName).not.toBe('MARK');
+  });
+
+  it('shows the label as a secondary line when the match was on another field', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    const airportOption = screen.getByRole('option', { name: /BOSTON/ });
+    expect(within(airportOption).getByText('KBOS')).toBeInTheDocument();
+  });
+
+  it('falls back to the sublabel when the match was on the label itself', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    const navaidOption = screen.getByRole('option', { name: /VORTAC/ });
+    expect(within(navaidOption).getByText('Boston VORTAC')).toBeInTheDocument();
+  });
+
+  it('shows a no-matches message for a query that yields no results', () => {
+    useChartSearchMock.mockReturnValue([]);
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('zzz');
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('No matches found')).toBeInTheDocument();
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+  });
+
+  it('selects the clicked result and clears the query', () => {
+    const onSelectResult = vi.fn();
+    render(<SearchBox onSelectResult={onSelectResult} />);
+    const input = typeQuery('bos');
+
+    fireEvent.click(screen.getByRole('option', { name: /VORTAC/ }));
+    expect(onSelectResult).toHaveBeenCalledTimes(1);
+    expect(onSelectResult).toHaveBeenCalledWith(navaid);
+    expect(input).toHaveValue('');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('pans a point result to the zoom floor when the view is more zoomed out', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    fireEvent.click(screen.getByRole('option', { name: /VORTAC/ }));
+    expect(panToMock).toHaveBeenCalledTimes(1);
+    // fakeMap.getZoom() returns 4 (CONUS), below the point-result floor, so the
+    // pick eases in to the floor zoom rather than staying at the overview scale.
+    expect(panToMock).toHaveBeenCalledWith(navaid.center, fakeMap, 10);
+  });
+
+  it('keeps the current zoom for a point result when the view is already closer', () => {
+    const closeMap = { getZoom: (): number => 14 };
+    getMapInstanceMock.mockReturnValue(closeMap);
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    fireEvent.click(screen.getByRole('option', { name: /VORTAC/ }));
+    // The floor is a `Math.max`, so a user already zoomed past it is left where
+    // they are rather than being yanked back out to the floor.
+    expect(panToMock).toHaveBeenCalledWith(navaid.center, closeMap, 14);
+  });
+
+  it('fits the bounds of an extent result instead of panning to a point', () => {
+    useChartSearchMock.mockReturnValue([airway]);
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('v1');
+
+    fireEvent.click(screen.getByRole('option', { name: /V1/ }));
+    expect(fitBoundsMock).toHaveBeenCalledTimes(1);
+    expect(fitBoundsMock).toHaveBeenCalledWith(airway.bbox, fakeMap);
+    expect(panToMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the pan but still selects when the map instance is not yet available', () => {
+    getMapInstanceMock.mockReturnValue(undefined);
+    const onSelectResult = vi.fn();
+    render(<SearchBox onSelectResult={onSelectResult} />);
+    typeQuery('bos');
+
+    fireEvent.click(screen.getByRole('option', { name: /VORTAC/ }));
+    expect(panToMock).not.toHaveBeenCalled();
+    expect(onSelectResult).toHaveBeenCalledWith(navaid);
+  });
+
+  it('preselects the first result and moves the active row with the arrow keys', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    const input = typeQuery('bos');
+
+    expect(optionAt(0)).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', optionAt(0).id);
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(optionAt(1)).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(optionAt(0)).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('selects the active result on Enter', () => {
+    const onSelectResult = vi.fn();
+    render(<SearchBox onSelectResult={onSelectResult} />);
+    const input = typeQuery('bos');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelectResult).toHaveBeenCalledWith(navaid);
+  });
+
+  it('makes the hovered row the active row', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    typeQuery('bos');
+
+    fireEvent.mouseEnter(optionAt(2));
+    expect(optionAt(2)).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('clears the query on Escape', () => {
+    render(<SearchBox onSelectResult={vi.fn()} />);
+    const input = typeQuery('bos');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(input).toHaveValue('');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('clears the query when the clear button is pressed', () => {
+    const onSelectResult = vi.fn();
+    render(<SearchBox onSelectResult={onSelectResult} />);
+    const input = typeQuery('bos');
+
+    fireEvent.click(screen.getByRole('button', { name: /clear search/i }));
+    expect(input).toHaveValue('');
+    expect(onSelectResult).not.toHaveBeenCalled();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-box.tsx
+++ b/apps/atlas/src/modes/chart/search/search-box.tsx
@@ -1,0 +1,338 @@
+import { useMap } from '@vis.gl/react-maplibre';
+import { useEffect, useId, useRef, useState } from 'react';
+import type { KeyboardEvent, ReactElement } from 'react';
+
+import {
+  fitFeatureBoundsWithInspectorOffset,
+  getMapInstance,
+  panToFeatureWithInspectorOffset,
+} from '../../../shared/inspector/use-chip-hover-pan.ts';
+import {
+  FLOATING_SURFACE_CLASSES,
+  FOCUS_RING_CLASSES,
+} from '../../../shared/styles/style-tokens.ts';
+
+import type { ChartSearchResult, SearchFeatureKind } from './search-features.ts';
+import { SearchFilterMenu } from './search-filter-menu.tsx';
+import { splitByMatchRanges } from './search-highlight.ts';
+import { useChartSearch } from './use-chart-search.ts';
+
+/**
+ * Zoom level a chosen point result (airport, navaid, or fix) eases to when the
+ * current view is more zoomed out than this. Applied as a floor via `Math.max`,
+ * so selecting a result from the CONUS overview zooms in to a useful level while
+ * a user already zoomed in closer is left where they are. High enough to clear
+ * the navaid (z5) and fix (z7) layer-visibility gates so the chosen feature
+ * actually renders.
+ */
+const POINT_RESULT_ZOOM = 10;
+
+/**
+ * Short uppercase badge text shown in the leading column of each result
+ * row so the user can tell at a glance what kind of feature the row is.
+ * Mirrors the human-readable labels the disambiguation popover uses.
+ */
+function kindBadgeLabel(kind: SearchFeatureKind): string {
+  switch (kind) {
+    case 'airport':
+      return 'Airport';
+    case 'navaid':
+      return 'Navaid';
+    case 'fix':
+      return 'Fix';
+    case 'airway':
+      return 'Airway';
+    case 'airspace':
+      return 'Airspace';
+  }
+}
+
+/**
+ * Secondary, muted line for a result row. When the matched field is not the
+ * primary label (e.g. an airport matched on its city while the row leads with
+ * the FAA id), the label is the useful context to show; otherwise fall back to
+ * the result's own sublabel (e.g. an airport or navaid name). Returns undefined
+ * when there is nothing extra worth showing.
+ */
+function secondaryText(result: ChartSearchResult): string | undefined {
+  if (result.label !== result.matchedText) {
+    return result.label;
+  }
+  return result.sublabel;
+}
+
+/**
+ * Props for {@link SearchBox}.
+ */
+export interface SearchBoxProps {
+  /**
+   * Called with the chosen result when the user activates a row (click or
+   * Enter). The caller owns the URL effects of selection - writing the
+   * `selected` param and revealing any hidden owning layer - plus any
+   * transient-state resets. The search box itself eases the camera to frame the
+   * result (zooming in on point features, fitting the bounds of extent features)
+   * and clears its query so the dropdown collapses.
+   */
+  onSelectResult: (result: ChartSearchResult) => void;
+}
+
+/**
+ * Floating chart-feature search box anchored to the top-left of the map area.
+ *
+ * Holds the in-progress query in component state (transient interaction text,
+ * not URL state) and runs the live, score-ranked search via
+ * {@link useChartSearch}, which reads the Layers-menu and search-filter state
+ * from the URL. Results render in a listbox dropdown that updates as the user
+ * types; each row shows a feature-kind badge, the matched text with the
+ * matched characters emphasized, and a muted secondary line for context.
+ *
+ * The input is an ARIA combobox driving an `aria-activedescendant` listbox:
+ * ArrowUp / ArrowDown move the active row, Enter selects it, and Escape clears
+ * the query. Hovering a row makes it the active row so mouse and keyboard share
+ * one highlight. Selecting a row eases the camera to frame the result (a zoom
+ * floor for point features, a fit-bounds for extent features), calls
+ * {@link SearchBoxProps.onSelectResult}, and clears the query, collapsing the
+ * dropdown.
+ */
+export function SearchBox({ onSelectResult }: SearchBoxProps): ReactElement {
+  const [query, setQuery] = useState('');
+  const [focused, setFocused] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const results = useChartSearch(query);
+  const [prevResults, setPrevResults] = useState(results);
+  const listboxId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  // The search box renders inside the chart-mode `<MapProvider>`, so it can
+  // reach the live MapLibre instance to ease the camera to a chosen result.
+  const map = useMap();
+  const mapRef = map.current ?? map.default;
+
+  const open = focused && query.trim().length > 0;
+  const activeIndexClamped = results.length === 0 ? 0 : Math.min(activeIndex, results.length - 1);
+  const activeDescendant =
+    open && results.length > 0 ? `${listboxId}-option-${activeIndexClamped}` : undefined;
+
+  // A fresh result set means a fresh best match: reset the active row to the
+  // top so Enter selects the strongest match for the latest keystroke. React
+  // recommends adjusting state during render (rather than in a syncing effect)
+  // when the new value derives from a prior render's value. `results` is a
+  // memoized array, so its identity only changes when the query or filters
+  // change - never on an unrelated re-render such as an arrow-key move.
+  if (results !== prevResults) {
+    setPrevResults(results);
+    setActiveIndex(0);
+  }
+
+  // Keep the keyboard-selected row scrolled into view as the user arrows
+  // through a list taller than the dropdown. Guarded for jsdom, which does
+  // not implement scrollIntoView.
+  useEffect((): void => {
+    if (!open) {
+      return;
+    }
+    const node = listRef.current?.children[activeIndexClamped];
+    if (node instanceof HTMLElement && typeof node.scrollIntoView === 'function') {
+      node.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndexClamped, open]);
+
+  function commit(result: ChartSearchResult): void {
+    // Frame the result before the caller commits the URL, mirroring the
+    // inspector's chip-commit ordering. Point features (airport, navaid, fix)
+    // ease to a zoom floor so a pick from the CONUS overview lands close enough
+    // to be useful; extent features (airways, airspace) fit their whole bounding
+    // box. Both read geometry from the result itself, so framing works even
+    // while the caller reveals and mounts a previously hidden layer.
+    const mapInstance = getMapInstance(mapRef);
+    if (mapInstance !== undefined) {
+      if (result.kind === 'airway' || result.kind === 'airspace') {
+        fitFeatureBoundsWithInspectorOffset(result.bbox, mapInstance);
+      } else {
+        panToFeatureWithInspectorOffset(
+          result.center,
+          mapInstance,
+          Math.max(mapInstance.getZoom(), POINT_RESULT_ZOOM),
+        );
+      }
+    }
+    onSelectResult(result);
+    setQuery('');
+    setActiveIndex(0);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'Escape') {
+      if (query.length > 0) {
+        event.preventDefault();
+        setQuery('');
+        setActiveIndex(0);
+      }
+      return;
+    }
+    if (!open || results.length === 0) {
+      return;
+    }
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setActiveIndex(Math.min(activeIndexClamped + 1, results.length - 1));
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setActiveIndex(Math.max(activeIndexClamped - 1, 0));
+        break;
+      case 'Enter': {
+        const result = results[activeIndexClamped];
+        if (result !== undefined) {
+          event.preventDefault();
+          commit(result);
+        }
+        break;
+      }
+    }
+  }
+
+  return (
+    <div className="absolute top-3 left-3 z-10 w-96 max-w-[calc(100vw-6rem)]">
+      <div className="relative">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-slate-400 dark:text-slate-500"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="6" cy="6" r="4.5" />
+            <path d="M9.5 9.5L13 13" />
+          </svg>
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-activedescendant={activeDescendant}
+          aria-autocomplete="list"
+          aria-label="Search chart features"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="Search airports, navaids, fixes..."
+          value={query}
+          onChange={(event): void => setQuery(event.target.value)}
+          onFocus={(): void => setFocused(true)}
+          onBlur={(): void => setFocused(false)}
+          onKeyDown={handleKeyDown}
+          className={`w-full rounded-md py-2.5 pr-16 pl-9 text-sm text-slate-700 shadow-md placeholder:text-slate-400 ${FLOATING_SURFACE_CLASSES} ${FOCUS_RING_CLASSES} md:py-1.5 dark:text-slate-200 dark:placeholder:text-slate-500`}
+        />
+        {query.length > 0 ? (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onMouseDown={(event): void => event.preventDefault()}
+            onClick={(): void => {
+              setQuery('');
+              setActiveIndex(0);
+              inputRef.current?.focus();
+            }}
+            className={`absolute top-1/2 right-9 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded text-slate-400 hover:text-slate-700 ${FOCUS_RING_CLASSES} dark:text-slate-500 dark:hover:text-slate-200`}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              aria-hidden="true"
+            >
+              <path d="M3 3L9 9M9 3L3 9" />
+            </svg>
+          </button>
+        ) : null}
+        <SearchFilterMenu />
+      </div>
+      {open ? (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label="Search results"
+          // Keep the input focused when the user presses on a row so the
+          // click registers as a selection rather than a blur that closes the
+          // dropdown before onClick fires.
+          onMouseDown={(event): void => event.preventDefault()}
+          className={`mt-1 max-h-[min(60vh,24rem)] overflow-y-auto rounded-md shadow-lg ${FLOATING_SURFACE_CLASSES}`}
+        >
+          {results.length === 0 ? (
+            <li
+              role="presentation"
+              className="px-3 py-2.5 text-sm text-slate-500 md:py-2 dark:text-slate-400"
+            >
+              No matches found
+            </li>
+          ) : (
+            results.map((result, index) => {
+              const isActive = index === activeIndexClamped;
+              const segments = splitByMatchRanges(result.matchedText, result.ranges);
+              const secondary = secondaryText(result);
+              return (
+                // Keyboard activation lives on the combobox input via
+                // aria-activedescendant (the ARIA listbox pattern); the options
+                // are not focusable, so a per-row key handler would be dead code.
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+                <li
+                  key={`${result.selection}-${index}`}
+                  id={`${listboxId}-option-${index}`}
+                  role="option"
+                  aria-selected={isActive}
+                  onClick={(): void => commit(result)}
+                  onMouseEnter={(): void => setActiveIndex(index)}
+                  className={`flex cursor-pointer items-baseline gap-2 px-3 py-3 text-sm md:py-1.5 ${
+                    isActive
+                      ? 'bg-indigo-50 text-indigo-700 dark:bg-indigo-950/50 dark:text-indigo-300'
+                      : 'text-slate-700 dark:text-slate-200'
+                  }`}
+                >
+                  <span className="w-16 shrink-0 text-[10px] font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+                    {kindBadgeLabel(result.kind)}
+                  </span>
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">
+                      {segments.map((segment, segmentIndex) =>
+                        segment.matched ? (
+                          <mark
+                            key={segmentIndex}
+                            className="bg-transparent font-semibold text-indigo-700 dark:text-indigo-300"
+                          >
+                            {segment.text}
+                          </mark>
+                        ) : (
+                          <span key={segmentIndex}>{segment.text}</span>
+                        ),
+                      )}
+                    </span>
+                    {secondary !== undefined ? (
+                      <span className="truncate text-xs text-slate-500 dark:text-slate-400">
+                        {secondary}
+                      </span>
+                    ) : null}
+                  </span>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/atlas/src/modes/chart/search/search-features.spec.ts
+++ b/apps/atlas/src/modes/chart/search/search-features.spec.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect } from 'vitest';
+
+import type { AirportSearchField, AirportSearchQuery, AirportSearchResult } from '@squawk/airports';
+import type { AirspaceSearchField, AirspaceSearchResult } from '@squawk/airspace';
+import type { AirwaySearchResult } from '@squawk/airways';
+import type { FixSearchQuery, FixSearchResult } from '@squawk/fixes';
+import type { NavaidSearchField, NavaidSearchResult } from '@squawk/navaids';
+import type {
+  Airport,
+  AirspaceFeature,
+  AirspaceType,
+  AirwayType,
+  Airway,
+  Fix,
+  Navaid,
+} from '@squawk/types';
+
+import { RENDERED_AIRPORT_FACILITY_TYPES, RENDERED_NAVAID_TYPES } from '../layers/drawable-sets.ts';
+
+import { DEFAULT_RESULT_LIMIT, searchChartFeatures } from './search-features.ts';
+import type { ChartSearchResolvers, ChartSearchResult } from './search-features.ts';
+import type { LayerVisibility, SearchScope } from './search-scope.ts';
+
+/**
+ * Builds a minimal {@link Airport} record, defaulting every required field so
+ * a test states only the attributes it asserts on.
+ */
+function makeAirport(overrides: Partial<Airport> = {}): Airport {
+  return {
+    faaId: 'TST',
+    name: 'TEST FIELD',
+    facilityType: 'AIRPORT',
+    ownershipType: 'PUBLIC',
+    useType: 'PUBLIC',
+    status: 'OPEN',
+    city: 'TESTVILLE',
+    country: 'US',
+    lat: 40,
+    lon: -75,
+    timezone: 'America/New_York',
+    runways: [],
+    frequencies: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a minimal {@link Navaid} record, defaulting to an operational VOR.
+ */
+function makeNavaid(overrides: Partial<Navaid> = {}): Navaid {
+  return {
+    identifier: 'TST',
+    name: 'TEST VOR',
+    type: 'VOR',
+    status: 'OPERATIONAL_IFR',
+    lat: 41,
+    lon: -73,
+    country: 'US',
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a minimal {@link Fix} record.
+ */
+function makeFix(overrides: Partial<Fix> = {}): Fix {
+  return {
+    identifier: 'TESTT',
+    icaoRegionCode: 'K6',
+    country: 'US',
+    lat: 42,
+    lon: -71,
+    useCode: 'WP',
+    pitch: false,
+    catch: false,
+    suaAtcaa: false,
+    chartTypes: [],
+    navaidAssociations: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a minimal {@link Airway} record with a two-waypoint route whose
+ * bounding-box center is `{ lng: -72, lat: 43 }`.
+ */
+function makeAirway(overrides: Partial<Airway> = {}): Airway {
+  return {
+    designation: 'V1',
+    type: 'VICTOR',
+    region: 'US',
+    waypoints: [
+      { name: 'ALPHA', waypointType: 'FIX', lat: 42, lon: -71 },
+      { name: 'BRAVO', waypointType: 'FIX', lat: 44, lon: -73 },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a minimal {@link AirspaceFeature} whose square boundary has a
+ * centroid of `[1.6, 1.6]`.
+ */
+function makeAirspace(overrides: Partial<AirspaceFeature> = {}): AirspaceFeature {
+  return {
+    type: 'CLASS_B',
+    name: 'TEST BRAVO',
+    identifier: 'TST',
+    floor: { valueFt: 0, reference: 'SFC' },
+    ceiling: { valueFt: 10000, reference: 'MSL' },
+    boundary: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [4, 0],
+          [4, 4],
+          [0, 4],
+          [0, 0],
+        ],
+      ],
+    },
+    state: null,
+    controllingFacility: null,
+    scheduleDescription: null,
+    artccStratum: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Wraps an airport in a resolver search result with empty highlight ranges.
+ */
+function airportMatch(
+  airport: Airport,
+  score: number,
+  matchedField: AirportSearchField = 'faaId',
+): AirportSearchResult {
+  return { airport, score, matchedField, ranges: [] };
+}
+
+/**
+ * Wraps a navaid in a resolver search result with empty highlight ranges.
+ */
+function navaidMatch(
+  navaid: Navaid,
+  score: number,
+  matchedField: NavaidSearchField = 'identifier',
+): NavaidSearchResult {
+  return { navaid, score, matchedField, ranges: [] };
+}
+
+/**
+ * Wraps a fix in a resolver search result with empty highlight ranges.
+ */
+function fixMatch(fix: Fix, score: number): FixSearchResult {
+  return { fix, score, matchedField: 'identifier', ranges: [] };
+}
+
+/**
+ * Wraps an airway in a resolver search result with empty highlight ranges.
+ */
+function airwayMatch(airway: Airway, score: number): AirwaySearchResult {
+  return { airway, score, matchedField: 'designation', ranges: [] };
+}
+
+/**
+ * Wraps an airspace feature in a resolver search result with empty ranges.
+ */
+function airspaceMatch(
+  feature: AirspaceFeature,
+  score: number,
+  matchedField: AirspaceSearchField = 'identifier',
+): AirspaceSearchResult {
+  return { feature, score, matchedField, ranges: [] };
+}
+
+/**
+ * The canned per-dataset matches a fake resolver set returns, regardless of
+ * the query it receives.
+ */
+interface CannedMatches {
+  /** Airport matches returned by the fake airport resolver. */
+  airports?: AirportSearchResult[];
+  /** Navaid matches returned by the fake navaid resolver. */
+  navaids?: NavaidSearchResult[];
+  /** Fix matches returned by the fake fix resolver. */
+  fixes?: FixSearchResult[];
+  /** Airway matches returned by the fake airway resolver. */
+  airways?: AirwaySearchResult[];
+  /** Airspace matches returned by the fake airspace resolver. */
+  airspace?: AirspaceSearchResult[];
+}
+
+/**
+ * Builds a set of fake resolvers whose `search` ignores its query and returns
+ * the supplied canned matches (or an empty list when none are given).
+ */
+function makeResolvers(canned: CannedMatches = {}): ChartSearchResolvers {
+  return {
+    airports: { search: () => canned.airports ?? [] },
+    navaids: { search: () => canned.navaids ?? [] },
+    fixes: { search: () => canned.fixes ?? [] },
+    airways: { search: () => canned.airways ?? [] },
+    airspace: { search: () => canned.airspace ?? [] },
+  };
+}
+
+/**
+ * Builds a {@link SearchScope} with every dataset disabled by default, so a
+ * test enables only the kinds it exercises.
+ */
+function makeScope(overrides: Partial<SearchScope> = {}): SearchScope {
+  return {
+    airports: { enabled: false, types: RENDERED_AIRPORT_FACILITY_TYPES },
+    navaids: { enabled: false, types: RENDERED_NAVAID_TYPES },
+    fixes: { enabled: false },
+    airways: { enabled: false, types: new Set<AirwayType>() },
+    airspace: { enabled: false, types: new Set<AirspaceType>() },
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a {@link LayerVisibility} with every dataset visible by default.
+ */
+function makeVisibility(overrides: Partial<LayerVisibility> = {}): LayerVisibility {
+  return {
+    airports: true,
+    navaids: true,
+    fixes: true,
+    airwayTypes: new Set<AirwayType>(['VICTOR']),
+    airspaceTypes: new Set<AirspaceType>(['CLASS_B']),
+    ...overrides,
+  };
+}
+
+/**
+ * Convenience runner that fills in a non-blank query and all-visible defaults.
+ */
+function run(params: {
+  /** Search text, defaulting to a non-blank value. */
+  text?: string;
+  /** Resolver set to query. */
+  resolvers: ChartSearchResolvers;
+  /** Query scope. */
+  scope: SearchScope;
+  /** Layer visibility, defaulting to all visible. */
+  visibility?: LayerVisibility;
+  /** Result cap. */
+  limit?: number;
+  /** Minimum score forwarded to resolvers. */
+  minScore?: number;
+}): ChartSearchResult[] {
+  return searchChartFeatures({
+    text: params.text ?? 'bos',
+    resolvers: params.resolvers,
+    scope: params.scope,
+    visibility: params.visibility ?? makeVisibility(),
+    ...(params.limit !== undefined && { limit: params.limit }),
+    ...(params.minScore !== undefined && { minScore: params.minScore }),
+  });
+}
+
+describe('searchChartFeatures', () => {
+  it('returns nothing for blank text without querying any resolver', () => {
+    const throwing: ChartSearchResolvers = {
+      airports: {
+        search: () => {
+          throw new Error('airports queried');
+        },
+      },
+      navaids: {
+        search: () => {
+          throw new Error('navaids queried');
+        },
+      },
+      fixes: {
+        search: () => {
+          throw new Error('fixes queried');
+        },
+      },
+      airways: {
+        search: () => {
+          throw new Error('airways queried');
+        },
+      },
+      airspace: {
+        search: () => {
+          throw new Error('airspace queried');
+        },
+      },
+    };
+    const results = run({
+      text: '   ',
+      resolvers: throwing,
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+    });
+    expect(results).toEqual([]);
+  });
+
+  it('does not query a dataset whose scope is disabled', () => {
+    const resolvers: ChartSearchResolvers = {
+      ...makeResolvers({ airports: [airportMatch(makeAirport({ faaId: 'BOS' }), 0.9)] }),
+      navaids: {
+        search: () => {
+          throw new Error('navaids queried');
+        },
+      },
+    };
+    const results = run({
+      resolvers,
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.kind).toBe('airport');
+  });
+
+  it('merges results across datasets and sorts by descending score', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airports: [airportMatch(makeAirport({ faaId: 'BOS' }), 0.5)],
+        navaids: [navaidMatch(makeNavaid({ identifier: 'BOS' }), 0.9)],
+        fixes: [fixMatch(makeFix({ identifier: 'BOSCO' }), 0.7)],
+      }),
+      scope: makeScope({
+        airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES },
+        navaids: { enabled: true, types: RENDERED_NAVAID_TYPES },
+        fixes: { enabled: true },
+      }),
+    });
+    expect(results.map((result) => result.kind)).toEqual(['navaid', 'fix', 'airport']);
+    expect(results.map((result) => result.score)).toEqual([0.9, 0.7, 0.5]);
+  });
+
+  it('truncates the merged list to the default limit', () => {
+    const matches = Array.from({ length: DEFAULT_RESULT_LIMIT + 5 }, (_unused, index) =>
+      airportMatch(makeAirport({ faaId: `A${index}` }), 1 - index * 0.01),
+    );
+    const results = run({
+      resolvers: makeResolvers({ airports: matches }),
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+    });
+    expect(results).toHaveLength(DEFAULT_RESULT_LIMIT);
+  });
+
+  it('honors a custom limit', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airports: [
+          airportMatch(makeAirport({ faaId: 'AAA' }), 0.9),
+          airportMatch(makeAirport({ faaId: 'BBB' }), 0.8),
+          airportMatch(makeAirport({ faaId: 'CCC' }), 0.7),
+        ],
+      }),
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+      limit: 2,
+    });
+    expect(results.map((result) => result.label)).toEqual(['AAA', 'BBB']);
+  });
+
+  it('drops navaids the resolver returns that are not in the drawable corpus', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        navaids: [
+          navaidMatch(
+            makeNavaid({ identifier: 'GON', type: 'VOR', status: 'OPERATIONAL_IFR' }),
+            0.9,
+          ),
+          navaidMatch(makeNavaid({ identifier: 'OLD', type: 'VOR', status: 'SHUTDOWN' }), 0.8),
+          navaidMatch(
+            makeNavaid({ identifier: 'VTX', type: 'VOT', status: 'OPERATIONAL_IFR' }),
+            0.7,
+          ),
+        ],
+      }),
+      scope: makeScope({ navaids: { enabled: true, types: RENDERED_NAVAID_TYPES } }),
+    });
+    expect(results.map((result) => result.label)).toEqual(['GON']);
+  });
+
+  it('drops an airway with no waypoints to derive a center from', () => {
+    const results = run({
+      resolvers: makeResolvers({ airways: [airwayMatch(makeAirway({ waypoints: [] }), 0.9)] }),
+      scope: makeScope({ airways: { enabled: true, types: new Set<AirwayType>(['VICTOR']) } }),
+    });
+    expect(results).toEqual([]);
+  });
+
+  it('centers an airway on its waypoint bounding box', () => {
+    const results = run({
+      resolvers: makeResolvers({ airways: [airwayMatch(makeAirway({ designation: 'V16' }), 0.9)] }),
+      scope: makeScope({ airways: { enabled: true, types: new Set<AirwayType>(['VICTOR']) } }),
+    });
+    const result = results[0];
+    expect(result?.kind).toBe('airway');
+    expect(result?.selection).toBe('airway:V16');
+    expect(result?.center).toEqual({ lng: -72, lat: 43 });
+    if (result?.kind === 'airway') {
+      expect(result.subtype).toBe('VICTOR');
+      expect(result.bbox).toEqual({ minLon: -73, maxLon: -71, minLat: 42, maxLat: 44 });
+    }
+  });
+
+  it('drops an airspace feature whose polygon has no computable centroid', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airspace: [
+          airspaceMatch(makeAirspace({ boundary: { type: 'Polygon', coordinates: [] } }), 0.9),
+        ],
+      }),
+      scope: makeScope({ airspace: { enabled: true, types: new Set<AirspaceType>(['CLASS_B']) } }),
+    });
+    expect(results).toEqual([]);
+  });
+
+  it('encodes an airspace selection from its identifier when present', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airspace: [
+          airspaceMatch(
+            makeAirspace({ type: 'CLASS_B', identifier: 'JFK', name: 'NEW YORK' }),
+            0.9,
+          ),
+        ],
+      }),
+      scope: makeScope({ airspace: { enabled: true, types: new Set<AirspaceType>(['CLASS_B']) } }),
+    });
+    const result = results[0];
+    expect(result?.selection).toBe('airspace:CLASS_B/JFK');
+    expect(result?.label).toBe('CLASS B JFK');
+    expect(result?.center.lng).toBeCloseTo(1.6, 10);
+    expect(result?.center.lat).toBeCloseTo(1.6, 10);
+  });
+
+  it('encodes an empty-identifier airspace selection from its centroid', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airspace: [
+          airspaceMatch(makeAirspace({ type: 'CLASS_E5', identifier: '', name: 'PODUNK E5' }), 0.9),
+        ],
+      }),
+      scope: makeScope({ airspace: { enabled: true, types: new Set<AirspaceType>(['CLASS_E5']) } }),
+    });
+    const result = results[0];
+    expect(result?.selection).toBe('airspace:CLASS_E5/c:1.60000,1.60000');
+    expect(result?.label).toBe('PODUNK E5');
+  });
+
+  it('selects the navaid matched text by matched field', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        navaids: [navaidMatch(makeNavaid({ identifier: 'BOS', name: 'BOSTON' }), 0.9, 'name')],
+      }),
+      scope: makeScope({ navaids: { enabled: true, types: RENDERED_NAVAID_TYPES } }),
+    });
+    const result = results[0];
+    expect(result?.kind).toBe('navaid');
+    if (result?.kind === 'navaid') {
+      expect(result.matchedField).toBe('name');
+      expect(result.matchedText).toBe('BOSTON');
+      expect(result.subtype).toBe('VOR');
+    }
+  });
+
+  it('selects the airspace matched text by matched field', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        airspace: [
+          airspaceMatch(
+            makeAirspace({ type: 'CLASS_B', identifier: 'JFK', name: 'NEW YORK' }),
+            0.9,
+            'name',
+          ),
+        ],
+      }),
+      scope: makeScope({ airspace: { enabled: true, types: new Set<AirspaceType>(['CLASS_B']) } }),
+    });
+    const result = results[0];
+    if (result?.kind === 'airspace') {
+      expect(result.matchedField).toBe('name');
+      expect(result.matchedText).toBe('NEW YORK');
+      expect(result.bbox).toEqual({ minLon: 0, maxLon: 4, minLat: 0, maxLat: 4 });
+    }
+  });
+
+  it('passes the resolver highlight ranges through unchanged', () => {
+    const match = airportMatch(makeAirport({ faaId: 'BOS' }), 0.9);
+    const results = run({
+      resolvers: makeResolvers({ airports: [match] }),
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+    });
+    expect(results[0]?.ranges).toBe(match.ranges);
+  });
+
+  it('tags a result hidden when its layer is not visible', () => {
+    const visible = run({
+      resolvers: makeResolvers({ airports: [airportMatch(makeAirport({ faaId: 'BOS' }), 0.9)] }),
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+      visibility: makeVisibility({ airports: true }),
+    });
+    expect(visible[0]?.hidden).toBe(false);
+
+    const hidden = run({
+      resolvers: makeResolvers({ airports: [airportMatch(makeAirport({ faaId: 'BOS' }), 0.9)] }),
+      scope: makeScope({ airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES } }),
+      visibility: makeVisibility({ airports: false }),
+    });
+    expect(hidden[0]?.hidden).toBe(true);
+  });
+
+  it('tags an airway hidden when its type is absent from the visible types', () => {
+    const results = run({
+      resolvers: makeResolvers({ airways: [airwayMatch(makeAirway({ type: 'VICTOR' }), 0.9)] }),
+      scope: makeScope({ airways: { enabled: true, types: new Set<AirwayType>(['VICTOR']) } }),
+      visibility: makeVisibility({ airwayTypes: new Set<AirwayType>() }),
+    });
+    expect(results[0]?.hidden).toBe(true);
+  });
+
+  it('forwards the trimmed text, scope types, limit, and minScore to the resolvers', () => {
+    let airportQuery: AirportSearchQuery | undefined;
+    let fixQuery: FixSearchQuery | undefined;
+    const resolvers: ChartSearchResolvers = {
+      ...makeResolvers(),
+      airports: {
+        search: (query) => {
+          airportQuery = query;
+          return [];
+        },
+      },
+      fixes: {
+        search: (query) => {
+          fixQuery = query;
+          return [];
+        },
+      },
+    };
+    run({
+      text: '  bos  ',
+      resolvers,
+      scope: makeScope({
+        airports: { enabled: true, types: RENDERED_AIRPORT_FACILITY_TYPES },
+        fixes: { enabled: true },
+      }),
+      limit: 7,
+      minScore: 0.3,
+    });
+    expect(airportQuery?.text).toBe('bos');
+    expect(airportQuery?.types).toBe(RENDERED_AIRPORT_FACILITY_TYPES);
+    expect(airportQuery?.limit).toBe(7);
+    expect(airportQuery?.minScore).toBe(0.3);
+    expect(fixQuery?.text).toBe('bos');
+    expect(fixQuery?.limit).toBe(7);
+    expect(fixQuery?.minScore).toBe(0.3);
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-features.ts
+++ b/apps/atlas/src/modes/chart/search/search-features.ts
@@ -1,0 +1,439 @@
+import type { AirportResolver, AirportSearchField, AirportSearchResult } from '@squawk/airports';
+import type { AirspaceResolver, AirspaceSearchField, AirspaceSearchResult } from '@squawk/airspace';
+import type { AirwayResolver, AirwaySearchField, AirwaySearchResult } from '@squawk/airways';
+import type { FixResolver, FixSearchField, FixSearchResult } from '@squawk/fixes';
+import { polygonGeoJson } from '@squawk/geo';
+import type { NavaidResolver, NavaidSearchField, NavaidSearchResult } from '@squawk/navaids';
+import type { MatchRange } from '@squawk/search';
+import type { Airport, AirspaceFeature, AirspaceType, AirwayType, NavaidType } from '@squawk/types';
+
+import { encodeSelected } from '../../../shared/inspector/entity.ts';
+import {
+  bboxFromCoords,
+  bboxFromWaypoints,
+  coordsOfPolygon,
+} from '../../../shared/inspector/geometry.ts';
+import type { BoundingBox } from '../../../shared/inspector/geometry.ts';
+import { formatAirspaceLabel } from '../click-to-select.ts';
+import { isDrawableNavaid } from '../layers/drawable-sets.ts';
+
+import type { LayerVisibility, SearchScope } from './search-scope.ts';
+
+/**
+ * Discriminator for the kind of chart feature a {@link ChartSearchResult}
+ * describes. Mirrors the inspector's entity-type literals so a result's
+ * `kind` can drive both the row badge and the downstream layer-reveal logic.
+ */
+export type SearchFeatureKind = 'airport' | 'navaid' | 'fix' | 'airway' | 'airspace';
+
+/**
+ * Fields shared by every {@link ChartSearchResult} variant, independent of
+ * feature kind. The per-kind variants add their typed `kind` discriminator,
+ * `matchedField`, and (for kinds with chart sub-classes) a `subtype`.
+ */
+export interface ChartSearchResultBase {
+  /**
+   * URL `selected` value that pins this result in the inspector, in the
+   * `{type}:{id}` form produced by {@link encodeSelected}. Round-trips through
+   * the inspector's entity resolver, so choosing a result and writing this to
+   * the URL resolves the same feature.
+   */
+  selection: string;
+  /** Primary display text for the result row (e.g. an FAA id or designation). */
+  label: string;
+  /** Secondary display text (e.g. a facility name), or undefined when the kind has none. */
+  sublabel: string | undefined;
+  /** Text of the field that produced the match, that {@link ChartSearchResultBase.ranges} index into. */
+  matchedText: string;
+  /** Matched character ranges within {@link ChartSearchResultBase.matchedText}, for highlighting. */
+  ranges: MatchRange[];
+  /** Fuzzy match strength in `[0, 1]`, where 1 is an exact match. Used to merge-sort across kinds. */
+  score: number;
+  /** Geographic point to center the camera on when this result is chosen, in MapLibre `{ lng, lat }` form. */
+  center: {
+    /** Longitude in decimal degrees (WGS84). */
+    lng: number;
+    /** Latitude in decimal degrees (WGS84). */
+    lat: number;
+  };
+  /**
+   * Whether this result's feature type is currently absent from the Layers
+   * menu (i.e. not drawn on the map). Always false unless the search ran with
+   * hidden results included; lets the UI flag and the selection flow reveal
+   * the owning layer.
+   */
+  hidden: boolean;
+}
+
+/**
+ * A scored airport search result.
+ */
+export interface AirportChartSearchResult extends ChartSearchResultBase {
+  /** Discriminator: airport result. */
+  kind: 'airport';
+  /** Which airport field produced the best match. */
+  matchedField: AirportSearchField;
+}
+
+/**
+ * A scored navaid search result, carrying the navaid's type for badge display.
+ */
+export interface NavaidChartSearchResult extends ChartSearchResultBase {
+  /** Discriminator: navaid result. */
+  kind: 'navaid';
+  /** The matched navaid's type (e.g. `'VOR'`, `'NDB'`), for badge display. */
+  subtype: NavaidType;
+  /** Which navaid field produced the best match. */
+  matchedField: NavaidSearchField;
+}
+
+/**
+ * A scored fix search result.
+ */
+export interface FixChartSearchResult extends ChartSearchResultBase {
+  /** Discriminator: fix result. */
+  kind: 'fix';
+  /** Which fix field produced the best match (always the identifier). */
+  matchedField: FixSearchField;
+}
+
+/**
+ * A scored airway search result, carrying the airway's type for badge display.
+ */
+export interface AirwayChartSearchResult extends ChartSearchResultBase {
+  /** Discriminator: airway result. */
+  kind: 'airway';
+  /** The matched airway's type (e.g. `'VICTOR'`, `'JET'`), for badge display. */
+  subtype: AirwayType;
+  /** Which airway field produced the best match (always the designation). */
+  matchedField: AirwaySearchField;
+  /** Bounding box of the airway's waypoints, used to fit the camera on selection. */
+  bbox: BoundingBox;
+}
+
+/**
+ * A scored airspace search result, carrying the airspace's type for badge display.
+ */
+export interface AirspaceChartSearchResult extends ChartSearchResultBase {
+  /** Discriminator: airspace result. */
+  kind: 'airspace';
+  /** The matched feature's airspace type (e.g. `'CLASS_B'`, `'MOA'`), for badge display. */
+  subtype: AirspaceType;
+  /** Which airspace field produced the best match. */
+  matchedField: AirspaceSearchField;
+  /** Bounding box of the airspace's boundary, used to fit the camera on selection. */
+  bbox: BoundingBox;
+}
+
+/**
+ * A single scored result from {@link searchChartFeatures}, discriminated by
+ * `kind`. Each variant carries everything the results dropdown needs to render
+ * a row (label, sublabel, highlight ranges, badge) and everything the
+ * selection flow needs to act on it (URL selection, camera center, hidden flag).
+ */
+export type ChartSearchResult =
+  | AirportChartSearchResult
+  | NavaidChartSearchResult
+  | FixChartSearchResult
+  | AirwayChartSearchResult
+  | AirspaceChartSearchResult;
+
+/**
+ * The minimal resolver surface {@link searchChartFeatures} depends on: just the
+ * `search` method of each chart dataset resolver. Narrowed via `Pick` so test
+ * fakes only need to implement `search`, not the full lookup surface.
+ */
+export interface ChartSearchResolvers {
+  /** Airport resolver, queried when {@link SearchScope.airports} is enabled. */
+  airports: Pick<AirportResolver, 'search'>;
+  /** Navaid resolver, queried when {@link SearchScope.navaids} is enabled. */
+  navaids: Pick<NavaidResolver, 'search'>;
+  /** Fix resolver, queried when {@link SearchScope.fixes} is enabled. */
+  fixes: Pick<FixResolver, 'search'>;
+  /** Airway resolver, queried when {@link SearchScope.airways} is enabled. */
+  airways: Pick<AirwayResolver, 'search'>;
+  /** Airspace resolver, queried when {@link SearchScope.airspace} is enabled. */
+  airspace: Pick<AirspaceResolver, 'search'>;
+}
+
+/**
+ * Parameters for {@link searchChartFeatures}.
+ */
+export interface ChartSearchParams {
+  /** Raw search text. Trimmed internally; a blank query yields no results. */
+  text: string;
+  /** The dataset resolvers to query. */
+  resolvers: ChartSearchResolvers;
+  /** Which datasets to query and the subtype filter for each, from `computeSearchScope`. */
+  scope: SearchScope;
+  /** Per-dataset Layers-menu visibility, used to tag each result's `hidden` flag. */
+  visibility: LayerVisibility;
+  /** Maximum number of merged results to return. Defaults to {@link DEFAULT_RESULT_LIMIT}. */
+  limit?: number;
+  /** Minimum match score (exclusive) forwarded to each resolver. When omitted, every match is kept. */
+  minScore?: number;
+}
+
+/**
+ * Default maximum number of merged results returned by
+ * {@link searchChartFeatures}.
+ */
+export const DEFAULT_RESULT_LIMIT = 20;
+
+/**
+ * Resolves the matched-field text for an airport result so the highlight
+ * ranges line up with the field the fuzzy matcher scored against.
+ */
+function airportMatchedText(airport: Airport, field: AirportSearchField): string {
+  switch (field) {
+    case 'faaId':
+      return airport.faaId;
+    case 'icao':
+      return airport.icao ?? '';
+    case 'name':
+      return airport.name;
+    case 'city':
+      return airport.city;
+  }
+}
+
+/**
+ * Builds an airport result row from a resolver match.
+ */
+function buildAirportResult(
+  match: AirportSearchResult,
+  visibility: LayerVisibility,
+): AirportChartSearchResult {
+  const airport = match.airport;
+  return {
+    kind: 'airport',
+    selection: encodeSelected({ type: 'airport', id: airport.faaId }),
+    label: airport.faaId,
+    sublabel: airport.name,
+    matchedField: match.matchedField,
+    matchedText: airportMatchedText(airport, match.matchedField),
+    ranges: match.ranges,
+    score: match.score,
+    center: { lng: airport.lon, lat: airport.lat },
+    hidden: !visibility.airports,
+  };
+}
+
+/**
+ * Builds a navaid result row from a resolver match.
+ */
+function buildNavaidResult(
+  match: NavaidSearchResult,
+  visibility: LayerVisibility,
+): NavaidChartSearchResult {
+  const navaid = match.navaid;
+  return {
+    kind: 'navaid',
+    selection: encodeSelected({ type: 'navaid', id: navaid.identifier }),
+    label: navaid.identifier,
+    sublabel: navaid.name,
+    subtype: navaid.type,
+    matchedField: match.matchedField,
+    matchedText: match.matchedField === 'identifier' ? navaid.identifier : navaid.name,
+    ranges: match.ranges,
+    score: match.score,
+    center: { lng: navaid.lon, lat: navaid.lat },
+    hidden: !visibility.navaids,
+  };
+}
+
+/**
+ * Builds a fix result row from a resolver match.
+ */
+function buildFixResult(match: FixSearchResult, visibility: LayerVisibility): FixChartSearchResult {
+  const fix = match.fix;
+  return {
+    kind: 'fix',
+    selection: encodeSelected({ type: 'fix', id: fix.identifier }),
+    label: fix.identifier,
+    sublabel: undefined,
+    matchedField: match.matchedField,
+    matchedText: fix.identifier,
+    ranges: match.ranges,
+    score: match.score,
+    center: { lng: fix.lon, lat: fix.lat },
+    hidden: !visibility.fixes,
+  };
+}
+
+/**
+ * Builds an airway result row from a resolver match. Returns undefined when the
+ * airway has no waypoints to derive a camera center from, so the result is
+ * dropped rather than carrying an unusable center.
+ */
+function buildAirwayResult(
+  match: AirwaySearchResult,
+  visibility: LayerVisibility,
+): AirwayChartSearchResult | undefined {
+  const airway = match.airway;
+  const bbox = bboxFromWaypoints(airway.waypoints);
+  if (bbox === undefined) {
+    return undefined;
+  }
+  return {
+    kind: 'airway',
+    selection: encodeSelected({ type: 'airway', id: airway.designation }),
+    label: airway.designation,
+    sublabel: undefined,
+    subtype: airway.type,
+    matchedField: match.matchedField,
+    matchedText: airway.designation,
+    ranges: match.ranges,
+    score: match.score,
+    center: { lng: (bbox.minLon + bbox.maxLon) / 2, lat: (bbox.minLat + bbox.maxLat) / 2 },
+    bbox,
+    hidden: !visibility.airwayTypes.has(airway.type),
+  };
+}
+
+/**
+ * Encodes the URL selection for an airspace feature. Non-empty identifiers use
+ * the `{type}/{identifier}` form; empty identifiers (some Class E5 surfaces)
+ * fall back to the centroid encoding `{type}/c:{lon},{lat}`, matching the
+ * click-path encoding so the inspector's `byCentroid` lookup resolves it.
+ */
+function airspaceSelection(feature: AirspaceFeature, centroid: readonly [number, number]): string {
+  if (feature.identifier !== '') {
+    return encodeSelected({ type: 'airspace', id: `${feature.type}/${feature.identifier}` });
+  }
+  const lon = centroid[0].toFixed(5);
+  const lat = centroid[1].toFixed(5);
+  return encodeSelected({ type: 'airspace', id: `${feature.type}/c:${lon},${lat}` });
+}
+
+/**
+ * Builds an airspace result row from a resolver match. Returns undefined when
+ * the feature's polygon has no computable centroid or bounding box, since the
+ * centroid backs both the camera center and the empty-identifier selection key
+ * and the bounding box frames the camera on selection.
+ */
+function buildAirspaceResult(
+  match: AirspaceSearchResult,
+  visibility: LayerVisibility,
+): AirspaceChartSearchResult | undefined {
+  const feature = match.feature;
+  const centroid = polygonGeoJson.polygonCentroid(feature.boundary);
+  if (centroid === undefined) {
+    return undefined;
+  }
+  const bbox = bboxFromCoords(coordsOfPolygon(feature.boundary));
+  if (bbox === undefined) {
+    return undefined;
+  }
+  return {
+    kind: 'airspace',
+    selection: airspaceSelection(feature, centroid),
+    label: formatAirspaceLabel(feature.type, feature.identifier, feature.name),
+    sublabel: undefined,
+    subtype: feature.type,
+    matchedField: match.matchedField,
+    matchedText: match.matchedField === 'identifier' ? feature.identifier : feature.name,
+    ranges: match.ranges,
+    score: match.score,
+    center: { lng: centroid[0], lat: centroid[1] },
+    bbox,
+    hidden: !visibility.airspaceTypes.has(feature.type),
+  };
+}
+
+/**
+ * Runs a fuzzy chart-feature search across every in-scope dataset and merges
+ * the results into a single score-ranked list.
+ *
+ * Each enabled dataset (per {@link ChartSearchParams.scope}) is queried with
+ * the trimmed text and its subtype filter. Navaid matches are post-filtered to
+ * the drawable corpus via {@link isDrawableNavaid} so shutdown facilities never
+ * surface. Airway and airspace matches that lack usable geometry (no waypoints,
+ * no polygon centroid) are dropped. The merged results are sorted by descending
+ * score and truncated to the limit.
+ *
+ * @param params - Search text, resolvers, scope, visibility, and limits.
+ * @returns Score-ranked results, best match first, capped at the limit.
+ */
+export function searchChartFeatures(params: ChartSearchParams): ChartSearchResult[] {
+  const text = params.text.trim();
+  if (text.length === 0) {
+    return [];
+  }
+
+  const { resolvers, scope, visibility } = params;
+  const limit = params.limit ?? DEFAULT_RESULT_LIMIT;
+  const minScore = params.minScore;
+  const results: ChartSearchResult[] = [];
+
+  if (scope.airports.enabled) {
+    const matches = resolvers.airports.search({
+      text,
+      types: scope.airports.types,
+      limit,
+      ...(minScore !== undefined && { minScore }),
+    });
+    for (const match of matches) {
+      results.push(buildAirportResult(match, visibility));
+    }
+  }
+
+  if (scope.navaids.enabled) {
+    const matches = resolvers.navaids.search({
+      text,
+      types: scope.navaids.types,
+      limit,
+      ...(minScore !== undefined && { minScore }),
+    });
+    for (const match of matches) {
+      if (!isDrawableNavaid(match.navaid)) {
+        continue;
+      }
+      results.push(buildNavaidResult(match, visibility));
+    }
+  }
+
+  if (scope.fixes.enabled) {
+    const matches = resolvers.fixes.search({
+      text,
+      limit,
+      ...(minScore !== undefined && { minScore }),
+    });
+    for (const match of matches) {
+      results.push(buildFixResult(match, visibility));
+    }
+  }
+
+  if (scope.airways.enabled) {
+    const matches = resolvers.airways.search({
+      text,
+      types: scope.airways.types,
+      limit,
+      ...(minScore !== undefined && { minScore }),
+    });
+    for (const match of matches) {
+      const result = buildAirwayResult(match, visibility);
+      if (result !== undefined) {
+        results.push(result);
+      }
+    }
+  }
+
+  if (scope.airspace.enabled) {
+    const matches = resolvers.airspace.search({
+      text,
+      types: scope.airspace.types,
+      limit,
+      ...(minScore !== undefined && { minScore }),
+    });
+    for (const match of matches) {
+      const result = buildAirspaceResult(match, visibility);
+      if (result !== undefined) {
+        results.push(result);
+      }
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, limit);
+}

--- a/apps/atlas/src/modes/chart/search/search-filter-menu.spec.tsx
+++ b/apps/atlas/src/modes/chart/search/search-filter-menu.spec.tsx
@@ -1,0 +1,534 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AIRSPACE_CLASSES, AIRWAY_CATEGORIES, LAYER_IDS } from '../url-state.ts';
+import type { ChartSearch } from '../url-state.ts';
+
+import { SearchFilterMenu } from './search-filter-menu.tsx';
+
+/** Shape of the single argument the component passes to `navigate`. */
+interface NavigateArg {
+  /** Updater that receives the current search and returns the next one. */
+  search: (prev: ChartSearch) => ChartSearch;
+  /** Whether to use history.replaceState instead of pushState. */
+  replace?: boolean;
+}
+
+/** Subset of the search shape the filter menu reads via `route.useSearch()`. */
+type FilterSearch = Pick<
+  ChartSearch,
+  | 'layers'
+  | 'airspaceClasses'
+  | 'airwayCategories'
+  | 'searchLayers'
+  | 'searchAirspaceClasses'
+  | 'searchAirwayCategories'
+  | 'searchIncludeHidden'
+>;
+
+const { useSearchMock, navigateMock } = vi.hoisted(() => ({
+  useSearchMock: vi.fn<() => FilterSearch>(),
+  navigateMock: vi.fn<(arg: NavigateArg) => void>(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({ useSearch: useSearchMock }),
+  useNavigate: () => navigateMock,
+}));
+
+// Radix DropdownMenu's open/close cycle drives off pointer events that jsdom
+// does not fully simulate, and its internals (portal layout, keyboard handling,
+// etc.) are third-party concerns we do not want to pin down. Mock the
+// primitives so the trigger and every menu item render unconditionally and row
+// clicks call the right handler. The Trigger forwards `aria-label` so the
+// active-filter state (which the funnel dot signals visually) can be asserted
+// through the button's accessible name. CheckboxItem renders as a div with
+// role="menuitemcheckbox" mirroring real Radix and passes `className` through so
+// the dimming style can be read off the row.
+vi.mock('@radix-ui/react-dropdown-menu', () => {
+  function Root({ children }: { children: ReactNode }): ReactNode {
+    return children;
+  }
+  function Trigger({
+    children,
+    className,
+    'aria-label': ariaLabel,
+  }: {
+    children: ReactNode;
+    className?: string;
+    'aria-label'?: string;
+  }): ReactNode {
+    return (
+      <button type="button" className={className} aria-label={ariaLabel}>
+        {children}
+      </button>
+    );
+  }
+  function Portal({ children }: { children: ReactNode }): ReactNode {
+    return children;
+  }
+  function Content({ children }: { children: ReactNode }): ReactNode {
+    return <div>{children}</div>;
+  }
+  function CheckboxItem({
+    children,
+    checked,
+    onCheckedChange,
+    onKeyDown,
+    className,
+  }: {
+    children: ReactNode;
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    onSelect?: (event: Event) => void;
+    onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+    className?: string;
+  }): ReactNode {
+    const activate = (): void => onCheckedChange(!checked);
+    return (
+      <div
+        role="menuitemcheckbox"
+        aria-checked={checked}
+        tabIndex={0}
+        className={className}
+        onClick={activate}
+        onKeyDown={(event) => {
+          // Run the consumer's handler first so it can preventDefault on
+          // arrow keys (the unified parent row uses ArrowRight/Left for
+          // expand/collapse before the menu's space/enter activation).
+          onKeyDown?.(event);
+          if (event.defaultPrevented) {
+            return;
+          }
+          if (event.key === ' ' || event.key === 'Enter') {
+            event.preventDefault();
+            activate();
+          }
+        }}
+      >
+        {children}
+      </div>
+    );
+  }
+  function ItemIndicator({ children }: { children: ReactNode }): ReactNode {
+    return <span>{children}</span>;
+  }
+  function Separator({ className }: { className?: string }): ReactNode {
+    return <div role="separator" className={className} />;
+  }
+  return { Root, Trigger, Portal, Content, CheckboxItem, ItemIndicator, Separator };
+});
+
+/**
+ * Reads the most recent navigate call's `search` updater and applies it to a
+ * stub previous state, returning what the URL would resolve to. The handlers
+ * always overwrite the fields they own from the component's current props
+ * (not from `prev`), so `prev` only needs to carry the fields a test does not
+ * assert on.
+ */
+function applyLatestSearchUpdate(prev: ChartSearch): ChartSearch {
+  const lastCall = navigateMock.mock.calls.at(-1);
+  if (lastCall === undefined) {
+    throw new Error('navigate was not called');
+  }
+  return lastCall[0].search(prev);
+}
+
+/** Builds a complete `FilterSearch` with the all-on / include-hidden-off defaults plus overrides. */
+function makeSearch(overrides: Partial<FilterSearch> = {}): FilterSearch {
+  return {
+    layers: [...LAYER_IDS],
+    airspaceClasses: [...AIRSPACE_CLASSES],
+    airwayCategories: [...AIRWAY_CATEGORIES],
+    searchLayers: [...LAYER_IDS],
+    searchAirspaceClasses: [...AIRSPACE_CLASSES],
+    searchAirwayCategories: [...AIRWAY_CATEGORIES],
+    searchIncludeHidden: false,
+    ...overrides,
+  };
+}
+
+/** Builds a complete `ChartSearch` for use as the `prev` argument in navigate updaters. */
+function makePrev(overrides: Partial<ChartSearch> = {}): ChartSearch {
+  return {
+    lat: 0,
+    lon: 0,
+    zoom: 0,
+    pitch: 0,
+    layers: [...LAYER_IDS],
+    airspaceClasses: [...AIRSPACE_CLASSES],
+    airwayCategories: [...AIRWAY_CATEGORIES],
+    searchLayers: [...LAYER_IDS],
+    searchAirspaceClasses: [...AIRSPACE_CLASSES],
+    searchAirwayCategories: [...AIRWAY_CATEGORIES],
+    searchIncludeHidden: false,
+    ...overrides,
+  };
+}
+
+/** Resolves the parent row for a given layer label. All parent rows are menuitemcheckbox. */
+function getParentRow(label: RegExp | string): HTMLElement {
+  const items = screen.getAllByRole('menuitemcheckbox');
+  const text = typeof label === 'string' ? label.toLowerCase() : label.source.toLowerCase();
+  const match = items.find((el) => el.textContent?.toLowerCase().includes(text));
+  if (match === undefined) {
+    throw new Error(`No row matching ${label}`);
+  }
+  return match;
+}
+
+/** Click the chevron button inside an expandable parent row to toggle expansion. */
+function expandLayer(layer: 'airways' | 'airspace'): void {
+  const row = getParentRow(layer);
+  const chevron = within(row).getByRole('button', {
+    name: new RegExp(`(expand|collapse) ${layer} sub-list`, 'i'),
+  });
+  fireEvent.click(chevron);
+}
+
+/** Click the parent row body itself to toggle the layer's checked state. */
+function clickParentLayer(layer: 'airways' | 'airspace' | 'airports' | 'navaids' | 'fixes'): void {
+  fireEvent.click(getParentRow(layer));
+}
+
+/** Resolves the master include-hidden toggle row. */
+function getIncludeHiddenRow(): HTMLElement {
+  return screen.getByRole('menuitemcheckbox', { name: /include hidden features/i });
+}
+
+describe('SearchFilterMenu', () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    useSearchMock.mockReturnValue(makeSearch());
+  });
+
+  it('renders the funnel trigger and the include-hidden master toggle', () => {
+    render(<SearchFilterMenu />);
+
+    expect(screen.getByRole('button', { name: 'Search filters' })).toBeInTheDocument();
+    expect(getIncludeHiddenRow()).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('reflects the search layers as checked state on the parent rows', () => {
+    useSearchMock.mockReturnValue(makeSearch({ searchLayers: ['airports'] }));
+    render(<SearchFilterMenu />);
+
+    expect(getParentRow('airports')).toHaveAttribute('aria-checked', 'true');
+    expect(getParentRow('navaids')).toHaveAttribute('aria-checked', 'false');
+    expect(getParentRow('fixes')).toHaveAttribute('aria-checked', 'false');
+    expect(getParentRow('airways')).toHaveAttribute('aria-checked', 'false');
+    expect(getParentRow('airspace')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  describe('active-filter indicator', () => {
+    it('shows the inactive label when nothing is narrowed and include-hidden is off', () => {
+      render(<SearchFilterMenu />);
+
+      expect(screen.getByRole('button', { name: 'Search filters' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Search filters (filters applied)' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('marks filters applied when include-hidden is on', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchIncludeHidden: true }));
+      render(<SearchFilterMenu />);
+
+      expect(
+        screen.getByRole('button', { name: 'Search filters (filters applied)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('marks filters applied when the search layer set is narrowed', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchLayers: ['airports'] }));
+      render(<SearchFilterMenu />);
+
+      expect(
+        screen.getByRole('button', { name: 'Search filters (filters applied)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('marks filters applied when the searchable airspace classes are narrowed', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchAirspaceClasses: ['CLASS_B'] }));
+      render(<SearchFilterMenu />);
+
+      expect(
+        screen.getByRole('button', { name: 'Search filters (filters applied)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('marks filters applied when the searchable airway categories are narrowed', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchAirwayCategories: ['LOW'] }));
+      render(<SearchFilterMenu />);
+
+      expect(
+        screen.getByRole('button', { name: 'Search filters (filters applied)' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('include-hidden master toggle', () => {
+    it('turns include-hidden on when the toggle is clicked', () => {
+      render(<SearchFilterMenu />);
+      fireEvent.click(getIncludeHiddenRow());
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      expect(applyLatestSearchUpdate(makePrev()).searchIncludeHidden).toBe(true);
+    });
+
+    it('turns include-hidden off when it is already on', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchIncludeHidden: true }));
+      render(<SearchFilterMenu />);
+      expect(getIncludeHiddenRow()).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(getIncludeHiddenRow());
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      expect(
+        applyLatestSearchUpdate(makePrev({ searchIncludeHidden: true })).searchIncludeHidden,
+      ).toBe(false);
+    });
+  });
+
+  describe('search-layer filtering', () => {
+    it('removes a simple layer from searchLayers when its row is clicked', () => {
+      render(<SearchFilterMenu />);
+      clickParentLayer('fixes');
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(makePrev());
+      expect(next.searchLayers).toEqual(['airports', 'navaids', 'airways', 'airspace']);
+    });
+
+    it('toggles an expandable parent in searchLayers without expanding it', () => {
+      render(<SearchFilterMenu />);
+      clickParentLayer('airways');
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(makePrev());
+      expect(next.searchLayers).toEqual(['airports', 'navaids', 'fixes', 'airspace']);
+      expect(
+        screen.queryByRole('menuitemcheckbox', { name: /low altitude/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('reveals airspace sub-rows reflecting searchAirspaceClasses', () => {
+      useSearchMock.mockReturnValue(makeSearch({ searchAirspaceClasses: ['CLASS_B', 'MOA'] }));
+      render(<SearchFilterMenu />);
+      expandLayer('airspace');
+
+      expect(screen.getByRole('menuitemcheckbox', { name: /class b/i })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      expect(screen.getByRole('menuitemcheckbox', { name: /^moa$/i })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+      expect(screen.getByRole('menuitemcheckbox', { name: /class c/i })).toHaveAttribute(
+        'aria-checked',
+        'false',
+      );
+    });
+
+    it('removes an airway category from searchAirwayCategories when its sub-row is unchecked', () => {
+      render(<SearchFilterMenu />);
+      expandLayer('airways');
+      fireEvent.click(screen.getByRole('menuitemcheckbox', { name: /oceanic & regional/i }));
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(makePrev());
+      expect(next.searchAirwayCategories).toEqual(['LOW', 'HIGH']);
+      expect(next.searchLayers).toEqual([...LAYER_IDS]);
+    });
+  });
+
+  describe('sub-class parent coupling', () => {
+    it('auto-unchecks the airspace parent when the last searchable class is unchecked', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({ searchLayers: [...LAYER_IDS], searchAirspaceClasses: ['CLASS_B'] }),
+      );
+      render(<SearchFilterMenu />);
+      expandLayer('airspace');
+      fireEvent.click(screen.getByRole('menuitemcheckbox', { name: /class b/i }));
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({ searchLayers: [...LAYER_IDS], searchAirspaceClasses: ['CLASS_B'] }),
+      );
+      expect(next.searchAirspaceClasses).toEqual([]);
+      expect(next.searchLayers).toEqual(['airports', 'navaids', 'fixes', 'airways']);
+    });
+
+    it('auto-checks the airways parent when a category is checked from empty', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: [],
+        }),
+      );
+      render(<SearchFilterMenu />);
+      expandLayer('airways');
+      fireEvent.click(screen.getByRole('menuitemcheckbox', { name: /high altitude/i }));
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: [],
+        }),
+      );
+      expect(next.searchAirwayCategories).toEqual(['HIGH']);
+      expect(next.searchLayers).toEqual([...LAYER_IDS]);
+    });
+
+    it('refills the searchable airway categories when the emptied parent is re-checked', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: [],
+        }),
+      );
+      render(<SearchFilterMenu />);
+      clickParentLayer('airways');
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: [],
+        }),
+      );
+      expect(next.searchLayers).toEqual([...LAYER_IDS]);
+      expect(next.searchAirwayCategories).toEqual([...AIRWAY_CATEGORIES]);
+    });
+
+    it('refills the searchable airspace classes when the emptied parent is re-checked', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airways'],
+          searchAirspaceClasses: [],
+        }),
+      );
+      render(<SearchFilterMenu />);
+      clickParentLayer('airspace');
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airways'],
+          searchAirspaceClasses: [],
+        }),
+      );
+      expect(next.searchLayers).toEqual([...LAYER_IDS]);
+      expect(next.searchAirspaceClasses).toEqual([...AIRSPACE_CLASSES]);
+    });
+
+    it('preserves a non-empty searchable sub-array when the parent is re-checked', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: ['LOW', 'HIGH'],
+        }),
+      );
+      render(<SearchFilterMenu />);
+      clickParentLayer('airways');
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: ['LOW', 'HIGH'],
+        }),
+      );
+      expect(next.searchLayers).toEqual([...LAYER_IDS]);
+      expect(next.searchAirwayCategories).toEqual(['LOW', 'HIGH']);
+    });
+
+    it('leaves an explicitly-off parent alone when non-empty sub-rows are adjusted', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: ['LOW', 'HIGH'],
+        }),
+      );
+      render(<SearchFilterMenu />);
+      expandLayer('airways');
+      fireEvent.click(screen.getByRole('menuitemcheckbox', { name: /high altitude/i }));
+
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(
+        makePrev({
+          searchLayers: ['airports', 'navaids', 'fixes', 'airspace'],
+          searchAirwayCategories: ['LOW', 'HIGH'],
+        }),
+      );
+      expect(next.searchAirwayCategories).toEqual(['LOW']);
+      expect(next.searchLayers).toEqual(['airports', 'navaids', 'fixes', 'airspace']);
+    });
+  });
+
+  describe('dimming (hidden-on-map rows)', () => {
+    it('dims a parent row whose layer is hidden on the map while include-hidden is off', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({ layers: ['airports', 'fixes', 'airways', 'airspace'] }),
+      );
+      render(<SearchFilterMenu />);
+
+      expect(getParentRow('navaids').className).toContain('opacity-60');
+      expect(getParentRow('airports').className).not.toContain('opacity-60');
+    });
+
+    it('dims an expandable parent that draws nothing because its sub-array is empty', () => {
+      useSearchMock.mockReturnValue(makeSearch({ layers: [...LAYER_IDS], airwayCategories: [] }));
+      render(<SearchFilterMenu />);
+
+      expect(getParentRow('airways').className).toContain('opacity-60');
+      expect(getParentRow('airspace').className).not.toContain('opacity-60');
+    });
+
+    it('does not dim parent rows when include-hidden is on', () => {
+      useSearchMock.mockReturnValue(makeSearch({ layers: [], searchIncludeHidden: true }));
+      render(<SearchFilterMenu />);
+
+      expect(getParentRow('navaids').className).not.toContain('opacity-60');
+      expect(getParentRow('airways').className).not.toContain('opacity-60');
+    });
+
+    it('dims a sub-row whose sub-class is hidden on the map while include-hidden is off', () => {
+      useSearchMock.mockReturnValue(makeSearch({ airspaceClasses: ['CLASS_B'] }));
+      render(<SearchFilterMenu />);
+      expandLayer('airspace');
+
+      expect(screen.getByRole('menuitemcheckbox', { name: /class b/i }).className).not.toContain(
+        'opacity-60',
+      );
+      expect(screen.getByRole('menuitemcheckbox', { name: /class c/i }).className).toContain(
+        'opacity-60',
+      );
+    });
+
+    it('does not dim sub-rows when include-hidden is on', () => {
+      useSearchMock.mockReturnValue(makeSearch({ airspaceClasses: [], searchIncludeHidden: true }));
+      render(<SearchFilterMenu />);
+      expandLayer('airspace');
+
+      expect(screen.getByRole('menuitemcheckbox', { name: /class c/i }).className).not.toContain(
+        'opacity-60',
+      );
+    });
+
+    it('keeps a dimmed parent row toggleable so search intent still persists', () => {
+      useSearchMock.mockReturnValue(
+        makeSearch({ layers: ['airports', 'fixes', 'airways', 'airspace'] }),
+      );
+      render(<SearchFilterMenu />);
+      expect(getParentRow('navaids').className).toContain('opacity-60');
+
+      clickParentLayer('navaids');
+      expect(navigateMock).toHaveBeenCalledTimes(1);
+      const next = applyLatestSearchUpdate(makePrev());
+      expect(next.searchLayers).toEqual(['airports', 'fixes', 'airways', 'airspace']);
+    });
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-filter-menu.tsx
+++ b/apps/atlas/src/modes/chart/search/search-filter-menu.tsx
@@ -1,0 +1,335 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { getRouteApi, useNavigate } from '@tanstack/react-router';
+import { Fragment, useCallback, useState } from 'react';
+import type { ReactElement } from 'react';
+
+import {
+  FLOATING_SURFACE_CLASSES,
+  FOCUS_RING_CLASSES,
+} from '../../../shared/styles/style-tokens.ts';
+import { MenuItemRow } from '../../../shared/ui/menu-item-row.tsx';
+import {
+  AIRSPACE_CLASS_OPTIONS,
+  AIRWAY_CATEGORY_OPTIONS,
+  EXPANDABLE_LAYERS,
+  LAYER_OPTIONS,
+} from '../layer-options.ts';
+import { CheckIcon } from '../layer-toggle-icons.tsx';
+import { ExpandableParentRow, SimpleParentRow, SubRow } from '../layer-toggle-rows.tsx';
+import { AIRSPACE_CLASSES, AIRWAY_CATEGORIES, CHART_ROUTE_PATH, LAYER_IDS } from '../url-state.ts';
+import type { AirspaceClass, AirwayCategory, LayerId } from '../url-state.ts';
+
+const route = getRouteApi(CHART_ROUTE_PATH);
+
+/**
+ * Funnel icon for the filter trigger button. Outline-only so it reads as a
+ * control affordance rather than a filled glyph, matching the hairline search
+ * and clear icons it sits alongside inside the search box.
+ */
+function FunnelIcon(): ReactElement {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polygon points="22 3 2 3 10 12.5 10 19 14 21 14 12.5 22 3" />
+    </svg>
+  );
+}
+
+/**
+ * Search-scope filter dropdown whose trigger sits inside the chart search box,
+ * anchored to the input's right edge. Mirrors
+ * the Layers menu's feature-type and sub-class rows, but writes the search
+ * filter URL fields (`searchLayers`, `searchAirspaceClasses`,
+ * `searchAirwayCategories`) instead of the Layers-menu fields - this is the
+ * user's "what to search" intent, independent of what the map currently draws.
+ * {@link useChartSearch} reads those fields back, so toggling a row re-runs the
+ * live search without this component threading any state through.
+ *
+ * A master "include hidden features" toggle at the top writes
+ * `searchIncludeHidden`; when off, the search corpus is intersected with what
+ * the Layers menu draws. Rows whose feature type is hidden on the map are
+ * dimmed while that toggle is off, signalling the row currently has no effect,
+ * yet they stay toggleable so the user's intent persists for when the layer is
+ * shown or hidden results are included. A dot on the funnel marks any non-
+ * default filter state so the user can tell at a glance that search is scoped.
+ */
+export function SearchFilterMenu(): ReactElement {
+  const {
+    layers,
+    airspaceClasses,
+    airwayCategories,
+    searchLayers,
+    searchAirspaceClasses,
+    searchAirwayCategories,
+    searchIncludeHidden,
+  } = route.useSearch();
+  const navigate = useNavigate({ from: CHART_ROUTE_PATH });
+  const [expanded, setExpanded] = useState<ReadonlySet<LayerId>>(() => new Set());
+
+  const toggleExpanded = useCallback((id: LayerId): void => {
+    setExpanded((prev) => {
+      const next = new Set<LayerId>(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleIncludeHiddenChange = useCallback(
+    (checked: boolean): void => {
+      void navigate({
+        search: (prev) => ({ ...prev, searchIncludeHidden: checked }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const handleSearchLayerChange = useCallback(
+    (id: LayerId, checked: boolean): void => {
+      const enabled = new Set<LayerId>(searchLayers);
+      if (checked) {
+        enabled.add(id);
+      } else {
+        enabled.delete(id);
+      }
+      const nextLayers = LAYER_IDS.filter((layerId) => enabled.has(layerId));
+
+      // Re-checking the parent of an expandable layer whose sub-array was
+      // emptied (which auto-unchecked the parent) refills the sub-array to all
+      // so the layer is actually searchable again. A preserved non-empty
+      // sub-array is left untouched.
+      let nextAirspaceClasses: readonly AirspaceClass[] = searchAirspaceClasses;
+      if (checked && id === 'airspace' && searchAirspaceClasses.length === 0) {
+        nextAirspaceClasses = [...AIRSPACE_CLASSES];
+      }
+      let nextAirwayCategories: readonly AirwayCategory[] = searchAirwayCategories;
+      if (checked && id === 'airways' && searchAirwayCategories.length === 0) {
+        nextAirwayCategories = [...AIRWAY_CATEGORIES];
+      }
+
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          searchLayers: nextLayers,
+          searchAirspaceClasses: [...nextAirspaceClasses],
+          searchAirwayCategories: [...nextAirwayCategories],
+        }),
+        replace: true,
+      });
+    },
+    [searchLayers, searchAirspaceClasses, searchAirwayCategories, navigate],
+  );
+
+  const handleSearchAirspaceClassChange = useCallback(
+    (id: AirspaceClass, checked: boolean): void => {
+      const enabled = new Set<AirspaceClass>(searchAirspaceClasses);
+      if (checked) {
+        enabled.add(id);
+      } else {
+        enabled.delete(id);
+      }
+      const nextSub = AIRSPACE_CLASSES.filter((classId) => enabled.has(classId));
+
+      // Couple parent membership with sub-array non-emptiness so the parent
+      // checkbox always matches whether anything airspace is searchable:
+      //   sub becomes empty + parent on -> auto-uncheck parent
+      //   sub becomes non-empty (was empty) + parent off -> auto-check parent
+      const parentCurrentlyOn = searchLayers.includes('airspace');
+      let nextLayers: readonly LayerId[] = searchLayers;
+      if (nextSub.length === 0 && parentCurrentlyOn) {
+        nextLayers = searchLayers.filter((layerId) => layerId !== 'airspace');
+      } else if (searchAirspaceClasses.length === 0 && nextSub.length > 0 && !parentCurrentlyOn) {
+        nextLayers = LAYER_IDS.filter(
+          (layerId) => searchLayers.includes(layerId) || layerId === 'airspace',
+        );
+      }
+
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          searchAirspaceClasses: nextSub,
+          searchLayers: [...nextLayers],
+        }),
+        replace: true,
+      });
+    },
+    [searchAirspaceClasses, searchLayers, navigate],
+  );
+
+  const handleSearchAirwayCategoryChange = useCallback(
+    (id: AirwayCategory, checked: boolean): void => {
+      const enabled = new Set<AirwayCategory>(searchAirwayCategories);
+      if (checked) {
+        enabled.add(id);
+      } else {
+        enabled.delete(id);
+      }
+      const nextSub = AIRWAY_CATEGORIES.filter((catId) => enabled.has(catId));
+
+      const parentCurrentlyOn = searchLayers.includes('airways');
+      let nextLayers: readonly LayerId[] = searchLayers;
+      if (nextSub.length === 0 && parentCurrentlyOn) {
+        nextLayers = searchLayers.filter((layerId) => layerId !== 'airways');
+      } else if (searchAirwayCategories.length === 0 && nextSub.length > 0 && !parentCurrentlyOn) {
+        nextLayers = LAYER_IDS.filter(
+          (layerId) => searchLayers.includes(layerId) || layerId === 'airways',
+        );
+      }
+
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          searchAirwayCategories: nextSub,
+          searchLayers: [...nextLayers],
+        }),
+        replace: true,
+      });
+    },
+    [searchAirwayCategories, searchLayers, navigate],
+  );
+
+  // What the Layers menu currently draws, used to dim rows that have no effect
+  // while hidden results are excluded. Mirrors computeLayerVisibility: a layer
+  // draws nothing when it is off, and an expandable layer draws nothing when no
+  // sub-class remains selected.
+  const airwaysParentOn = layers.includes('airways');
+  const airspaceParentOn = layers.includes('airspace');
+  const drawnByLayer: Record<LayerId, boolean> = {
+    airports: layers.includes('airports'),
+    navaids: layers.includes('navaids'),
+    fixes: layers.includes('fixes'),
+    airways: airwaysParentOn && airwayCategories.length > 0,
+    airspace: airspaceParentOn && airspaceClasses.length > 0,
+  };
+
+  // A non-default filter state lights the funnel dot: a narrowed feature set in
+  // any of the three sub-filters, or include-hidden flipped on.
+  const hasActiveFilter =
+    searchIncludeHidden ||
+    searchLayers.length < LAYER_IDS.length ||
+    searchAirspaceClasses.length < AIRSPACE_CLASSES.length ||
+    searchAirwayCategories.length < AIRWAY_CATEGORIES.length;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        aria-label={hasActiveFilter ? 'Search filters (filters applied)' : 'Search filters'}
+        className={`absolute top-1/2 right-1.5 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded text-slate-400 hover:text-slate-700 ${FOCUS_RING_CLASSES} dark:text-slate-500 dark:hover:text-slate-200`}
+      >
+        <span className="flex h-5 w-5 items-center justify-center">
+          <FunnelIcon />
+        </span>
+        {hasActiveFilter ? (
+          <span
+            aria-hidden="true"
+            className="absolute top-1 right-1 h-1.5 w-1.5 rounded-full bg-indigo-500 dark:bg-indigo-400"
+          />
+        ) : null}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className={`z-40 min-w-[14rem] rounded-md p-1 shadow-lg ${FLOATING_SURFACE_CLASSES}`}
+        >
+          {/*
+            Master include-hidden toggle. Sits above the per-type rows behind a
+            separator so the hierarchy reads as "scope switch above, the feature
+            rows it relaxes below". Flipping it on un-dims every row at once.
+          */}
+          <MenuItemRow
+            checked={searchIncludeHidden}
+            onCheckedChange={handleIncludeHiddenChange}
+            onSelect={(event) => event.preventDefault()}
+            className="px-2 py-2.5 md:py-1.5"
+          >
+            <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center">
+              <DropdownMenu.ItemIndicator>
+                <CheckIcon />
+              </DropdownMenu.ItemIndicator>
+            </span>
+            <span className="flex-1">Include hidden features</span>
+          </MenuItemRow>
+          <DropdownMenu.Separator className="my-1 h-px bg-slate-200 dark:bg-slate-700" />
+          {LAYER_OPTIONS.map((option) => {
+            const isExpandable = EXPANDABLE_LAYERS.has(option.id);
+            const parentChecked = searchLayers.includes(option.id);
+            const parentDimmed = !searchIncludeHidden && !drawnByLayer[option.id];
+            return (
+              <Fragment key={option.id}>
+                {isExpandable ? (
+                  <ExpandableParentRow
+                    label={option.label}
+                    checked={parentChecked}
+                    onCheckedChange={(checked) => handleSearchLayerChange(option.id, checked)}
+                    expanded={expanded.has(option.id)}
+                    onToggleExpanded={() => toggleExpanded(option.id)}
+                    enabledCount={
+                      option.id === 'airways'
+                        ? searchAirwayCategories.length
+                        : searchAirspaceClasses.length
+                    }
+                    totalCount={
+                      option.id === 'airways' ? AIRWAY_CATEGORIES.length : AIRSPACE_CLASSES.length
+                    }
+                    hintMinZoom={undefined}
+                    dimmed={parentDimmed}
+                  />
+                ) : (
+                  <SimpleParentRow
+                    label={option.label}
+                    checked={parentChecked}
+                    onCheckedChange={(checked) => handleSearchLayerChange(option.id, checked)}
+                    hintMinZoom={undefined}
+                    dimmed={parentDimmed}
+                  />
+                )}
+                {option.id === 'airways' && expanded.has('airways')
+                  ? AIRWAY_CATEGORY_OPTIONS.map((category) => (
+                      <SubRow
+                        key={category.id}
+                        label={category.label}
+                        checked={searchAirwayCategories.includes(category.id)}
+                        onCheckedChange={(c) => handleSearchAirwayCategoryChange(category.id, c)}
+                        dimmed={
+                          !searchIncludeHidden &&
+                          !(airwaysParentOn && airwayCategories.includes(category.id))
+                        }
+                      />
+                    ))
+                  : null}
+                {option.id === 'airspace' && expanded.has('airspace')
+                  ? AIRSPACE_CLASS_OPTIONS.map((cls) => (
+                      <SubRow
+                        key={cls.id}
+                        label={cls.label}
+                        checked={searchAirspaceClasses.includes(cls.id)}
+                        onCheckedChange={(c) => handleSearchAirspaceClassChange(cls.id, c)}
+                        dimmed={
+                          !searchIncludeHidden &&
+                          !(airspaceParentOn && airspaceClasses.includes(cls.id))
+                        }
+                      />
+                    ))
+                  : null}
+              </Fragment>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/apps/atlas/src/modes/chart/search/search-highlight.spec.ts
+++ b/apps/atlas/src/modes/chart/search/search-highlight.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+
+import type { MatchRange } from '@squawk/search';
+
+import { splitByMatchRanges } from './search-highlight.ts';
+
+/**
+ * Rebuilds the original string from a segment list. Every test asserts this
+ * equals the input, since the split must be lossless and in order.
+ */
+function joinSegments(segments: ReturnType<typeof splitByMatchRanges>): string {
+  return segments.map((segment) => segment.text).join('');
+}
+
+describe('splitByMatchRanges', () => {
+  it('returns an empty array for blank text', () => {
+    expect(splitByMatchRanges('', [{ start: 0, end: 0 }])).toEqual([]);
+  });
+
+  it('returns one unmatched segment when there are no ranges', () => {
+    expect(splitByMatchRanges('BOSTON', [])).toEqual([{ text: 'BOSTON', matched: false }]);
+  });
+
+  it('splits a single interior range into unmatched / matched / unmatched', () => {
+    const segments = splitByMatchRanges('BOSTON', [{ start: 1, end: 3 }]);
+    expect(segments).toEqual([
+      { text: 'B', matched: false },
+      { text: 'OS', matched: true },
+      { text: 'TON', matched: false },
+    ]);
+    expect(joinSegments(segments)).toBe('BOSTON');
+  });
+
+  it('omits the leading unmatched segment when a range starts at 0', () => {
+    const segments = splitByMatchRanges('BOSTON', [{ start: 0, end: 3 }]);
+    expect(segments).toEqual([
+      { text: 'BOS', matched: true },
+      { text: 'TON', matched: false },
+    ]);
+  });
+
+  it('omits the trailing unmatched segment when a range ends at the string end', () => {
+    const segments = splitByMatchRanges('BOSTON', [{ start: 3, end: 6 }]);
+    expect(segments).toEqual([
+      { text: 'BOS', matched: false },
+      { text: 'TON', matched: true },
+    ]);
+  });
+
+  it('returns a single matched segment when the range covers the whole string', () => {
+    expect(splitByMatchRanges('BOS', [{ start: 0, end: 3 }])).toEqual([
+      { text: 'BOS', matched: true },
+    ]);
+  });
+
+  it('sorts out-of-order ranges before walking them', () => {
+    const ranges: MatchRange[] = [
+      { start: 4, end: 5 },
+      { start: 0, end: 1 },
+    ];
+    const segments = splitByMatchRanges('ABCDE', ranges);
+    expect(segments).toEqual([
+      { text: 'A', matched: true },
+      { text: 'BCD', matched: false },
+      { text: 'E', matched: true },
+    ]);
+  });
+
+  it('merges overlapping ranges into one matched run', () => {
+    const segments = splitByMatchRanges('ABCDEF', [
+      { start: 1, end: 4 },
+      { start: 2, end: 5 },
+    ]);
+    expect(segments).toEqual([
+      { text: 'A', matched: false },
+      { text: 'BCDE', matched: true },
+      { text: 'F', matched: false },
+    ]);
+  });
+
+  it('merges directly adjacent ranges so a shared boundary does not split the run', () => {
+    const segments = splitByMatchRanges('ABCDEF', [
+      { start: 1, end: 3 },
+      { start: 3, end: 5 },
+    ]);
+    expect(segments).toEqual([
+      { text: 'A', matched: false },
+      { text: 'BCDE', matched: true },
+      { text: 'F', matched: false },
+    ]);
+  });
+
+  it('clamps ranges that run past the string bounds', () => {
+    const segments = splitByMatchRanges('ABC', [{ start: -5, end: 99 }]);
+    expect(segments).toEqual([{ text: 'ABC', matched: true }]);
+  });
+
+  it('drops empty and inverted ranges', () => {
+    const segments = splitByMatchRanges('ABC', [
+      { start: 1, end: 1 },
+      { start: 2, end: 0 },
+    ]);
+    expect(segments).toEqual([{ text: 'ABC', matched: false }]);
+  });
+
+  it('reproduces the input when concatenating segments across mixed ranges', () => {
+    const text = 'KBOS BOSTON LOGAN';
+    const segments = splitByMatchRanges(text, [
+      { start: 5, end: 11 },
+      { start: 0, end: 1 },
+    ]);
+    expect(joinSegments(segments)).toBe(text);
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-highlight.ts
+++ b/apps/atlas/src/modes/chart/search/search-highlight.ts
@@ -1,0 +1,70 @@
+import type { MatchRange } from '@squawk/search';
+
+/**
+ * A contiguous run of result text tagged with whether the fuzzy matcher
+ * scored it. The results dropdown renders matched segments emphasized and
+ * unmatched segments plain, reconstructing the full string in order.
+ */
+export interface HighlightSegment {
+  /** The substring for this run. Never empty. */
+  text: string;
+  /** Whether this run falls inside a {@link MatchRange}. */
+  matched: boolean;
+}
+
+/**
+ * Splits `text` into ordered matched / unmatched segments from a set of
+ * {@link MatchRange}s (half-open `[start, end)` character intervals).
+ *
+ * Ranges are clamped to the string bounds, sorted, and merged so overlapping
+ * or adjacent ranges collapse into a single matched run. Empty segments are
+ * never emitted, so concatenating every segment's `text` reproduces the input
+ * exactly. A blank input yields an empty array.
+ *
+ * @param text - The full field text the ranges index into.
+ * @param ranges - Matched character ranges, in any order.
+ * @returns Ordered segments covering the whole string, matched runs flagged.
+ */
+export function splitByMatchRanges(
+  text: string,
+  ranges: readonly MatchRange[],
+): HighlightSegment[] {
+  if (text.length === 0) {
+    return [];
+  }
+
+  // Clamp to bounds and drop empties, then sort so the merge walk is linear.
+  const normalized = ranges
+    .map((range) => ({
+      start: Math.max(0, Math.min(range.start, text.length)),
+      end: Math.max(0, Math.min(range.end, text.length)),
+    }))
+    .filter((range) => range.start < range.end)
+    .sort((a, b) => a.start - b.start);
+
+  // Merge overlapping or directly adjacent ranges so a boundary between two
+  // ranges does not split one matched run into two segments.
+  const merged: { start: number; end: number }[] = [];
+  for (const range of normalized) {
+    const last = merged[merged.length - 1];
+    if (last !== undefined && range.start <= last.end) {
+      last.end = Math.max(last.end, range.end);
+    } else {
+      merged.push({ start: range.start, end: range.end });
+    }
+  }
+
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+  for (const range of merged) {
+    if (range.start > cursor) {
+      segments.push({ text: text.slice(cursor, range.start), matched: false });
+    }
+    segments.push({ text: text.slice(range.start, range.end), matched: true });
+    cursor = range.end;
+  }
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), matched: false });
+  }
+  return segments;
+}

--- a/apps/atlas/src/modes/chart/search/search-resolvers.spec.ts
+++ b/apps/atlas/src/modes/chart/search/search-resolvers.spec.ts
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useChartSearchResolvers } from './search-resolvers.ts';
+
+const {
+  useDatasetStatesMock,
+  getAirportResolverMock,
+  getNavaidResolverMock,
+  getFixResolverMock,
+  getAirwayResolverMock,
+  getAirspaceResolverMock,
+} = vi.hoisted(() => ({
+  useDatasetStatesMock: vi.fn(),
+  getAirportResolverMock: vi.fn(),
+  getNavaidResolverMock: vi.fn(),
+  getFixResolverMock: vi.fn(),
+  getAirwayResolverMock: vi.fn(),
+  getAirspaceResolverMock: vi.fn(),
+}));
+
+vi.mock('../../../shared/inspector/entity-resolver.ts', () => ({
+  useDatasetStates: useDatasetStatesMock,
+}));
+vi.mock('../../../shared/data/airport-dataset.ts', () => ({
+  getAirportResolver: getAirportResolverMock,
+}));
+vi.mock('../../../shared/data/navaid-dataset.ts', () => ({
+  getNavaidResolver: getNavaidResolverMock,
+}));
+vi.mock('../../../shared/data/fix-dataset.ts', () => ({ getFixResolver: getFixResolverMock }));
+vi.mock('../../../shared/data/airway-dataset.ts', () => ({
+  getAirwayResolver: getAirwayResolverMock,
+}));
+vi.mock('../../../shared/data/airspace-dataset.ts', () => ({
+  getAirspaceResolver: getAirspaceResolverMock,
+}));
+
+// Sentinel resolvers returned by the mocked factories so the test can assert
+// the hook wires each loaded dataset to the matching factory's output.
+const airportResolver = { search: vi.fn(() => []) };
+const navaidResolver = { search: vi.fn(() => []) };
+const fixResolver = { search: vi.fn(() => []) };
+const airwayResolver = { search: vi.fn(() => []) };
+const airspaceResolver = { search: vi.fn(() => []) };
+
+/** Builds an all-loaded dataset-states object with sentinel datasets per kind. */
+function loadedStates(): unknown {
+  return {
+    airport: { status: 'loaded', dataset: { kind: 'airport' } },
+    navaid: { status: 'loaded', dataset: { kind: 'navaid' } },
+    fix: { status: 'loaded', dataset: { kind: 'fix' } },
+    airway: { status: 'loaded', dataset: { kind: 'airway' } },
+    airspace: { status: 'loaded', dataset: { kind: 'airspace' } },
+  };
+}
+
+/** Builds an all-loading dataset-states object (no dataset slots resolved). */
+function loadingStates(): unknown {
+  return {
+    airport: { status: 'loading' },
+    navaid: { status: 'loading' },
+    fix: { status: 'loading' },
+    airway: { status: 'loading' },
+    airspace: { status: 'loading' },
+  };
+}
+
+describe('useChartSearchResolvers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAirportResolverMock.mockReturnValue(airportResolver);
+    getNavaidResolverMock.mockReturnValue(navaidResolver);
+    getFixResolverMock.mockReturnValue(fixResolver);
+    getAirwayResolverMock.mockReturnValue(airwayResolver);
+    getAirspaceResolverMock.mockReturnValue(airspaceResolver);
+  });
+
+  it('exposes each loaded dataset resolver built from its dataset', () => {
+    useDatasetStatesMock.mockReturnValue(loadedStates());
+    const { result } = renderHook(() => useChartSearchResolvers());
+
+    expect(result.current.airports).toBe(airportResolver);
+    expect(result.current.navaids).toBe(navaidResolver);
+    expect(result.current.fixes).toBe(fixResolver);
+    expect(result.current.airways).toBe(airwayResolver);
+    expect(result.current.airspace).toBe(airspaceResolver);
+    expect(getAirportResolverMock).toHaveBeenCalledWith({ kind: 'airport' });
+    expect(getAirspaceResolverMock).toHaveBeenCalledWith({ kind: 'airspace' });
+  });
+
+  it('falls back to an empty-result stub for datasets that have not loaded', () => {
+    useDatasetStatesMock.mockReturnValue(loadingStates());
+    const { result } = renderHook(() => useChartSearchResolvers());
+
+    expect(result.current.airports.search({ text: 'BOS' })).toEqual([]);
+    expect(result.current.navaids.search({ text: 'BOS' })).toEqual([]);
+    expect(result.current.fixes.search({ text: 'MERIT' })).toEqual([]);
+    expect(result.current.airways.search({ text: 'V1' })).toEqual([]);
+    expect(result.current.airspace.search({ text: 'BOS' })).toEqual([]);
+    expect(getAirportResolverMock).not.toHaveBeenCalled();
+    expect(getNavaidResolverMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a stable resolver object across renders while the states are unchanged', () => {
+    const states = loadedStates();
+    useDatasetStatesMock.mockReturnValue(states);
+    const { result, rerender } = renderHook(() => useChartSearchResolvers());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-resolvers.ts
+++ b/apps/atlas/src/modes/chart/search/search-resolvers.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import { getAirportResolver } from '../../../shared/data/airport-dataset.ts';
+import { getAirspaceResolver } from '../../../shared/data/airspace-dataset.ts';
+import { getAirwayResolver } from '../../../shared/data/airway-dataset.ts';
+import { getFixResolver } from '../../../shared/data/fix-dataset.ts';
+import { getNavaidResolver } from '../../../shared/data/navaid-dataset.ts';
+import { useDatasetStates } from '../../../shared/inspector/entity-resolver.ts';
+
+import type { ChartSearchResolvers } from './search-features.ts';
+
+/**
+ * Subscribes to all five chart datasets and exposes their `search` methods in
+ * the {@link ChartSearchResolvers} shape consumed by {@link searchChartFeatures}.
+ *
+ * Each dataset is queried only once it has loaded; until then its slot carries
+ * a stub whose `search` returns no matches, so the search box can run against
+ * whatever has loaded so far without waiting on the slowest dataset. The
+ * underlying `useXDataset()` fetches are shared at module scope, so mounting
+ * this hook triggers no requests beyond what chart-mode already initiates.
+ *
+ * @returns Per-kind resolver `search` surfaces, memoized on the dataset states.
+ */
+export function useChartSearchResolvers(): ChartSearchResolvers {
+  const states = useDatasetStates();
+
+  return useMemo<ChartSearchResolvers>(
+    () => ({
+      airports:
+        states.airport.status === 'loaded'
+          ? getAirportResolver(states.airport.dataset)
+          : { search: () => [] },
+      navaids:
+        states.navaid.status === 'loaded'
+          ? getNavaidResolver(states.navaid.dataset)
+          : { search: () => [] },
+      fixes:
+        states.fix.status === 'loaded' ? getFixResolver(states.fix.dataset) : { search: () => [] },
+      airways:
+        states.airway.status === 'loaded'
+          ? getAirwayResolver(states.airway.dataset)
+          : { search: () => [] },
+      airspace:
+        states.airspace.status === 'loaded'
+          ? getAirspaceResolver(states.airspace.dataset)
+          : { search: () => [] },
+    }),
+    [states],
+  );
+}

--- a/apps/atlas/src/modes/chart/search/search-scope.spec.ts
+++ b/apps/atlas/src/modes/chart/search/search-scope.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+
+import type { AirspaceType, AirwayType } from '@squawk/types';
+
+import { RENDERED_AIRPORT_FACILITY_TYPES, RENDERED_NAVAID_TYPES } from '../layers/drawable-sets.ts';
+
+import { computeLayerVisibility, computeSearchScope } from './search-scope.ts';
+import type { LayerSelection } from './search-scope.ts';
+
+/**
+ * Builds a {@link LayerSelection} from partial overrides, defaulting to an
+ * empty selection so each test states only the layers and sub-classes it
+ * cares about.
+ */
+function selection(overrides: Partial<LayerSelection> = {}): LayerSelection {
+  return {
+    layers: overrides.layers ?? [],
+    airspaceClasses: overrides.airspaceClasses ?? [],
+    airwayCategories: overrides.airwayCategories ?? [],
+  };
+}
+
+describe('computeLayerVisibility', () => {
+  it('reflects the enabled point layers', () => {
+    const visibility = computeLayerVisibility(selection({ layers: ['airports', 'fixes'] }));
+    expect(visibility.airports).toBe(true);
+    expect(visibility.fixes).toBe(true);
+    expect(visibility.navaids).toBe(false);
+  });
+
+  it('expands enabled airway categories into their underlying types', () => {
+    const visibility = computeLayerVisibility(
+      selection({ layers: ['airways'], airwayCategories: ['LOW'] }),
+    );
+    expect([...visibility.airwayTypes].sort()).toEqual(['RNAV_T', 'VICTOR']);
+  });
+
+  it('expands enabled airspace classes into their underlying types', () => {
+    const visibility = computeLayerVisibility(
+      selection({ layers: ['airspace'], airspaceClasses: ['CLASS_E'] }),
+    );
+    expect([...visibility.airspaceTypes].sort()).toEqual([
+      'CLASS_E2',
+      'CLASS_E3',
+      'CLASS_E4',
+      'CLASS_E5',
+      'CLASS_E6',
+      'CLASS_E7',
+    ]);
+  });
+
+  it('yields no airway types when the airways layer is disabled, even with categories set', () => {
+    const visibility = computeLayerVisibility(selection({ airwayCategories: ['LOW', 'HIGH'] }));
+    expect(visibility.airwayTypes.size).toBe(0);
+  });
+
+  it('yields no airspace types when the airspace layer is disabled, even with classes set', () => {
+    const visibility = computeLayerVisibility(selection({ airspaceClasses: ['CLASS_B'] }));
+    expect(visibility.airspaceTypes.size).toBe(0);
+  });
+});
+
+describe('computeSearchScope', () => {
+  it('disables a dataset the filter omits, even when it is visible', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airports', 'navaids'] }),
+      filter: selection({ layers: ['navaids'] }),
+      includeHidden: false,
+    });
+    expect(scope.airports.enabled).toBe(false);
+    expect(scope.navaids.enabled).toBe(true);
+  });
+
+  it('gates a filtered dataset by visibility when hidden results are excluded', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['navaids'] }),
+      filter: selection({ layers: ['airports'] }),
+      includeHidden: false,
+    });
+    expect(scope.airports.enabled).toBe(false);
+  });
+
+  it('enables a hidden filtered dataset when include-hidden is on', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['navaids'] }),
+      filter: selection({ layers: ['airports'] }),
+      includeHidden: true,
+    });
+    expect(scope.airports.enabled).toBe(true);
+  });
+
+  it('always scopes airport and navaid queries to the rendered drawable sets', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airports', 'navaids'] }),
+      filter: selection({ layers: ['airports', 'navaids'] }),
+      includeHidden: false,
+    });
+    expect(scope.airports.types).toBe(RENDERED_AIRPORT_FACILITY_TYPES);
+    expect(scope.navaids.types).toBe(RENDERED_NAVAID_TYPES);
+  });
+
+  it('intersects airway filter categories with the visible types when hidden is excluded', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airways'], airwayCategories: ['LOW'] }),
+      filter: selection({ layers: ['airways'], airwayCategories: ['LOW', 'HIGH'] }),
+      includeHidden: false,
+    });
+    expect(scope.airways.enabled).toBe(true);
+    expect([...scope.airways.types].sort()).toEqual<AirwayType[]>(['RNAV_T', 'VICTOR']);
+  });
+
+  it('passes the full airway filter scope through when include-hidden is on', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airways'], airwayCategories: ['LOW'] }),
+      filter: selection({ layers: ['airways'], airwayCategories: ['LOW', 'HIGH'] }),
+      includeHidden: true,
+    });
+    expect([...scope.airways.types].sort()).toEqual<AirwayType[]>([
+      'JET',
+      'RNAV_Q',
+      'RNAV_T',
+      'VICTOR',
+    ]);
+  });
+
+  it('disables airways when no in-scope type survives the visibility gate', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airways'], airwayCategories: ['LOW'] }),
+      filter: selection({ layers: ['airways'], airwayCategories: ['HIGH'] }),
+      includeHidden: false,
+    });
+    expect(scope.airways.enabled).toBe(false);
+    expect(scope.airways.types.size).toBe(0);
+  });
+
+  it('disables airways when the filter omits the airways layer', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airways'], airwayCategories: ['LOW'] }),
+      filter: selection({ airwayCategories: ['LOW'] }),
+      includeHidden: true,
+    });
+    expect(scope.airways.enabled).toBe(false);
+    expect(scope.airways.types.size).toBe(0);
+  });
+
+  it('intersects airspace filter classes with the visible types when hidden is excluded', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airspace'], airspaceClasses: ['CLASS_B'] }),
+      filter: selection({ layers: ['airspace'], airspaceClasses: ['CLASS_B', 'CLASS_C'] }),
+      includeHidden: false,
+    });
+    expect(scope.airspace.enabled).toBe(true);
+    expect([...scope.airspace.types].sort()).toEqual<AirspaceType[]>(['CLASS_B']);
+  });
+
+  it('disables airspace when no in-scope type survives the visibility gate', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['airspace'], airspaceClasses: ['CLASS_B'] }),
+      filter: selection({ layers: ['airspace'], airspaceClasses: ['CLASS_C'] }),
+      includeHidden: false,
+    });
+    expect(scope.airspace.enabled).toBe(false);
+    expect(scope.airspace.types.size).toBe(0);
+  });
+
+  it('treats fixes as a flag-only scope with no subtype filter', () => {
+    const scope = computeSearchScope({
+      layers: selection({ layers: ['fixes'] }),
+      filter: selection({ layers: ['fixes'] }),
+      includeHidden: false,
+    });
+    expect(scope.fixes).toEqual({ enabled: true });
+  });
+});

--- a/apps/atlas/src/modes/chart/search/search-scope.ts
+++ b/apps/atlas/src/modes/chart/search/search-scope.ts
@@ -1,0 +1,205 @@
+import type { AirspaceType, AirwayType, FacilityType, NavaidType } from '@squawk/types';
+
+import { RENDERED_AIRPORT_FACILITY_TYPES, RENDERED_NAVAID_TYPES } from '../layers/drawable-sets.ts';
+import { AIRSPACE_CLASS_TYPES, AIRWAY_CATEGORY_TYPES } from '../url-state.ts';
+import type { AirspaceClass, AirwayCategory, LayerId } from '../url-state.ts';
+
+/**
+ * A selection of chart layers and their sub-classes. Both the Layers menu
+ * state (what the map currently draws) and the search filter state (what the
+ * user wants searched) take this shape, so the same expansion logic serves
+ * both.
+ */
+export interface LayerSelection {
+  /** Enabled top-level layers. */
+  layers: readonly LayerId[];
+  /** Enabled airspace classes; consulted only when `airspace` is among {@link LayerSelection.layers}. */
+  airspaceClasses: readonly AirspaceClass[];
+  /** Enabled airway categories; consulted only when `airways` is among {@link LayerSelection.layers}. */
+  airwayCategories: readonly AirwayCategory[];
+}
+
+/**
+ * The set of feature subtypes currently drawn on the map, derived from the
+ * Layers menu selection. Used to tag each search result's `hidden` flag and
+ * to gate the search corpus when hidden results are excluded.
+ *
+ * Visibility here means only "the layer (and sub-class) is enabled in the
+ * Layers menu"; it deliberately ignores zoom-level gating, so a result for a
+ * fix that is enabled but below its paint zoom is still considered visible.
+ */
+export interface LayerVisibility {
+  /** Whether the airports layer is enabled. */
+  airports: boolean;
+  /** Whether the navaids layer is enabled. */
+  navaids: boolean;
+  /** Whether the fixes layer is enabled. */
+  fixes: boolean;
+  /** Airway types currently drawn (empty when the airways layer is disabled). */
+  airwayTypes: ReadonlySet<AirwayType>;
+  /** Airspace types currently drawn (empty when the airspace layer is disabled). */
+  airspaceTypes: ReadonlySet<AirspaceType>;
+}
+
+/**
+ * The query scope for a single dataset with chart sub-classes: whether to
+ * query it at all, and the subtype filter to pass to its resolver.
+ */
+export interface KindScope<T extends string> {
+  /** Whether the dataset should be queried. False when nothing in it is in scope. */
+  enabled: boolean;
+  /** Subtype filter forwarded to the resolver's `search`. */
+  types: ReadonlySet<T>;
+}
+
+/**
+ * The fully-resolved scope of a chart search: which datasets to query and,
+ * for datasets with chart sub-classes, the subtype filter to apply. Computed
+ * by {@link computeSearchScope} from the Layers menu state, the search filter
+ * state, and the include-hidden toggle.
+ */
+export interface SearchScope {
+  /** Airport query scope. `types` is always the drawable airport facility set when enabled. */
+  airports: KindScope<FacilityType>;
+  /** Navaid query scope. `types` is always the drawable navaid type set when enabled. */
+  navaids: KindScope<NavaidType>;
+  /** Fix query scope. Fixes have no chart sub-classes, so only the enabled flag applies. */
+  fixes: { enabled: boolean };
+  /** Airway query scope, filtered to the in-scope airway types. */
+  airways: KindScope<AirwayType>;
+  /** Airspace query scope, filtered to the in-scope airspace types. */
+  airspace: KindScope<AirspaceType>;
+}
+
+/**
+ * Parameters for {@link computeSearchScope}.
+ */
+export interface SearchScopeParams {
+  /** The Layers menu selection: what is currently drawn on the map. */
+  layers: LayerSelection;
+  /** The search filter selection: which feature types the user wants searched. */
+  filter: LayerSelection;
+  /**
+   * When true, the search ignores the Layers menu and queries the full filter
+   * scope, surfacing results for feature types that are currently hidden. When
+   * false, the corpus is intersected with what the Layers menu draws.
+   */
+  includeHidden: boolean;
+}
+
+/**
+ * Expands a list of airway categories into the underlying airway types they
+ * cover, via {@link AIRWAY_CATEGORY_TYPES}.
+ */
+function expandAirwayCategories(categories: readonly AirwayCategory[]): Set<AirwayType> {
+  const types = new Set<AirwayType>();
+  for (const category of categories) {
+    for (const type of AIRWAY_CATEGORY_TYPES[category]) {
+      types.add(type);
+    }
+  }
+  return types;
+}
+
+/**
+ * Expands a list of airspace classes into the underlying airspace types they
+ * cover, via {@link AIRSPACE_CLASS_TYPES}.
+ */
+function expandAirspaceClasses(classes: readonly AirspaceClass[]): Set<AirspaceType> {
+  const types = new Set<AirspaceType>();
+  for (const cls of classes) {
+    for (const type of AIRSPACE_CLASS_TYPES[cls]) {
+      types.add(type);
+    }
+  }
+  return types;
+}
+
+/**
+ * Computes which feature subtypes are currently drawn on the map from the
+ * Layers menu selection. A sub-class set is empty when its top-level layer is
+ * disabled, so a disabled airways layer yields no visible airway types even if
+ * categories remain checked underneath it.
+ *
+ * @param selection - The Layers menu selection.
+ * @returns The per-dataset visibility, keyed for tagging search results.
+ */
+export function computeLayerVisibility(selection: LayerSelection): LayerVisibility {
+  const enabledLayers = new Set<LayerId>(selection.layers);
+  return {
+    airports: enabledLayers.has('airports'),
+    navaids: enabledLayers.has('navaids'),
+    fixes: enabledLayers.has('fixes'),
+    airwayTypes: enabledLayers.has('airways')
+      ? expandAirwayCategories(selection.airwayCategories)
+      : new Set<AirwayType>(),
+    airspaceTypes: enabledLayers.has('airspace')
+      ? expandAirspaceClasses(selection.airspaceClasses)
+      : new Set<AirspaceType>(),
+  };
+}
+
+/**
+ * Restricts a set of in-scope subtypes to those currently visible, unless
+ * hidden results are allowed (in which case the full set passes through).
+ */
+function gateByVisibility<T>(
+  inScope: ReadonlySet<T>,
+  visible: ReadonlySet<T>,
+  includeHidden: boolean,
+): Set<T> {
+  const result = new Set<T>();
+  for (const type of inScope) {
+    if (includeHidden || visible.has(type)) {
+      result.add(type);
+    }
+  }
+  return result;
+}
+
+/**
+ * Computes the effective search scope from the Layers menu state, the search
+ * filter state, and the include-hidden toggle.
+ *
+ * A feature type is searched when it is enabled in the search filter AND
+ * either hidden results are allowed or the type is currently drawn on the map.
+ * The search filter is the user's explicit "what to search" choice; the
+ * include-hidden toggle only relaxes the secondary requirement that a type
+ * also be visible in the Layers menu.
+ *
+ * @param params - The Layers selection, filter selection, and include-hidden flag.
+ * @returns The per-dataset query scope to drive {@link searchChartFeatures}.
+ */
+export function computeSearchScope(params: SearchScopeParams): SearchScope {
+  const visibility = computeLayerVisibility(params.layers);
+  const filterLayers = new Set<LayerId>(params.filter.layers);
+  const includeHidden = params.includeHidden;
+
+  const airportsEnabled = filterLayers.has('airports') && (includeHidden || visibility.airports);
+  const navaidsEnabled = filterLayers.has('navaids') && (includeHidden || visibility.navaids);
+  const fixesEnabled = filterLayers.has('fixes') && (includeHidden || visibility.fixes);
+
+  const airwayTypes = filterLayers.has('airways')
+    ? gateByVisibility(
+        expandAirwayCategories(params.filter.airwayCategories),
+        visibility.airwayTypes,
+        includeHidden,
+      )
+    : new Set<AirwayType>();
+
+  const airspaceTypes = filterLayers.has('airspace')
+    ? gateByVisibility(
+        expandAirspaceClasses(params.filter.airspaceClasses),
+        visibility.airspaceTypes,
+        includeHidden,
+      )
+    : new Set<AirspaceType>();
+
+  return {
+    airports: { enabled: airportsEnabled, types: RENDERED_AIRPORT_FACILITY_TYPES },
+    navaids: { enabled: navaidsEnabled, types: RENDERED_NAVAID_TYPES },
+    fixes: { enabled: fixesEnabled },
+    airways: { enabled: airwayTypes.size > 0, types: airwayTypes },
+    airspace: { enabled: airspaceTypes.size > 0, types: airspaceTypes },
+  };
+}

--- a/apps/atlas/src/modes/chart/search/use-chart-search.spec.ts
+++ b/apps/atlas/src/modes/chart/search/use-chart-search.spec.ts
@@ -1,0 +1,103 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useChartSearch } from './use-chart-search.ts';
+
+const {
+  useSearchMock,
+  useChartSearchResolversMock,
+  computeLayerVisibilityMock,
+  computeSearchScopeMock,
+  searchChartFeaturesMock,
+} = vi.hoisted(() => ({
+  useSearchMock: vi.fn(),
+  useChartSearchResolversMock: vi.fn(),
+  computeLayerVisibilityMock: vi.fn(),
+  computeSearchScopeMock: vi.fn(),
+  searchChartFeaturesMock: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({ useSearch: useSearchMock }),
+}));
+vi.mock('./search-resolvers.ts', () => ({
+  useChartSearchResolvers: useChartSearchResolversMock,
+}));
+vi.mock('./search-scope.ts', () => ({
+  computeLayerVisibility: computeLayerVisibilityMock,
+  computeSearchScope: computeSearchScopeMock,
+}));
+vi.mock('./search-features.ts', () => ({
+  searchChartFeatures: searchChartFeaturesMock,
+}));
+
+const resolversSentinel = { airports: { search: vi.fn() } };
+const visibilitySentinel = { visibility: true };
+const scopeSentinel = { scope: true };
+
+/** Full chart-search URL state with distinct layer vs search-filter values. */
+const search = {
+  layers: ['airports', 'navaids'],
+  airspaceClasses: ['CLASS_B'],
+  airwayCategories: ['LOW'],
+  searchLayers: ['airports', 'fixes'],
+  searchAirspaceClasses: ['CLASS_C'],
+  searchAirwayCategories: ['HIGH'],
+  searchIncludeHidden: true,
+};
+
+describe('useChartSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSearchMock.mockReturnValue(search);
+    useChartSearchResolversMock.mockReturnValue(resolversSentinel);
+    computeLayerVisibilityMock.mockReturnValue(visibilitySentinel);
+    computeSearchScopeMock.mockReturnValue(scopeSentinel);
+    searchChartFeaturesMock.mockReturnValue([]);
+  });
+
+  it('derives visibility from the URL layer state', () => {
+    renderHook(() => useChartSearch('BOS'));
+    expect(computeLayerVisibilityMock).toHaveBeenCalledWith({
+      layers: search.layers,
+      airspaceClasses: search.airspaceClasses,
+      airwayCategories: search.airwayCategories,
+    });
+  });
+
+  it('derives scope from the layer state, the search-filter state, and include-hidden', () => {
+    renderHook(() => useChartSearch('BOS'));
+    expect(computeSearchScopeMock).toHaveBeenCalledWith({
+      layers: {
+        layers: search.layers,
+        airspaceClasses: search.airspaceClasses,
+        airwayCategories: search.airwayCategories,
+      },
+      filter: {
+        layers: search.searchLayers,
+        airspaceClasses: search.searchAirspaceClasses,
+        airwayCategories: search.searchAirwayCategories,
+      },
+      includeHidden: search.searchIncludeHidden,
+    });
+  });
+
+  it('returns the merged results for the query, resolvers, scope, and visibility', () => {
+    const resultsSentinel = [{ kind: 'airport' }];
+    searchChartFeaturesMock.mockReturnValue(resultsSentinel);
+    const { result } = renderHook(() => useChartSearch('BOS'));
+
+    expect(result.current).toBe(resultsSentinel);
+    expect(searchChartFeaturesMock).toHaveBeenCalledWith({
+      text: 'BOS',
+      resolvers: resolversSentinel,
+      scope: scopeSentinel,
+      visibility: visibilitySentinel,
+    });
+  });
+
+  it('passes a blank query straight through to the search', () => {
+    renderHook(() => useChartSearch(''));
+    expect(searchChartFeaturesMock).toHaveBeenCalledWith(expect.objectContaining({ text: '' }));
+  });
+});

--- a/apps/atlas/src/modes/chart/search/use-chart-search.ts
+++ b/apps/atlas/src/modes/chart/search/use-chart-search.ts
@@ -1,0 +1,70 @@
+import { getRouteApi } from '@tanstack/react-router';
+import { useDeferredValue, useMemo } from 'react';
+
+import { CHART_ROUTE_PATH } from '../url-state.ts';
+
+import { searchChartFeatures } from './search-features.ts';
+import type { ChartSearchResult } from './search-features.ts';
+import { useChartSearchResolvers } from './search-resolvers.ts';
+import { computeLayerVisibility, computeSearchScope } from './search-scope.ts';
+
+const route = getRouteApi(CHART_ROUTE_PATH);
+
+/**
+ * Runs the live chart-feature search for the current query against the URL's
+ * Layers-menu state and search-filter state.
+ *
+ * The query is passed through {@link useDeferredValue} so a fast typist keeps a
+ * responsive input while the (synchronous, in-memory) fuzzy search runs against
+ * the latest settled keystroke. Visibility and scope are derived from the URL
+ * so toggling a layer or a search-filter sub-class re-runs the search without
+ * the caller threading any of that state through.
+ *
+ * @param query - Raw search-box text. Blank input yields no results.
+ * @returns Score-ranked results, best match first, capped at the merge limit.
+ */
+export function useChartSearch(query: string): ChartSearchResult[] {
+  const {
+    layers,
+    airspaceClasses,
+    airwayCategories,
+    searchLayers,
+    searchAirspaceClasses,
+    searchAirwayCategories,
+    searchIncludeHidden,
+  } = route.useSearch();
+  const resolvers = useChartSearchResolvers();
+  const deferredQuery = useDeferredValue(query);
+
+  const visibility = useMemo(
+    () => computeLayerVisibility({ layers, airspaceClasses, airwayCategories }),
+    [layers, airspaceClasses, airwayCategories],
+  );
+
+  const scope = useMemo(
+    () =>
+      computeSearchScope({
+        layers: { layers, airspaceClasses, airwayCategories },
+        filter: {
+          layers: searchLayers,
+          airspaceClasses: searchAirspaceClasses,
+          airwayCategories: searchAirwayCategories,
+        },
+        includeHidden: searchIncludeHidden,
+      }),
+    [
+      layers,
+      airspaceClasses,
+      airwayCategories,
+      searchLayers,
+      searchAirspaceClasses,
+      searchAirwayCategories,
+      searchIncludeHidden,
+    ],
+  );
+
+  return useMemo(
+    () => searchChartFeatures({ text: deferredQuery, resolvers, scope, visibility }),
+    [deferredQuery, resolvers, scope, visibility],
+  );
+}

--- a/apps/atlas/src/modes/chart/url-state.spec.ts
+++ b/apps/atlas/src/modes/chart/url-state.spec.ts
@@ -22,6 +22,10 @@ describe('chartSearchSchema', () => {
       layers: [...LAYER_IDS],
       airspaceClasses: [...CHART_DEFAULTS.airspaceClasses],
       airwayCategories: [...AIRWAY_CATEGORIES],
+      searchLayers: [...CHART_DEFAULTS.searchLayers],
+      searchAirspaceClasses: [...CHART_DEFAULTS.searchAirspaceClasses],
+      searchAirwayCategories: [...CHART_DEFAULTS.searchAirwayCategories],
+      searchIncludeHidden: CHART_DEFAULTS.searchIncludeHidden,
     });
   });
 

--- a/apps/atlas/src/modes/chart/url-state.ts
+++ b/apps/atlas/src/modes/chart/url-state.ts
@@ -148,6 +148,24 @@ export const AIRWAY_CATEGORY_TYPES: Record<AirwayCategory, readonly AirwayType[]
 };
 
 /**
+ * Reverse of {@link AIRWAY_CATEGORY_TYPES}: maps each underlying `AirwayType`
+ * to the user-facing category that contains it. Used when we have an arbitrary
+ * `AirwayType` (e.g. on a search result) and need to ask "which category must
+ * be enabled for this airway to draw?". Computed once at module load.
+ */
+export const AIRWAY_CATEGORY_FOR_TYPE: Record<AirwayType, AirwayCategory> = (() => {
+  const map: Partial<Record<AirwayType, AirwayCategory>> = {};
+  for (const category of AIRWAY_CATEGORIES) {
+    for (const type of AIRWAY_CATEGORY_TYPES[category]) {
+      map[type] = category;
+    }
+  }
+  // Every AirwayType is covered by exactly one category above; the cast
+  // narrows the partial map to the total record.
+  return map as Record<AirwayType, AirwayCategory>;
+})();
+
+/**
  * Default chart-mode map view: continental US center at a zoom that shows the
  * full CONUS area, with every data layer enabled and most airspace classes
  * enabled. ARTCC is opted out by default because its sector boundaries cover
@@ -172,6 +190,28 @@ export const CHART_DEFAULTS = {
   airspaceClasses: AIRSPACE_CLASSES.filter((cls) => cls !== 'ARTCC'),
   /** Default active airway categories: every category visible. */
   airwayCategories: AIRWAY_CATEGORIES,
+  /**
+   * Default search-filter layer set: every layer is searchable. The search
+   * filter is the "what to search" choice, independent of what the map draws;
+   * the include-hidden toggle decides whether the corpus is then intersected
+   * with the visible layer set (see {@link CHART_DEFAULTS.searchIncludeHidden}).
+   */
+  searchLayers: LAYER_IDS,
+  /**
+   * Default searchable airspace classes: every class, including ARTCC. Unlike
+   * the map default this includes ARTCC, because the filter expresses intent
+   * to search the class; whether ARTCC results actually surface still depends
+   * on its Layers-menu visibility unless include-hidden is on.
+   */
+  searchAirspaceClasses: AIRSPACE_CLASSES,
+  /** Default searchable airway categories: every category. */
+  searchAirwayCategories: AIRWAY_CATEGORIES,
+  /**
+   * Default include-hidden toggle: off, so search surfaces only features the
+   * Layers menu currently draws. Flipping it on lets results include feature
+   * types that are toggled off on the map.
+   */
+  searchIncludeHidden: false,
 } as const;
 
 /**
@@ -228,6 +268,43 @@ export const chartSearchSchema = z.object({
     .array(z.enum(AIRWAY_CATEGORIES))
     .default([...CHART_DEFAULTS.airwayCategories])
     .catch([...CHART_DEFAULTS.airwayCategories]),
+  /**
+   * Search-filter layer set: which top-level feature types the search box
+   * queries. Independent of `layers` (what the map draws). Default is every
+   * layer; an empty array yields a search that returns nothing. Unknown ids
+   * or non-array values fall back to the default.
+   */
+  searchLayers: z
+    .array(z.enum(LAYER_IDS))
+    .default([...CHART_DEFAULTS.searchLayers])
+    .catch([...CHART_DEFAULTS.searchLayers]),
+  /**
+   * Search-filter airspace classes (consulted only when `searchLayers`
+   * includes `airspace`). Default is every class; an empty array drops
+   * airspace from search. Unknown ids or non-array values fall back to the
+   * default.
+   */
+  searchAirspaceClasses: z
+    .array(z.enum(AIRSPACE_CLASSES))
+    .default([...CHART_DEFAULTS.searchAirspaceClasses])
+    .catch([...CHART_DEFAULTS.searchAirspaceClasses]),
+  /**
+   * Search-filter airway categories (consulted only when `searchLayers`
+   * includes `airways`). Default is every category; an empty array drops
+   * airways from search. Unknown ids or non-array values fall back to the
+   * default.
+   */
+  searchAirwayCategories: z
+    .array(z.enum(AIRWAY_CATEGORIES))
+    .default([...CHART_DEFAULTS.searchAirwayCategories])
+    .catch([...CHART_DEFAULTS.searchAirwayCategories]),
+  /**
+   * Include-hidden toggle. When true, search ignores the Layers menu and
+   * returns results for feature types that are currently toggled off on the
+   * map. When false (default), the search corpus is intersected with what the
+   * map draws. Invalid values fall back to false.
+   */
+  searchIncludeHidden: z.boolean().default(CHART_DEFAULTS.searchIncludeHidden).catch(false),
   /**
    * Currently inspected entity, encoded as `{type}:{id}` (e.g. `airport:BOS`,
    * `navaid:BOS`, `airway:V16`, `airspace:CLASS_B/JFK`). Absent when no entity

--- a/apps/atlas/src/shared/inspector/use-chip-hover-pan.spec.ts
+++ b/apps/atlas/src/shared/inspector/use-chip-hover-pan.spec.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   INSPECTOR_OVERLAY_DESKTOP_WIDTH_PX,
+  fitFeatureBoundsWithInspectorOffset,
   isPointOutsideComfortableArea,
   panToFeatureWithInspectorOffset,
   restoreCenter,
@@ -22,6 +23,7 @@ interface FakeMap {
   project: (lngLat: [number, number]) => { x: number; y: number };
   getCanvas: () => FakeCanvas;
   easeTo: ReturnType<typeof vi.fn>;
+  fitBounds: ReturnType<typeof vi.fn>;
 }
 
 function buildFakeMap(
@@ -33,6 +35,7 @@ function buildFakeMap(
     project: projectFn ?? (() => ({ x: 100, y: 100 })),
     getCanvas: () => ({ clientWidth: canvasWidth, clientHeight: canvasHeight }),
     easeTo: vi.fn(),
+    fitBounds: vi.fn(),
   };
 }
 
@@ -131,6 +134,59 @@ describe('panToFeatureWithInspectorOffset', () => {
     const args = map.easeTo.mock.calls[0]?.[0];
     expect(args.offset[0]).toBe(0);
     expect(args.offset[1]).toBeLessThan(0);
+  });
+
+  it('omits zoom from the ease when no zoom is supplied', () => {
+    const map = buildFakeMap(1024, 768);
+    panToFeatureWithInspectorOffset({ lng: -73, lat: 40 }, map as unknown as MaplibreMap);
+    const args = map.easeTo.mock.calls[0]?.[0];
+    expect(args.zoom).toBeUndefined();
+  });
+
+  it('eases to the supplied zoom when one is passed', () => {
+    const map = buildFakeMap(1024, 768);
+    panToFeatureWithInspectorOffset({ lng: -73, lat: 40 }, map as unknown as MaplibreMap, 10);
+    const args = map.easeTo.mock.calls[0]?.[0];
+    expect(args.zoom).toBe(10);
+  });
+});
+
+describe('fitFeatureBoundsWithInspectorOffset', () => {
+  it('fits the bounding-box corners with the right edge reserved on desktop', () => {
+    const map = buildFakeMap(1024, 768);
+    fitFeatureBoundsWithInspectorOffset(
+      { minLon: -73, maxLon: -71, minLat: 42, maxLat: 44 },
+      map as unknown as MaplibreMap,
+    );
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    const [corners, options] = map.fitBounds.mock.calls[0] ?? [];
+    expect(corners).toEqual([
+      [-73, 42],
+      [-71, 44],
+    ]);
+    // Desktop occludes the right edge, so its padding carries the overlay
+    // footprint on top of the base margin while the other edges stay at base.
+    expect(options.padding.left).toBe(options.padding.top);
+    expect(options.padding.right).toBeGreaterThan(options.padding.left);
+    expect(options.maxZoom).toBe(11);
+  });
+
+  it('reserves the bottom edge instead of the right edge on mobile', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 600,
+    });
+    const map = buildFakeMap(600, 1000);
+    fitFeatureBoundsWithInspectorOffset(
+      { minLon: -73, maxLon: -71, minLat: 42, maxLat: 44 },
+      map as unknown as MaplibreMap,
+    );
+    const options = map.fitBounds.mock.calls[0]?.[1];
+    // Mobile occludes the bottom sheet, so the bottom padding grows while the
+    // right edge falls back to the base margin.
+    expect(options.padding.bottom).toBeGreaterThan(options.padding.top);
+    expect(options.padding.right).toBe(options.padding.top);
   });
 });
 

--- a/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
+++ b/apps/atlas/src/shared/inspector/use-chip-hover-pan.ts
@@ -65,6 +65,22 @@ function getInspectorOcclusionPx(): { x: number; y: number } {
 const PAN_DURATION_MS = 350;
 
 /**
+ * Base pixel margin left between a fitted feature's bounding box and every
+ * viewport edge in {@link fitFeatureBoundsWithInspectorOffset}, so an airway or
+ * airspace never renders flush against the canvas border. The inspector-occluded
+ * edge gets this margin plus the overlay's footprint.
+ */
+const FIT_BOUNDS_BASE_PADDING_PX = 40;
+
+/**
+ * Upper bound on the zoom {@link fitFeatureBoundsWithInspectorOffset} applies, so
+ * a tiny extent feature (a short airway segment, a small Class D) keeps some
+ * surrounding context instead of slamming to street level, and a degenerate
+ * single-point bounding box does not zoom all the way in.
+ */
+const FIT_BOUNDS_MAX_ZOOM = 11;
+
+/**
  * Minimum pixel margin from any visible-area edge before a feature is
  * considered "comfortably onscreen". Anything closer to an edge - or
  * fully offscreen - triggers the chip-hover pan so the user does not
@@ -403,10 +419,16 @@ export function isPointOutsideComfortableArea(
  * left strip rather than directly under the right-side panel; on
  * mobile the negative y-offset shifts the focal point up so the
  * target appears in the visible top strip above the bottom sheet.
+ *
+ * When `zoom` is provided the camera also eases to that zoom level; omitting it
+ * preserves the current zoom. The chip-hover, commit, and recenter callers omit
+ * it (they reframe a point without changing scale); the search box passes a
+ * logical zoom so a pick from the CONUS overview lands close enough to be useful.
  */
 export function panToFeatureWithInspectorOffset(
   lngLat: { lng: number; lat: number },
   map: MaplibreMap,
+  zoom?: number,
 ): void {
   const occlusion = getInspectorOcclusionPx();
   // Guard against negative zero on the un-occluded axis: dividing 0 by
@@ -418,8 +440,39 @@ export function panToFeatureWithInspectorOffset(
   map.easeTo({
     center: [lngLat.lng, lngLat.lat],
     offset: [offsetX, offsetY],
+    ...(zoom !== undefined && { zoom }),
     duration: PAN_DURATION_MS,
   });
+}
+
+/**
+ * Frames an extent feature (an airway or an airspace) by easing the camera so
+ * the feature's bounding box fits within the un-occluded portion of the map.
+ * Unlike {@link panToFeatureWithInspectorOffset}, which centers a point at a
+ * fixed zoom, this derives the zoom from the box so the whole feature is
+ * visible. The inspector's footprint is reserved with asymmetric padding (the
+ * right edge on desktop, the bottom edge on mobile) so the fitted feature stays
+ * clear of the overlay, and {@link FIT_BOUNDS_MAX_ZOOM} caps how far in a small
+ * box pulls the camera.
+ */
+export function fitFeatureBoundsWithInspectorOffset(bbox: BoundingBox, map: MaplibreMap): void {
+  const occlusion = getInspectorOcclusionPx();
+  map.fitBounds(
+    [
+      [bbox.minLon, bbox.minLat],
+      [bbox.maxLon, bbox.maxLat],
+    ],
+    {
+      padding: {
+        top: FIT_BOUNDS_BASE_PADDING_PX,
+        bottom: FIT_BOUNDS_BASE_PADDING_PX + occlusion.y,
+        left: FIT_BOUNDS_BASE_PADDING_PX,
+        right: FIT_BOUNDS_BASE_PADDING_PX + occlusion.x,
+      },
+      maxZoom: FIT_BOUNDS_MAX_ZOOM,
+      duration: PAN_DURATION_MS,
+    },
+  );
 }
 
 /**

--- a/apps/atlas/src/shell/theme-switcher.tsx
+++ b/apps/atlas/src/shell/theme-switcher.tsx
@@ -56,7 +56,7 @@ export function ThemeSwitcher(): ReactElement {
         <DropdownMenu.Content
           align="end"
           sideOffset={4}
-          className="min-w-[10rem] rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
+          className="z-40 min-w-[10rem] rounded-md border border-slate-200 bg-white p-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
         >
           <DropdownMenu.RadioGroup
             value={preference}


### PR DESCRIPTION
## Summary

- Adds a floating chart-feature search box (top-left) that fuzzy-matches across airports, navaids, fixes, airways, and airspace at once, ranking results by score as the user types. Rows are badged by feature kind, highlight the matched characters, and the box is a fully keyboard-driven ARIA combobox.
- A filter menu narrows the search to specific types / subtypes (mirroring the Layers menu), and an include-hidden toggle widens it to features the Layers menu is currently hiding.
- Choosing a result frames the feature in the camera (a zoom floor for point features, a fit-bounds for airways and airspace), opens the inspector, and reveals whatever layer (and airway category or airspace class) is needed to draw it.
- Extracts shared layer metadata so the Layers menu and search scope stay in sync, and gives the portaled dropdown menus a z-index so they open above the search box instead of behind it.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added specs across the new `search/` module (scope, features, resolvers, highlight, filter menu, search box, reveal-for-result, use-chart-search) and camera-framing tests in `use-chip-hover-pan.spec.ts`; full atlas suite passes (643 tests).
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; `apps/atlas` is `private: true` and not published.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->