### PR TITLE
Add drawable route geometry export to @squawk/flightplan and MCP

### DIFF
--- a/.changeset/flightplan-route-geometry.md
+++ b/.changeset/flightplan-route-geometry.md
@@ -1,0 +1,12 @@
+---
+'@squawk/flightplan': minor
+'@squawk/mcp': minor
+---
+
+### Added
+
+- `@squawk/flightplan` exposes the parsed route's drawable geometry:
+  - `routeToLineString(route)` builds a GeoJSON `LineString` (GeoJSON `[lon, lat]` ordering) ready to render as a map polyline, or `undefined` when the route yields fewer than two drawable points.
+  - `extractRoutePoints(route)` returns the ordered `RoutePoint[]` of drawable points, expanding airway and SID/STAR segments into their constituent fixes and suppressing consecutive duplicates. Coordinate-less elements (DCT, speed/altitude, unresolved) contribute no points.
+  - `RouteLeg` (from `computeRouteDistance`) now carries `fromLat`/`fromLon`/`toLat`/`toLon` for each leg's endpoints, alongside the existing `from`/`to` labels.
+- `@squawk/mcp` adds a `get_route_geometry` tool returning the ordered drawable points and GeoJSON `LineString` for a route string, and its `compute_route_distance` tool now reports the per-leg endpoint coordinates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13945,7 +13945,8 @@
       "license": "MIT",
       "dependencies": {
         "@squawk/geo": "^0.4.3",
-        "@squawk/types": "^0.8.0"
+        "@squawk/types": "^0.8.0",
+        "@types/geojson": "^7946.0.16"
       },
       "devDependencies": {
         "@squawk/airport-data": "^0.7.3",

--- a/packages/libs/flightplan/README.md
+++ b/packages/libs/flightplan/README.md
@@ -159,3 +159,58 @@ both an airport and a navaid), the resolver uses this priority order:
 3. Procedure (SID/STAR)
 4. Fix
 5. Navaid
+
+### `computeRouteDistance(route, groundSpeedKt?)`
+
+Computes the total great-circle route distance and optional estimated time
+enroute from a parsed route. Walks the same ordered point sequence as the
+geometry helpers below, so distance and geometry stay in agreement. Airway
+segments use FAA-published per-segment distances when available, falling back
+to great-circle computation.
+
+```typescript
+import { computeRouteDistance } from '@squawk/flightplan';
+
+const route = resolver.parse('KJFK DCT MERIT J60 MARTN DCT KLAX');
+const result = computeRouteDistance(route, 450);
+console.log(result.totalDistanceNm, result.estimatedTimeEnrouteHrs);
+```
+
+**Parameters:**
+
+- `route` - a `ParsedRoute` from `resolver.parse`
+- `groundSpeedKt` - optional ground speed in knots; omit to skip ETE
+
+**Returns:** `RouteDistanceResult` with:
+
+- `legs` - ordered `RouteLeg` values, each with `from`/`to` point labels, their `fromLat`/`fromLon`/`toLat`/`toLon` coordinates in decimal degrees, `distanceNm`, and `cumulativeDistanceNm`
+- `totalDistanceNm` - total great-circle distance in nautical miles
+- `estimatedTimeEnrouteHrs` - ETE in hours, or `undefined` when no ground speed was given
+- `unresolvedElements` - route elements that could not contribute coordinates
+
+### `extractRoutePoints(route)`
+
+Extracts the ordered sequence of drawable geographic points from a parsed
+route. Expands airway and SID/STAR segments into their constituent fixes and
+suppresses consecutive duplicate points (e.g. an airway entry fix that matches
+the preceding waypoint). Elements without coordinates (DCT, speed/altitude
+groups, unresolved tokens) contribute no points.
+
+**Returns:** `RoutePoint[]`, each with `label`, `lat`, and `lon`.
+
+### `routeToLineString(route)`
+
+Builds a GeoJSON `LineString` from a parsed route, ready to render as a
+polyline on a map (e.g. MapLibre, Leaflet). Coordinates follow the GeoJSON
+`[lon, lat]` ordering. Returns `undefined` when the route yields fewer than
+two drawable points, since a `LineString` requires at least two positions.
+
+```typescript
+import { routeToLineString } from '@squawk/flightplan';
+
+const route = resolver.parse('KJFK DCT MERIT J60 MARTN DCT KLAX');
+const line = routeToLineString(route);
+if (line) {
+  map.addSource('route', { type: 'geojson', data: line });
+}
+```

--- a/packages/libs/flightplan/api/flightplan.api.md
+++ b/packages/libs/flightplan/api/flightplan.api.md
@@ -8,6 +8,7 @@ import type { Airport } from '@squawk/types';
 import type { Airway } from '@squawk/types';
 import type { AirwayWaypoint } from '@squawk/types';
 import type { Fix } from '@squawk/types';
+import type { LineString } from 'geojson';
 import type { Navaid } from '@squawk/types';
 import type { Procedure } from '@squawk/types';
 import type { ProcedureLeg } from '@squawk/types';
@@ -48,6 +49,9 @@ export interface DirectRouteElement {
     raw: string;
     type: 'direct';
 }
+
+// @public
+export function extractRoutePoints(route: ParsedRoute): RoutePoint[];
 
 // @public
 export interface FlightplanAirportLookup {
@@ -119,8 +123,22 @@ export interface RouteLeg {
     cumulativeDistanceNm: number;
     distanceNm: number;
     from: string;
+    fromLat: number;
+    fromLon: number;
     to: string;
+    toLat: number;
+    toLon: number;
 }
+
+// @public
+export interface RoutePoint {
+    label: string;
+    lat: number;
+    lon: number;
+}
+
+// @public
+export function routeToLineString(route: ParsedRoute): LineString | undefined;
 
 // @public
 export interface SidRouteElement {

--- a/packages/libs/flightplan/package.json
+++ b/packages/libs/flightplan/package.json
@@ -29,7 +29,8 @@
   },
   "files": [
     "dist",
-    "!dist/**/*.spec.*"
+    "!dist/**/*.spec.*",
+    "!dist/test-utils.*"
   ],
   "scripts": {
     "build": "tsc",
@@ -42,7 +43,8 @@
   },
   "dependencies": {
     "@squawk/geo": "^0.4.3",
-    "@squawk/types": "^0.8.0"
+    "@squawk/types": "^0.8.0",
+    "@types/geojson": "^7946.0.16"
   },
   "devDependencies": {
     "@squawk/airport-data": "^0.7.3",

--- a/packages/libs/flightplan/src/index.ts
+++ b/packages/libs/flightplan/src/index.ts
@@ -27,3 +27,5 @@ export type {
 } from './resolver.js';
 export { computeRouteDistance } from './route-distance.js';
 export type { RouteLeg, RouteDistanceResult } from './route-distance.js';
+export { extractRoutePoints, routeToLineString } from './route-geometry.js';
+export type { RoutePoint } from './route-geometry.js';

--- a/packages/libs/flightplan/src/route-distance.spec.ts
+++ b/packages/libs/flightplan/src/route-distance.spec.ts
@@ -3,151 +3,22 @@ import assert from 'node:assert/strict';
 import { describe, it, beforeAll } from 'vitest';
 
 import { greatCircle } from '@squawk/geo';
-import type { Airport, AirwayWaypoint } from '@squawk/types';
 
-import type {
-  ParsedRoute,
-  RouteElement,
-  AirportRouteElement,
-  WaypointRouteElement,
-  CoordinateRouteElement,
-  DirectRouteElement,
-  SpeedAltitudeRouteElement,
-  AirwayRouteElement,
-  SidRouteElement,
-  StarRouteElement,
-  UnresolvedRouteElement,
-  FlightplanResolver,
-} from './resolver.js';
+import type { FlightplanResolver } from './resolver.js';
 import { computeRouteDistance } from './route-distance.js';
-
-/**
- * Returns true if two numbers are within the given delta of each other.
- */
-function close(a: number, b: number, delta = 0.01): boolean {
-  return Math.abs(a - b) <= delta;
-}
-
-// ---------------------------------------------------------------------------
-// Synthetic element helpers
-// ---------------------------------------------------------------------------
-
-function makeAirport(raw: string, lat: number, lon: number): AirportRouteElement {
-  return {
-    type: 'airport',
-    raw,
-    airport: { lat, lon, faaId: raw, name: raw } as Airport,
-  };
-}
-
-function makeWaypoint(raw: string, lat: number, lon: number): WaypointRouteElement {
-  return { type: 'waypoint', raw, lat, lon };
-}
-
-function makeCoordinate(raw: string, lat: number, lon: number): CoordinateRouteElement {
-  return { type: 'coordinate', raw, lat, lon };
-}
-
-function makeDirect(): DirectRouteElement {
-  return { type: 'direct', raw: 'DCT' };
-}
-
-function makeSpeedAltitude(): SpeedAltitudeRouteElement {
-  return { type: 'speedAltitude', raw: 'N0450F350', speedKt: 450, flightLevel: 350 };
-}
-
-function makeUnresolved(raw: string): UnresolvedRouteElement {
-  return { type: 'unresolved', raw };
-}
-
-function makeAirway(
-  raw: string,
-  waypoints: {
-    name?: string;
-    identifier?: string;
-    lat: number;
-    lon: number;
-    distanceToNextNm?: number;
-  }[],
-): AirwayRouteElement {
-  return {
-    type: 'airway',
-    raw,
-    airway: { designation: raw, type: 'JET', region: 'US', waypoints: [] } as never,
-    entryFix: waypoints[0]?.identifier ?? waypoints[0]?.name ?? '',
-    exitFix:
-      waypoints[waypoints.length - 1]?.identifier ?? waypoints[waypoints.length - 1]?.name ?? '',
-    waypoints: waypoints.map((wp) => {
-      const base: AirwayWaypoint = {
-        name: wp.name ?? wp.identifier ?? '',
-        waypointType: 'FIX',
-        lat: wp.lat,
-        lon: wp.lon,
-      };
-      if (wp.identifier !== undefined) {
-        base.identifier = wp.identifier;
-      }
-      if (wp.distanceToNextNm !== undefined) {
-        base.distanceToNextNm = wp.distanceToNextNm;
-      }
-      return base;
-    }),
-  };
-}
-
-function makeSid(
-  raw: string,
-  fixes: { fixIdentifier: string; lat: number; lon: number }[],
-): SidRouteElement {
-  return {
-    type: 'sid',
-    raw,
-    procedure: {
-      name: raw,
-      identifier: raw,
-      type: 'SID',
-      airports: [],
-      commonRoutes: [],
-      transitions: [],
-    },
-    legs: fixes.map((wp) => ({
-      pathTerminator: 'TF' as const,
-      fixIdentifier: wp.fixIdentifier,
-      category: 'FIX' as const,
-      lat: wp.lat,
-      lon: wp.lon,
-    })),
-  };
-}
-
-function makeStar(
-  raw: string,
-  fixes: { fixIdentifier: string; lat: number; lon: number }[],
-): StarRouteElement {
-  return {
-    type: 'star',
-    raw,
-    procedure: {
-      name: raw,
-      identifier: raw,
-      type: 'STAR',
-      airports: [],
-      commonRoutes: [],
-      transitions: [],
-    },
-    legs: fixes.map((wp) => ({
-      pathTerminator: 'TF' as const,
-      fixIdentifier: wp.fixIdentifier,
-      category: 'FIX' as const,
-      lat: wp.lat,
-      lon: wp.lon,
-    })),
-  };
-}
-
-function route(elements: RouteElement[]): ParsedRoute {
-  return { raw: 'test', elements };
-}
+import {
+  close,
+  makeAirport,
+  makeAirway,
+  makeCoordinate,
+  makeDirect,
+  makeSid,
+  makeSpeedAltitude,
+  makeStar,
+  makeUnresolved,
+  makeWaypoint,
+  route,
+} from './test-utils.js';
 
 // ---------------------------------------------------------------------------
 // Unit tests (synthetic data)
@@ -182,6 +53,10 @@ describe('computeRouteDistance', () => {
       assert.ok(close(result.totalDistanceNm, expected));
       assert.equal(result.legs[0]!.from, 'AAA');
       assert.equal(result.legs[0]!.to, 'BBB');
+      assert.equal(result.legs[0]!.fromLat, 40.0);
+      assert.equal(result.legs[0]!.fromLon, -74.0);
+      assert.equal(result.legs[0]!.toLat, 41.0);
+      assert.equal(result.legs[0]!.toLon, -74.0);
       assert.ok(close(result.legs[0]!.distanceNm, expected));
       assert.ok(close(result.legs[0]!.cumulativeDistanceNm, expected));
     });

--- a/packages/libs/flightplan/src/route-distance.ts
+++ b/packages/libs/flightplan/src/route-distance.ts
@@ -1,12 +1,13 @@
 /**
  * Route distance and estimated time enroute computation for parsed flight
- * plan routes. Extracts the ordered geographic point sequence from a
- * {@link ParsedRoute} and sums great-circle leg distances.
+ * plan routes. Sums great-circle leg distances over the ordered geographic
+ * point sequence produced by the `route-geometry` module.
  */
 
 import { greatCircle } from '@squawk/geo';
 
 import type { ParsedRoute, RouteElement } from './resolver.js';
+import { extractGeoPoints } from './route-geometry.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -20,6 +21,14 @@ export interface RouteLeg {
   from: string;
   /** Identifier or raw token of the ending point. */
   to: string;
+  /** Latitude of the starting point in decimal degrees, positive north. */
+  fromLat: number;
+  /** Longitude of the starting point in decimal degrees, positive east. */
+  fromLon: number;
+  /** Latitude of the ending point in decimal degrees, positive north. */
+  toLat: number;
+  /** Longitude of the ending point in decimal degrees, positive east. */
+  toLon: number;
   /** Great-circle distance of this leg in nautical miles. */
   distanceNm: number;
   /** Cumulative distance from the route start through the end of this leg in nautical miles. */
@@ -43,128 +52,6 @@ export interface RouteDistanceResult {
    * so the total may be approximate.
    */
   unresolvedElements: RouteElement[];
-}
-
-// ---------------------------------------------------------------------------
-// Internal types
-// ---------------------------------------------------------------------------
-
-/** A geographic point extracted from a route element. */
-interface GeoPoint {
-  /** Display label (identifier or raw token). */
-  label: string;
-  /** Latitude in decimal degrees, positive north. */
-  lat: number;
-  /** Longitude in decimal degrees, positive east. */
-  lon: number;
-  /**
-   * Pre-computed distance to the next point along an airway segment in
-   * nautical miles, if available from the source data.
-   */
-  precomputedDistanceToNextNm?: number;
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/** Epsilon for comparing coordinates to detect duplicate points. */
-const COORD_EPSILON = 1e-9;
-
-/**
- * Returns true if two points share the same coordinates (within epsilon).
- */
-function samePosition(a: GeoPoint, b: GeoPoint): boolean {
-  return Math.abs(a.lat - b.lat) < COORD_EPSILON && Math.abs(a.lon - b.lon) < COORD_EPSILON;
-}
-
-/**
- * Walks the route elements and extracts an ordered array of geographic
- * points. Duplicate consecutive points (e.g. an airway entry fix that
- * matches the preceding waypoint) are suppressed.
- *
- * Also collects all `unresolved` elements encountered during the walk.
- */
-function extractGeoPoints(elements: RouteElement[]): {
-  points: GeoPoint[];
-  unresolvedElements: RouteElement[];
-} {
-  const points: GeoPoint[] = [];
-  const unresolvedElements: RouteElement[] = [];
-
-  function emit(point: GeoPoint): void {
-    if (points.length > 0 && samePosition(points[points.length - 1]!, point)) {
-      // When the duplicate carries a precomputed distance that the existing
-      // point lacks, adopt it. This happens when an airway's entry fix
-      // overlaps the preceding waypoint -- the airway waypoint has the
-      // published segment distance that would otherwise be lost.
-      const last = points[points.length - 1]!;
-      if (
-        point.precomputedDistanceToNextNm !== undefined &&
-        last.precomputedDistanceToNextNm === undefined
-      ) {
-        last.precomputedDistanceToNextNm = point.precomputedDistanceToNextNm;
-      }
-      return;
-    }
-    points.push(point);
-  }
-
-  for (const el of elements) {
-    switch (el.type) {
-      case 'airport':
-        emit({ label: el.raw, lat: el.airport.lat, lon: el.airport.lon });
-        break;
-
-      case 'waypoint':
-        emit({ label: el.raw, lat: el.lat, lon: el.lon });
-        break;
-
-      case 'coordinate':
-        emit({ label: el.raw, lat: el.lat, lon: el.lon });
-        break;
-
-      case 'airway':
-        for (let i = 0; i < el.waypoints.length; i++) {
-          const wp = el.waypoints[i]!;
-          const isLast = i === el.waypoints.length - 1;
-          const point: GeoPoint = {
-            label: wp.identifier ?? wp.name,
-            lat: wp.lat,
-            lon: wp.lon,
-          };
-          // Only carry precomputed distance for non-last waypoints (the
-          // last waypoint's distanceToNextNm points beyond this segment).
-          if (!isLast && wp.distanceToNextNm !== undefined) {
-            point.precomputedDistanceToNextNm = wp.distanceToNextNm;
-          }
-          emit(point);
-        }
-        break;
-
-      case 'sid':
-      case 'star':
-        for (const leg of el.legs) {
-          if (leg.fixIdentifier === undefined || leg.lat === undefined || leg.lon === undefined) {
-            continue;
-          }
-          emit({ label: leg.fixIdentifier, lat: leg.lat, lon: leg.lon });
-        }
-        break;
-
-      case 'unresolved':
-        unresolvedElements.push(el);
-        break;
-
-      // 'direct' and 'speedAltitude' are expected non-geographic markers
-      // and are silently skipped.
-      case 'direct':
-      case 'speedAltitude':
-        break;
-    }
-  }
-
-  return { points, unresolvedElements };
 }
 
 // ---------------------------------------------------------------------------
@@ -223,6 +110,10 @@ export function computeRouteDistance(
     legs.push({
       from: from.label,
       to: to.label,
+      fromLat: from.lat,
+      fromLon: from.lon,
+      toLat: to.lat,
+      toLon: to.lon,
       distanceNm: legDistanceNm,
       cumulativeDistanceNm: totalDistanceNm,
     });

--- a/packages/libs/flightplan/src/route-geometry.spec.ts
+++ b/packages/libs/flightplan/src/route-geometry.spec.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+
+import { describe, it } from 'vitest';
+
+import { extractRoutePoints, routeToLineString } from './route-geometry.js';
+import {
+  makeAirport,
+  makeAirway,
+  makeCoordinate,
+  makeDirect,
+  makeSid,
+  makeSpeedAltitude,
+  makeStar,
+  makeUnresolved,
+  makeWaypoint,
+  route,
+} from './test-utils.js';
+
+// ---------------------------------------------------------------------------
+// extractRoutePoints
+// ---------------------------------------------------------------------------
+
+describe('extractRoutePoints', () => {
+  it('returns an empty array for an empty route', () => {
+    assert.deepEqual(extractRoutePoints(route([])), []);
+  });
+
+  it('returns label/lat/lon for airport, waypoint, and coordinate elements', () => {
+    const points = extractRoutePoints(
+      route([
+        makeAirport('KJFK', 40.6413, -73.7781),
+        makeWaypoint('MERIT', 41.0, -73.0),
+        makeCoordinate('4200N07200W', 42.0, -72.0),
+      ]),
+    );
+
+    assert.deepEqual(points, [
+      { label: 'KJFK', lat: 40.6413, lon: -73.7781 },
+      { label: 'MERIT', lat: 41.0, lon: -73.0 },
+      { label: '4200N07200W', lat: 42.0, lon: -72.0 },
+    ]);
+  });
+
+  it('does not expose the internal precomputed distance field', () => {
+    const points = extractRoutePoints(
+      route([
+        makeAirway('J60', [
+          { identifier: 'A', lat: 40.0, lon: -74.0, distanceToNextNm: 100 },
+          { identifier: 'B', lat: 41.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.equal(points.length, 2);
+    for (const point of points) {
+      assert.deepEqual(Object.keys(point).sort(), ['label', 'lat', 'lon']);
+    }
+  });
+
+  it('expands airway waypoints into individual points', () => {
+    const points = extractRoutePoints(
+      route([
+        makeAirway('J60', [
+          { identifier: 'A', lat: 40.0, lon: -74.0 },
+          { identifier: 'B', lat: 41.0, lon: -74.0 },
+          { identifier: 'C', lat: 42.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['A', 'B', 'C'],
+    );
+  });
+
+  it('uses airway waypoint name as label when identifier is absent', () => {
+    const points = extractRoutePoints(
+      route([
+        makeAirway('J60', [
+          { name: 'ALPHA POINT', lat: 40.0, lon: -74.0 },
+          { name: 'BRAVO POINT', lat: 41.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['ALPHA POINT', 'BRAVO POINT'],
+    );
+  });
+
+  it('flattens SID legs into points', () => {
+    const points = extractRoutePoints(
+      route([
+        makeSid('DEEZZ5', [
+          { fixIdentifier: 'RWY', lat: 40.0, lon: -74.0 },
+          { fixIdentifier: 'TURNN', lat: 40.5, lon: -74.0 },
+          { fixIdentifier: 'DEEZZ', lat: 41.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['RWY', 'TURNN', 'DEEZZ'],
+    );
+  });
+
+  it('flattens STAR legs into points', () => {
+    const points = extractRoutePoints(
+      route([
+        makeStar('ARRIV3', [
+          { fixIdentifier: 'ENTER', lat: 41.0, lon: -74.0 },
+          { fixIdentifier: 'DESCN', lat: 40.5, lon: -74.0 },
+          { fixIdentifier: 'FINAL', lat: 40.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['ENTER', 'DESCN', 'FINAL'],
+    );
+  });
+
+  it('skips procedure legs that lack a fix identifier or coordinates', () => {
+    const points = extractRoutePoints(
+      route([
+        makeSid('CLIMB1', [
+          { fixIdentifier: 'RWY', lat: 40.0, lon: -74.0 },
+          {},
+          { fixIdentifier: 'TOP', lat: 40.5, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['RWY', 'TOP'],
+    );
+  });
+
+  it('suppresses consecutive duplicate points', () => {
+    const points = extractRoutePoints(
+      route([
+        makeWaypoint('MERIT', 40.5, -74.0),
+        makeAirway('J60', [
+          { identifier: 'MERIT', lat: 40.5, lon: -74.0 },
+          { identifier: 'MARTN', lat: 41.0, lon: -74.0 },
+        ]),
+      ]),
+    );
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['MERIT', 'MARTN'],
+    );
+  });
+
+  it('contributes no points for DCT, speed/altitude, and unresolved elements', () => {
+    const points = extractRoutePoints(
+      route([makeDirect(), makeSpeedAltitude(), makeUnresolved('XYZZY')]),
+    );
+
+    assert.deepEqual(points, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeToLineString
+// ---------------------------------------------------------------------------
+
+describe('routeToLineString', () => {
+  it('builds a LineString with [lon, lat] coordinates', () => {
+    const line = routeToLineString(
+      route([makeWaypoint('A', 40.0, -74.0), makeWaypoint('B', 41.0, -73.0)]),
+    );
+
+    assert.deepEqual(line, {
+      type: 'LineString',
+      coordinates: [
+        [-74.0, 40.0],
+        [-73.0, 41.0],
+      ],
+    });
+  });
+
+  it('returns undefined for an empty route', () => {
+    assert.equal(routeToLineString(route([])), undefined);
+  });
+
+  it('returns undefined when the route yields a single point', () => {
+    assert.equal(routeToLineString(route([makeWaypoint('SOLO', 40.0, -74.0)])), undefined);
+  });
+});

--- a/packages/libs/flightplan/src/route-geometry.ts
+++ b/packages/libs/flightplan/src/route-geometry.ts
@@ -1,0 +1,229 @@
+/**
+ * Drawable geometry extraction for parsed flight plan routes. Walks the
+ * {@link ParsedRoute} elements into an ordered point sequence - expanding
+ * airway waypoints, flattening SID/STAR legs, and suppressing consecutive
+ * duplicate points - and exposes that sequence both as plain
+ * {@link RoutePoint} values and as a GeoJSON `LineString` for map rendering.
+ *
+ * The same walk feeds `computeRouteDistance` in the `route-distance` module,
+ * so distance and geometry stay in agreement.
+ */
+
+import type { LineString } from 'geojson';
+
+import type { ParsedRoute, RouteElement } from './resolver.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single drawable geographic point along a parsed route, in route order.
+ */
+export interface RoutePoint {
+  /** Display label (identifier or raw token) for the point. */
+  label: string;
+  /** Latitude in decimal degrees, positive north. */
+  lat: number;
+  /** Longitude in decimal degrees, positive east. */
+  lon: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/**
+ * A geographic point extracted from a route element. Internal to the package;
+ * carries the precomputed airway segment distance that `computeRouteDistance`
+ * needs but that is not part of the public {@link RoutePoint} shape.
+ *
+ * @internal
+ */
+export interface GeoPoint {
+  /** Display label (identifier or raw token). */
+  label: string;
+  /** Latitude in decimal degrees, positive north. */
+  lat: number;
+  /** Longitude in decimal degrees, positive east. */
+  lon: number;
+  /**
+   * Pre-computed distance to the next point along an airway segment in
+   * nautical miles, if available from the source data.
+   */
+  precomputedDistanceToNextNm?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Epsilon for comparing coordinates to detect duplicate points. */
+const COORD_EPSILON = 1e-9;
+
+/**
+ * Returns true if two points share the same coordinates (within epsilon).
+ */
+function samePosition(a: GeoPoint, b: GeoPoint): boolean {
+  return Math.abs(a.lat - b.lat) < COORD_EPSILON && Math.abs(a.lon - b.lon) < COORD_EPSILON;
+}
+
+/**
+ * Walks the route elements and extracts an ordered array of geographic
+ * points. Duplicate consecutive points (e.g. an airway entry fix that
+ * matches the preceding waypoint) are suppressed.
+ *
+ * Also collects all `unresolved` elements encountered during the walk.
+ *
+ * Internal to the package: `extractRoutePoints` and `routeToLineString`
+ * project this into public shapes, and `computeRouteDistance` consumes the
+ * precomputed segment distances directly.
+ *
+ * @internal
+ */
+export function extractGeoPoints(elements: RouteElement[]): {
+  points: GeoPoint[];
+  unresolvedElements: RouteElement[];
+} {
+  const points: GeoPoint[] = [];
+  const unresolvedElements: RouteElement[] = [];
+
+  function emit(point: GeoPoint): void {
+    if (points.length > 0 && samePosition(points[points.length - 1]!, point)) {
+      // When the duplicate carries a precomputed distance that the existing
+      // point lacks, adopt it. This happens when an airway's entry fix
+      // overlaps the preceding waypoint -- the airway waypoint has the
+      // published segment distance that would otherwise be lost.
+      const last = points[points.length - 1]!;
+      if (
+        point.precomputedDistanceToNextNm !== undefined &&
+        last.precomputedDistanceToNextNm === undefined
+      ) {
+        last.precomputedDistanceToNextNm = point.precomputedDistanceToNextNm;
+      }
+      return;
+    }
+    points.push(point);
+  }
+
+  for (const el of elements) {
+    switch (el.type) {
+      case 'airport':
+        emit({ label: el.raw, lat: el.airport.lat, lon: el.airport.lon });
+        break;
+
+      case 'waypoint':
+        emit({ label: el.raw, lat: el.lat, lon: el.lon });
+        break;
+
+      case 'coordinate':
+        emit({ label: el.raw, lat: el.lat, lon: el.lon });
+        break;
+
+      case 'airway':
+        for (let i = 0; i < el.waypoints.length; i++) {
+          const wp = el.waypoints[i]!;
+          const isLast = i === el.waypoints.length - 1;
+          const point: GeoPoint = {
+            label: wp.identifier ?? wp.name,
+            lat: wp.lat,
+            lon: wp.lon,
+          };
+          // Only carry precomputed distance for non-last waypoints (the
+          // last waypoint's distanceToNextNm points beyond this segment).
+          if (!isLast && wp.distanceToNextNm !== undefined) {
+            point.precomputedDistanceToNextNm = wp.distanceToNextNm;
+          }
+          emit(point);
+        }
+        break;
+
+      case 'sid':
+      case 'star':
+        for (const leg of el.legs) {
+          if (leg.fixIdentifier === undefined || leg.lat === undefined || leg.lon === undefined) {
+            continue;
+          }
+          emit({ label: leg.fixIdentifier, lat: leg.lat, lon: leg.lon });
+        }
+        break;
+
+      case 'unresolved':
+        unresolvedElements.push(el);
+        break;
+
+      // 'direct' and 'speedAltitude' are expected non-geographic markers
+      // and are silently skipped.
+      case 'direct':
+      case 'speedAltitude':
+        break;
+    }
+  }
+
+  return { points, unresolvedElements };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the ordered sequence of drawable geographic points from a parsed
+ * flight plan route.
+ *
+ * Expands airway and SID/STAR segments into their constituent fixes and
+ * suppresses consecutive duplicate points (e.g. an airway entry fix that
+ * matches the preceding waypoint). Elements without coordinates (DCT,
+ * speed/altitude groups, unresolved tokens) contribute no points.
+ *
+ * This is the same walk that backs `computeRouteDistance`, so the point
+ * sequence here lines up with that result's legs.
+ *
+ * ```typescript
+ * import { createFlightplanResolver, extractRoutePoints } from '@squawk/flightplan';
+ *
+ * const resolver = createFlightplanResolver({ airports, navaids, fixes, airways });
+ * const route = resolver.parse('KJFK DCT MERIT J60 MARTN DCT KLAX');
+ * const points = extractRoutePoints(route);
+ * ```
+ *
+ * @param route - A parsed route from {@link FlightplanResolver.parse}.
+ * @returns Ordered drawable points along the route.
+ */
+export function extractRoutePoints(route: ParsedRoute): RoutePoint[] {
+  const { points } = extractGeoPoints(route.elements);
+  return points.map((p) => ({ label: p.label, lat: p.lat, lon: p.lon }));
+}
+
+/**
+ * Builds a GeoJSON `LineString` from a parsed flight plan route, ready to
+ * render as a polyline on a map (e.g. MapLibre, Leaflet).
+ *
+ * Coordinates follow the GeoJSON `[lon, lat]` ordering. Returns `undefined`
+ * when the route yields fewer than two drawable points, since a `LineString`
+ * requires at least two positions to be valid.
+ *
+ * ```typescript
+ * import { createFlightplanResolver, routeToLineString } from '@squawk/flightplan';
+ *
+ * const resolver = createFlightplanResolver({ airports, navaids, fixes, airways });
+ * const route = resolver.parse('KJFK DCT MERIT J60 MARTN DCT KLAX');
+ * const line = routeToLineString(route);
+ * if (line) {
+ *   map.addSource('route', { type: 'geojson', data: line });
+ * }
+ * ```
+ *
+ * @param route - A parsed route from {@link FlightplanResolver.parse}.
+ * @returns A GeoJSON `LineString`, or `undefined` if fewer than two points.
+ */
+export function routeToLineString(route: ParsedRoute): LineString | undefined {
+  const points = extractRoutePoints(route);
+  if (points.length < 2) {
+    return undefined;
+  }
+  return {
+    type: 'LineString',
+    coordinates: points.map((p) => [p.lon, p.lat]),
+  };
+}

--- a/packages/libs/flightplan/src/test-utils.ts
+++ b/packages/libs/flightplan/src/test-utils.ts
@@ -1,0 +1,226 @@
+import type { Airport, AirwayWaypoint, ProcedureLeg } from '@squawk/types';
+
+import type {
+  AirportRouteElement,
+  AirwayRouteElement,
+  CoordinateRouteElement,
+  DirectRouteElement,
+  ParsedRoute,
+  RouteElement,
+  SidRouteElement,
+  SpeedAltitudeRouteElement,
+  StarRouteElement,
+  UnresolvedRouteElement,
+  WaypointRouteElement,
+} from './resolver.js';
+
+/**
+ * Returns true if two numbers are within the given delta of each other.
+ * Used across spec files for floating-point comparisons.
+ *
+ * @param a - First value to compare.
+ * @param b - Second value to compare.
+ * @param delta - Maximum allowed absolute difference (default: 0.01).
+ * @returns True if |a - b| <= delta.
+ */
+export function close(a: number, b: number, delta = 0.01): boolean {
+  return Math.abs(a - b) <= delta;
+}
+
+/**
+ * Builds a synthetic airport route element for tests.
+ *
+ * @param raw - Raw token / label.
+ * @param lat - Latitude in decimal degrees.
+ * @param lon - Longitude in decimal degrees.
+ * @returns An airport route element.
+ */
+export function makeAirport(raw: string, lat: number, lon: number): AirportRouteElement {
+  return {
+    type: 'airport',
+    raw,
+    airport: { lat, lon, faaId: raw, name: raw } as Airport,
+  };
+}
+
+/**
+ * Builds a synthetic waypoint route element for tests.
+ *
+ * @param raw - Raw token / label.
+ * @param lat - Latitude in decimal degrees.
+ * @param lon - Longitude in decimal degrees.
+ * @returns A waypoint route element.
+ */
+export function makeWaypoint(raw: string, lat: number, lon: number): WaypointRouteElement {
+  return { type: 'waypoint', raw, lat, lon };
+}
+
+/**
+ * Builds a synthetic coordinate route element for tests.
+ *
+ * @param raw - Raw token / label.
+ * @param lat - Latitude in decimal degrees.
+ * @param lon - Longitude in decimal degrees.
+ * @returns A coordinate route element.
+ */
+export function makeCoordinate(raw: string, lat: number, lon: number): CoordinateRouteElement {
+  return { type: 'coordinate', raw, lat, lon };
+}
+
+/**
+ * Builds a synthetic DCT (direct) route element for tests.
+ *
+ * @returns A direct route element.
+ */
+export function makeDirect(): DirectRouteElement {
+  return { type: 'direct', raw: 'DCT' };
+}
+
+/**
+ * Builds a synthetic speed/altitude route element for tests.
+ *
+ * @returns A speed/altitude route element.
+ */
+export function makeSpeedAltitude(): SpeedAltitudeRouteElement {
+  return { type: 'speedAltitude', raw: 'N0450F350', speedKt: 450, flightLevel: 350 };
+}
+
+/**
+ * Builds a synthetic unresolved route element for tests.
+ *
+ * @param raw - Raw token / label.
+ * @returns An unresolved route element.
+ */
+export function makeUnresolved(raw: string): UnresolvedRouteElement {
+  return { type: 'unresolved', raw };
+}
+
+/**
+ * Builds a synthetic airway route element for tests.
+ *
+ * @param raw - Airway designation / raw token.
+ * @param waypoints - Ordered waypoints, each with optional name/identifier,
+ *   coordinates, and an optional precomputed distance to the next waypoint.
+ * @returns An airway route element.
+ */
+export function makeAirway(
+  raw: string,
+  waypoints: {
+    name?: string;
+    identifier?: string;
+    lat: number;
+    lon: number;
+    distanceToNextNm?: number;
+  }[],
+): AirwayRouteElement {
+  return {
+    type: 'airway',
+    raw,
+    airway: { designation: raw, type: 'JET', region: 'US', waypoints: [] } as never,
+    entryFix: waypoints[0]?.identifier ?? waypoints[0]?.name ?? '',
+    exitFix:
+      waypoints[waypoints.length - 1]?.identifier ?? waypoints[waypoints.length - 1]?.name ?? '',
+    waypoints: waypoints.map((wp) => {
+      const base: AirwayWaypoint = {
+        name: wp.name ?? wp.identifier ?? '',
+        waypointType: 'FIX',
+        lat: wp.lat,
+        lon: wp.lon,
+      };
+      if (wp.identifier !== undefined) {
+        base.identifier = wp.identifier;
+      }
+      if (wp.distanceToNextNm !== undefined) {
+        base.distanceToNextNm = wp.distanceToNextNm;
+      }
+      return base;
+    }),
+  };
+}
+
+/**
+ * Builds a synthetic procedure leg for SID/STAR test fixtures. Coordinate-less
+ * legs (e.g. heading-to-altitude legs) are represented by omitting the fix
+ * identifier and coordinates, mirroring how the resolver surfaces non-fix legs.
+ *
+ * @param fix - Optional fix identifier and coordinates for the leg.
+ * @returns A procedure leg.
+ */
+function makeProcedureLeg(fix: { fixIdentifier?: string; lat?: number; lon?: number }): ProcedureLeg {
+  const leg: ProcedureLeg = { pathTerminator: 'TF' };
+  if (fix.fixIdentifier !== undefined) {
+    leg.fixIdentifier = fix.fixIdentifier;
+    leg.category = 'FIX';
+  }
+  if (fix.lat !== undefined) {
+    leg.lat = fix.lat;
+  }
+  if (fix.lon !== undefined) {
+    leg.lon = fix.lon;
+  }
+  return leg;
+}
+
+/**
+ * Builds a synthetic SID route element for tests.
+ *
+ * @param raw - Procedure identifier / raw token.
+ * @param fixes - Ordered fixes, each with an optional identifier and
+ *   coordinates. Omit the coordinates to model a coordinate-less leg.
+ * @returns A SID route element.
+ */
+export function makeSid(
+  raw: string,
+  fixes: { fixIdentifier?: string; lat?: number; lon?: number }[],
+): SidRouteElement {
+  return {
+    type: 'sid',
+    raw,
+    procedure: {
+      name: raw,
+      identifier: raw,
+      type: 'SID',
+      airports: [],
+      commonRoutes: [],
+      transitions: [],
+    },
+    legs: fixes.map(makeProcedureLeg),
+  };
+}
+
+/**
+ * Builds a synthetic STAR route element for tests.
+ *
+ * @param raw - Procedure identifier / raw token.
+ * @param fixes - Ordered fixes, each with an optional identifier and
+ *   coordinates. Omit the coordinates to model a coordinate-less leg.
+ * @returns A STAR route element.
+ */
+export function makeStar(
+  raw: string,
+  fixes: { fixIdentifier?: string; lat?: number; lon?: number }[],
+): StarRouteElement {
+  return {
+    type: 'star',
+    raw,
+    procedure: {
+      name: raw,
+      identifier: raw,
+      type: 'STAR',
+      airports: [],
+      commonRoutes: [],
+      transitions: [],
+    },
+    legs: fixes.map(makeProcedureLeg),
+  };
+}
+
+/**
+ * Wraps an ordered list of route elements in a parsed route for tests.
+ *
+ * @param elements - Ordered route elements.
+ * @returns A parsed route with a fixed raw string.
+ */
+export function route(elements: RouteElement[]): ParsedRoute {
+  return { raw: 'test', elements };
+}

--- a/packages/libs/flightplan/src/test-utils.ts
+++ b/packages/libs/flightplan/src/test-utils.ts
@@ -146,7 +146,11 @@ export function makeAirway(
  * @param fix - Optional fix identifier and coordinates for the leg.
  * @returns A procedure leg.
  */
-function makeProcedureLeg(fix: { fixIdentifier?: string; lat?: number; lon?: number }): ProcedureLeg {
+function makeProcedureLeg(fix: {
+  fixIdentifier?: string;
+  lat?: number;
+  lon?: number;
+}): ProcedureLeg {
   const leg: ProcedureLeg = { pathTerminator: 'TF' };
   if (fix.fixIdentifier !== undefined) {
     leg.fixIdentifier = fix.fixIdentifier;

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -98,7 +98,7 @@ version explicitly in the client config:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "@squawk/mcp@0.10.0"]
+      "args": ["-y", "@squawk/mcp@0.11.0"]
     }
   }
 }
@@ -164,7 +164,7 @@ Pinning works the same way:
   "mcpServers": {
     "squawk": {
       "command": "npx",
-      "args": ["-y", "-p", "@squawk/icao-registry-data@0.8.10", "@squawk/mcp@0.10.0"]
+      "args": ["-y", "-p", "@squawk/icao-registry-data@0.8.10", "@squawk/mcp@0.11.0"]
     }
   }
 }
@@ -343,6 +343,7 @@ lookup so sessions that never need it do not pay the cost.
 | ------------------------ | ---------------------------------------------------------- |
 | `parse_flightplan_route` | Parse an ICAO Item 15 route into structured route elements |
 | `compute_route_distance` | Total great-circle route distance with optional ETE        |
+| `get_route_geometry`     | Ordered drawable points and a GeoJSON LineString           |
 
 ### Flight computer (`@squawk/flight-math`)
 

--- a/packages/libs/mcp/src/tools.spec.ts
+++ b/packages/libs/mcp/src/tools.spec.ts
@@ -1360,6 +1360,34 @@ describe('flightplan tools', () => {
       await close();
     }
   });
+
+  it('get_route_geometry returns ordered points and a LineString', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_route_geometry',
+        arguments: { routeString: 'KJFK DCT KLAX' },
+      });
+      const parsed = z
+        .object({
+          points: z.array(
+            z.object({ label: z.string(), lat: z.number(), lon: z.number() }).passthrough(),
+          ),
+          lineString: z
+            .object({
+              type: z.literal('LineString'),
+              coordinates: z.array(z.array(z.number())),
+            })
+            .optional(),
+        })
+        .parse(result.structuredContent);
+      assert(parsed.points.length >= 2);
+      assert(parsed.lineString !== undefined);
+      expect(parsed.lineString.coordinates.length).toBe(parsed.points.length);
+    } finally {
+      await close();
+    }
+  });
 });
 
 describe('weather parsing tools', () => {

--- a/packages/libs/mcp/src/tools/flightplan.ts
+++ b/packages/libs/mcp/src/tools/flightplan.ts
@@ -9,7 +9,12 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import { computeRouteDistance, createFlightplanResolver } from '@squawk/flightplan';
+import {
+  computeRouteDistance,
+  createFlightplanResolver,
+  extractRoutePoints,
+  routeToLineString,
+} from '@squawk/flightplan';
 
 import {
   airportResolver,
@@ -62,7 +67,7 @@ export function registerFlightplanTools(server: McpServer): void {
     {
       title: 'Compute route distance and ETE',
       description:
-        'Parses a flight plan route string and computes the total great-circle distance in nautical miles, the ordered list of legs with cumulative distance, and (when groundSpeedKt is supplied) the estimated time enroute in hours. Uses FAA-published per-segment distances on airway segments when available; otherwise falls back to great-circle computation. Unresolved tokens are surfaced separately so the caller can decide whether to trust the total.',
+        'Parses a flight plan route string and computes the total great-circle distance in nautical miles, the ordered list of legs with cumulative distance, and (when groundSpeedKt is supplied) the estimated time enroute in hours. Each leg carries the from/to point labels and their latitude/longitude in decimal degrees, so the result doubles as a drawable leg-by-leg geometry. Uses FAA-published per-segment distances on airway segments when available; otherwise falls back to great-circle computation. Unresolved tokens are surfaced separately so the caller can decide whether to trust the total. To get the route as a single ordered point sequence or a GeoJSON LineString for map rendering, use get_route_geometry instead.',
       inputSchema: {
         routeString: z
           .string()
@@ -83,6 +88,31 @@ export function registerFlightplanTools(server: McpServer): void {
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         structuredContent: { result },
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_route_geometry',
+    {
+      title: 'Get drawable route geometry',
+      description:
+        'Parses a flight plan route string and returns its drawable geometry: the ordered sequence of geographic points (each with a label and latitude/longitude in decimal degrees) and a GeoJSON LineString ready to render as a polyline on a map. Airway and SID/STAR segments are expanded into their constituent fixes, and consecutive duplicate points (e.g. an airway entry fix that matches the preceding waypoint) are suppressed. LineString coordinates follow the GeoJSON [lon, lat] ordering. The lineString field is omitted when the route yields fewer than two drawable points, since a LineString requires at least two positions. Use compute_route_distance instead when you need leg distances or estimated time enroute.',
+      inputSchema: {
+        routeString: z
+          .string()
+          .min(1)
+          .describe('Whitespace-separated route string in ICAO Item 15 conventions.'),
+      },
+    },
+    ({ routeString }) => {
+      const route = resolver.parse(routeString);
+      const points = extractRoutePoints(route);
+      const lineString = routeToLineString(route);
+      const result = { points, lineString };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        structuredContent: result,
       };
     },
   );


### PR DESCRIPTION
## Summary

- `@squawk/flightplan` now exports its drawable route geometry: `extractRoutePoints(route)` (ordered points, with airway and SID/STAR segments expanded and consecutive duplicates suppressed) and `routeToLineString(route)` (a GeoJSON `LineString`, or `undefined` for fewer than two points). `RouteLeg` also gains per-endpoint `fromLat`/`fromLon`/`toLat`/`toLon`.
- `@squawk/mcp` surfaces it via a new `get_route_geometry` tool and adds the per-leg coordinates to `compute_route_distance`.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added `route-geometry.spec.ts` (100% file coverage), refactored `route-distance.spec.ts` to assert the new `RouteLeg` coordinate fields, and extended mcp `tools.spec.ts` for `get_route_geometry`.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - Bumps `@squawk/flightplan` and `@squawk/mcp` minor.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->