### PR TITLE
Add position-disambiguated identifier lookup to navaids and fixes

### DIFF
--- a/.changeset/position-aware-resolver-lookup.md
+++ b/.changeset/position-aware-resolver-lookup.md
@@ -1,0 +1,11 @@
+---
+'@squawk/navaids': minor
+'@squawk/fixes': minor
+'@squawk/mcp': minor
+---
+
+### Added
+
+- **@squawk/navaids** `byIdentAtPosition(ident, lat, lon, toleranceNm?)` resolver method returns the single navaid sharing an identifier that lies nearest a geographic position. The same identifier can be published by more than one station (a co-located NDB and VOR/DME, or two distant stations reusing a code); this disambiguates the collision by proximity to a known point such as a map-click location or an adjacent route waypoint. Pass `toleranceNm` to reject matches beyond a maximum great-circle distance, or omit it to let the nearest match win regardless.
+- **@squawk/fixes** `byIdentAtPosition(ident, lat, lon, toleranceNm?)` resolver method returns the single fix sharing an identifier that lies nearest a geographic position. The same identifier can be published in more than one ICAO region; this disambiguates the collision by proximity to a known point. Pass `toleranceNm` to bound the match by great-circle distance, or omit it to let the nearest match win.
+- **@squawk/mcp** adds `get_navaid_by_ident_at_position` and `get_fix_by_ident_at_position` tools wrapping the new resolver methods, each returning the nearest matching record (or null) for a shared identifier near a given position.

--- a/packages/libs/fixes/README.md
+++ b/packages/libs/fixes/README.md
@@ -71,6 +71,28 @@ Looks up fixes by identifier (e.g. "MERIT", "BOSCO"). Multiple fixes can share
 the same identifier in different ICAO regions. Case-insensitive.
 Returns `Fix[]`.
 
+### `resolver.byIdentAtPosition(ident, lat, lon, toleranceNm?)`
+
+Looks up the single fix sharing the given identifier that lies nearest to a
+geographic position. The same fix identifier can be published in more than one
+ICAO region; this disambiguates the collision by proximity to a known point such
+as a map-click location or an adjacent route waypoint.
+
+| Parameter     | Type   | Description                                                                                             |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| `ident`       | string | Fix identifier (case-insensitive)                                                                       |
+| `lat`         | number | Latitude of the reference position in decimal degrees (WGS84)                                           |
+| `lon`         | number | Longitude of the reference position in decimal degrees (WGS84)                                          |
+| `toleranceNm` | number | Optional. Maximum great-circle distance in nautical miles. Omit to let the nearest match win regardless |
+
+Returns the nearest matching `Fix` by great-circle distance, or `undefined` when
+no fix carries the identifier or none fall within `toleranceNm`.
+
+```typescript
+// Disambiguate a shared identifier against an adjacent route waypoint
+const fix = resolver.byIdentAtPosition('BOSCO', 40.64, -73.78);
+```
+
 ### `resolver.nearest(query)`
 
 Finds fixes nearest to a geographic position, sorted by distance ascending.

--- a/packages/libs/fixes/api/fixes.api.md
+++ b/packages/libs/fixes/api/fixes.api.md
@@ -14,6 +14,7 @@ export function createFixResolver(options: FixResolverOptions): FixResolver;
 // @public
 export interface FixResolver {
     byIdent(ident: string): Fix[];
+    byIdentAtPosition(ident: string, lat: number, lon: number, toleranceNm?: number): Fix | undefined;
     nearest(query: NearestFixQuery): NearestFixResult[];
     search(query: FixSearchQuery): FixSearchResult[];
 }

--- a/packages/libs/fixes/src/resolver.spec.ts
+++ b/packages/libs/fixes/src/resolver.spec.ts
@@ -55,6 +55,87 @@ describe('byIdent', () => {
   });
 });
 
+describe('byIdentAtPosition', () => {
+  /**
+   * Builds a minimal synthetic fix at a given position. US fix identifiers
+   * are unique within the bundled dataset, so a shared identifier across
+   * distinct positions has to be constructed to exercise nearest-wins
+   * disambiguation.
+   */
+  function makeFix(identifier: string, lat: number, lon: number): Fix {
+    return {
+      identifier,
+      icaoRegionCode: 'K1',
+      country: 'US',
+      lat,
+      lon,
+      useCode: 'RP',
+      pitch: false,
+      catch: false,
+      suaAtcaa: false,
+      chartTypes: [],
+      navaidAssociations: [],
+    };
+  }
+
+  it('returns the match nearest to the query position when an identifier is shared', () => {
+    const east = makeFix('DUPE', 40, -74);
+    const west = makeFix('DUPE', 34, -118);
+    const local = createFixResolver({ data: [east, west] });
+
+    const nearEast = local.byIdentAtPosition('DUPE', 40.5, -74.5);
+    const nearWest = local.byIdentAtPosition('DUPE', 33.5, -117.5);
+    assert(
+      nearEast !== undefined && nearWest !== undefined,
+      'expected a match near each position',
+    );
+    expect(nearEast.lat).toBe(east.lat);
+    expect(nearEast.lon).toBe(east.lon);
+    expect(nearWest.lat).toBe(west.lat);
+    expect(nearWest.lon).toBe(west.lon);
+  });
+
+  it('is case-insensitive', () => {
+    const match = resolver.byIdent('MERIT')[0];
+    assert(match !== undefined, 'expected a MERIT fix');
+    const upper = resolver.byIdentAtPosition('MERIT', match.lat, match.lon);
+    const lower = resolver.byIdentAtPosition('merit', match.lat, match.lon);
+    assert(
+      upper !== undefined && lower !== undefined,
+      'expected case-insensitive MERIT match',
+    );
+    expect(lower.identifier).toBe('MERIT');
+  });
+
+  it('returns undefined for an unknown identifier', () => {
+    expect(resolver.byIdentAtPosition('ZZZZZZZZZ', 0, 0)).toBeUndefined();
+  });
+
+  it('returns the nearest match regardless of distance when no tolerance is given', () => {
+    // Query from the mid-Pacific; the nearest MERIT record still wins.
+    const result = resolver.byIdentAtPosition('MERIT', 0, -160);
+    assert(result !== undefined, 'expected a match with no tolerance');
+    assert(
+      resolver.byIdent('MERIT').some((f) => f.lat === result.lat && f.lon === result.lon),
+      'result should be one of the MERIT records',
+    );
+  });
+
+  it('excludes matches beyond the tolerance', () => {
+    // Mid-Pacific query with a 5 nm tolerance: no MERIT record is that close.
+    expect(resolver.byIdentAtPosition('MERIT', 0, -160, 5)).toBeUndefined();
+  });
+
+  it('returns the match when it falls within the tolerance', () => {
+    const match = resolver.byIdent('MERIT')[0];
+    assert(match !== undefined, 'expected a MERIT fix');
+    const result = resolver.byIdentAtPosition('MERIT', match.lat, match.lon, 1);
+    assert(result !== undefined, 'expected a within-tolerance match');
+    expect(result.lat).toBe(match.lat);
+    expect(result.lon).toBe(match.lon);
+  });
+});
+
 describe('nearest', () => {
   it('finds fixes near a known position', () => {
     // Near JFK airport
@@ -175,6 +256,7 @@ describe('createFixResolver with empty dataset', () => {
   it('returns empty results for all lookups', () => {
     const empty = createFixResolver({ data: [] });
     expect(empty.byIdent('MERIT').length).toBe(0);
+    expect(empty.byIdentAtPosition('MERIT', 0, 0)).toBeUndefined();
     expect(empty.nearest({ lat: 0, lon: 0 }).length).toBe(0);
     expect(empty.search({ text: 'test' }).length).toBe(0);
   });

--- a/packages/libs/fixes/src/resolver.spec.ts
+++ b/packages/libs/fixes/src/resolver.spec.ts
@@ -85,10 +85,7 @@ describe('byIdentAtPosition', () => {
 
     const nearEast = local.byIdentAtPosition('DUPE', 40.5, -74.5);
     const nearWest = local.byIdentAtPosition('DUPE', 33.5, -117.5);
-    assert(
-      nearEast !== undefined && nearWest !== undefined,
-      'expected a match near each position',
-    );
+    assert(nearEast !== undefined && nearWest !== undefined, 'expected a match near each position');
     expect(nearEast.lat).toBe(east.lat);
     expect(nearEast.lon).toBe(east.lon);
     expect(nearWest.lat).toBe(west.lat);
@@ -100,10 +97,7 @@ describe('byIdentAtPosition', () => {
     assert(match !== undefined, 'expected a MERIT fix');
     const upper = resolver.byIdentAtPosition('MERIT', match.lat, match.lon);
     const lower = resolver.byIdentAtPosition('merit', match.lat, match.lon);
-    assert(
-      upper !== undefined && lower !== undefined,
-      'expected case-insensitive MERIT match',
-    );
+    assert(upper !== undefined && lower !== undefined, 'expected case-insensitive MERIT match');
     expect(lower.identifier).toBe('MERIT');
   });
 

--- a/packages/libs/fixes/src/resolver.ts
+++ b/packages/libs/fixes/src/resolver.ts
@@ -100,12 +100,7 @@ export interface FixResolver {
    * @param toleranceNm - Optional maximum great-circle distance in nautical miles. When omitted, the nearest match wins regardless of distance.
    * @returns The nearest matching fix, or `undefined` when none match or none fall within `toleranceNm`.
    */
-  byIdentAtPosition(
-    ident: string,
-    lat: number,
-    lon: number,
-    toleranceNm?: number,
-  ): Fix | undefined;
+  byIdentAtPosition(ident: string, lat: number, lon: number, toleranceNm?: number): Fix | undefined;
 
   /**
    * Finds fixes nearest to a geographic position, sorted by distance.

--- a/packages/libs/fixes/src/resolver.ts
+++ b/packages/libs/fixes/src/resolver.ts
@@ -82,6 +82,32 @@ export interface FixResolver {
   byIdent(ident: string): Fix[];
 
   /**
+   * Looks up the single fix sharing the given identifier that lies nearest
+   * to a geographic position. The same fix identifier can be published in
+   * more than one ICAO region; this disambiguates the collision by proximity
+   * to a known point such as a map-click location or an adjacent route
+   * waypoint.
+   *
+   * Returns the nearest matching fix by great-circle distance. When
+   * `toleranceNm` is provided, matches farther than that distance are
+   * excluded and the method returns `undefined` if none qualify. When
+   * `toleranceNm` is omitted, the nearest match is returned regardless of
+   * distance. Returns `undefined` when no fix carries the identifier.
+   *
+   * @param ident - Fix identifier (case-insensitive).
+   * @param lat - Latitude of the reference position in decimal degrees (WGS84).
+   * @param lon - Longitude of the reference position in decimal degrees (WGS84).
+   * @param toleranceNm - Optional maximum great-circle distance in nautical miles. When omitted, the nearest match wins regardless of distance.
+   * @returns The nearest matching fix, or `undefined` when none match or none fall within `toleranceNm`.
+   */
+  byIdentAtPosition(
+    ident: string,
+    lat: number,
+    lon: number,
+    toleranceNm?: number,
+  ): Fix | undefined;
+
+  /**
    * Finds fixes nearest to a geographic position, sorted by distance.
    * Results are filtered by max distance and limited to the requested count.
    */
@@ -148,6 +174,33 @@ export function createFixResolver(options: FixResolverOptions): FixResolver {
   return {
     byIdent(ident: string): Fix[] {
       return byIdentMap.get(ident.toUpperCase()) ?? [];
+    },
+
+    byIdentAtPosition(
+      ident: string,
+      lat: number,
+      lon: number,
+      toleranceNm?: number,
+    ): Fix | undefined {
+      const matches = byIdentMap.get(ident.toUpperCase());
+      if (matches === undefined || matches.length === 0) {
+        return undefined;
+      }
+
+      let nearest: Fix | undefined;
+      let nearestDistNm = Infinity;
+      for (const fix of matches) {
+        const distNm = greatCircle.distanceNm(lat, lon, fix.lat, fix.lon);
+        if (distNm < nearestDistNm) {
+          nearest = fix;
+          nearestDistNm = distNm;
+        }
+      }
+
+      if (toleranceNm !== undefined && nearestDistNm > toleranceNm) {
+        return undefined;
+      }
+      return nearest;
     },
 
     nearest(query: NearestFixQuery): NearestFixResult[] {

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -263,20 +263,22 @@ directly.
 
 ### Navaids (`@squawk/navaids` + `@squawk/navaid-data`)
 
-| Tool                        | Purpose                                         |
-| --------------------------- | ----------------------------------------------- |
-| `get_navaid_by_ident`       | Look up navaids by identifier                   |
-| `find_navaids_by_frequency` | Find navaids tuned to a given MHz/kHz frequency |
-| `find_nearest_navaids`      | Find navaids nearest a position                 |
-| `search_navaids`            | Fuzzy search by name or identifier              |
+| Tool                              | Purpose                                                  |
+| --------------------------------- | -------------------------------------------------------- |
+| `get_navaid_by_ident`             | Look up navaids by identifier                            |
+| `get_navaid_by_ident_at_position` | Look up the navaid sharing an identifier nearest a point |
+| `find_navaids_by_frequency`       | Find navaids tuned to a given MHz/kHz frequency          |
+| `find_nearest_navaids`            | Find navaids nearest a position                          |
+| `search_navaids`                  | Fuzzy search by name or identifier                       |
 
 ### Fixes (`@squawk/fixes` + `@squawk/fix-data`)
 
-| Tool                 | Purpose                       |
-| -------------------- | ----------------------------- |
-| `get_fix_by_ident`   | Look up fixes by identifier   |
-| `find_nearest_fixes` | Find fixes nearest a position |
-| `search_fixes`       | Fuzzy search by identifier    |
+| Tool                           | Purpose                                               |
+| ------------------------------ | ----------------------------------------------------- |
+| `get_fix_by_ident`             | Look up fixes by identifier                           |
+| `get_fix_by_ident_at_position` | Look up the fix sharing an identifier nearest a point |
+| `find_nearest_fixes`           | Find fixes nearest a position                         |
+| `search_fixes`                 | Fuzzy search by identifier                            |
 
 ### Airways (`@squawk/airways` + `@squawk/airway-data`)
 

--- a/packages/libs/mcp/src/server.spec.ts
+++ b/packages/libs/mcp/src/server.spec.ts
@@ -51,11 +51,13 @@ const EXPECTED_TOOLS: readonly string[] = [
   'search_airspace',
   // navaids
   'get_navaid_by_ident',
+  'get_navaid_by_ident_at_position',
   'find_navaids_by_frequency',
   'find_nearest_navaids',
   'search_navaids',
   // fixes
   'get_fix_by_ident',
+  'get_fix_by_ident_at_position',
   'find_nearest_fixes',
   'search_fixes',
   // airways

--- a/packages/libs/mcp/src/tools.spec.ts
+++ b/packages/libs/mcp/src/tools.spec.ts
@@ -997,6 +997,50 @@ describe('navaid tools', () => {
       await close();
     }
   });
+
+  it('get_navaid_by_ident_at_position returns the nearest matching navaid', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_navaid_by_ident_at_position',
+        arguments: { ident: 'ABI', lat: 32.481, lon: -99.863 },
+      });
+      const parsed = z
+        .object({ navaid: z.object({ identifier: z.string() }).passthrough() })
+        .parse(result.structuredContent);
+      expect(parsed.navaid.identifier).toBe('ABI');
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_navaid_by_ident_at_position returns null for an unknown identifier', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_navaid_by_ident_at_position',
+        arguments: { ident: 'ZZZZZ', lat: 0, lon: 0 },
+      });
+      const parsed = z.object({ navaid: z.null() }).parse(result.structuredContent);
+      expect(parsed.navaid).toBe(null);
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_navaid_by_ident_at_position excludes matches beyond toleranceNm', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_navaid_by_ident_at_position',
+        arguments: { ident: 'ABI', lat: 0, lon: -160, toleranceNm: 5 },
+      });
+      const parsed = z.object({ navaid: z.null() }).parse(result.structuredContent);
+      expect(parsed.navaid).toBe(null);
+    } finally {
+      await close();
+    }
+  });
 });
 
 describe('fix tools', () => {
@@ -1087,6 +1131,50 @@ describe('fix tools', () => {
       });
       const parsed = z.object({ fixes: z.array(z.unknown()) }).parse(result.structuredContent);
       assert(Array.isArray(parsed.fixes));
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_fix_by_ident_at_position returns the nearest matching fix', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_fix_by_ident_at_position',
+        arguments: { ident: 'MERIT', lat: 41, lon: -73 },
+      });
+      const parsed = z
+        .object({ fix: z.object({ identifier: z.string() }).passthrough() })
+        .parse(result.structuredContent);
+      expect(parsed.fix.identifier).toBe('MERIT');
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_fix_by_ident_at_position returns null for an unknown identifier', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_fix_by_ident_at_position',
+        arguments: { ident: 'ZZZZZZZZZ', lat: 0, lon: 0 },
+      });
+      const parsed = z.object({ fix: z.null() }).parse(result.structuredContent);
+      expect(parsed.fix).toBe(null);
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_fix_by_ident_at_position excludes matches beyond toleranceNm', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_fix_by_ident_at_position',
+        arguments: { ident: 'MERIT', lat: 0, lon: -160, toleranceNm: 5 },
+      });
+      const parsed = z.object({ fix: z.null() }).parse(result.structuredContent);
+      expect(parsed.fix).toBe(null);
     } finally {
       await close();
     }

--- a/packages/libs/mcp/src/tools/fixes.ts
+++ b/packages/libs/mcp/src/tools/fixes.ts
@@ -51,6 +51,42 @@ export function registerFixTools(server: McpServer): void {
   );
 
   server.registerTool(
+    'get_fix_by_ident_at_position',
+    {
+      title: 'Get fix by identifier nearest a position',
+      description:
+        'Looks up the single US fix/waypoint sharing the given identifier that lies nearest to a geographic position. The same fix identifier can be published in more than one ICAO region; this disambiguates the collision by proximity to a known point such as a map-click location or an adjacent route waypoint. When toleranceNm is provided, matches farther than that distance are excluded and the result is null; when omitted, the nearest match wins regardless of distance. Returns null when no fix carries the identifier.',
+      inputSchema: {
+        ident: z.string().min(1).describe('Fix identifier (case-insensitive).'),
+        lat: z
+          .number()
+          .min(-90)
+          .max(90)
+          .describe('Latitude of the reference position in decimal degrees (WGS84).'),
+        lon: z
+          .number()
+          .min(-180)
+          .max(180)
+          .describe('Longitude of the reference position in decimal degrees (WGS84).'),
+        toleranceNm: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            'Maximum great-circle distance in nautical miles. Omit to let the nearest match win regardless of distance.',
+          ),
+      },
+    },
+    ({ ident, lat, lon, toleranceNm }) => {
+      const fix = fixResolver.byIdentAtPosition(ident, lat, lon, toleranceNm) ?? null;
+      return {
+        content: [{ type: 'text', text: JSON.stringify(fix, null, 2) }],
+        structuredContent: { fix },
+      };
+    },
+  );
+
+  server.registerTool(
     'find_nearest_fixes',
     {
       title: 'Find nearest fixes',

--- a/packages/libs/mcp/src/tools/navaids.ts
+++ b/packages/libs/mcp/src/tools/navaids.ts
@@ -53,6 +53,42 @@ export function registerNavaidTools(server: McpServer): void {
   );
 
   server.registerTool(
+    'get_navaid_by_ident_at_position',
+    {
+      title: 'Get navaid by identifier nearest a position',
+      description:
+        'Looks up the single US navaid sharing the given identifier that lies nearest to a geographic position. Multiple navaids can publish the same identifier (a co-located NDB and VOR/DME, or two distant stations reusing a code); this disambiguates them by proximity to a known point such as a map-click location or an adjacent route waypoint. When toleranceNm is provided, matches farther than that distance are excluded and the result is null; when omitted, the nearest match wins regardless of distance. Returns null when no navaid carries the identifier.',
+      inputSchema: {
+        ident: z.string().min(1).describe('Navaid identifier (case-insensitive).'),
+        lat: z
+          .number()
+          .min(-90)
+          .max(90)
+          .describe('Latitude of the reference position in decimal degrees (WGS84).'),
+        lon: z
+          .number()
+          .min(-180)
+          .max(180)
+          .describe('Longitude of the reference position in decimal degrees (WGS84).'),
+        toleranceNm: z
+          .number()
+          .positive()
+          .optional()
+          .describe(
+            'Maximum great-circle distance in nautical miles. Omit to let the nearest match win regardless of distance.',
+          ),
+      },
+    },
+    ({ ident, lat, lon, toleranceNm }) => {
+      const navaid = navaidResolver.byIdentAtPosition(ident, lat, lon, toleranceNm) ?? null;
+      return {
+        content: [{ type: 'text', text: JSON.stringify(navaid, null, 2) }],
+        structuredContent: { navaid },
+      };
+    },
+  );
+
+  server.registerTool(
     'find_navaids_by_frequency',
     {
       title: 'Find navaids by frequency',

--- a/packages/libs/navaids/README.md
+++ b/packages/libs/navaids/README.md
@@ -77,6 +77,29 @@ Looks up navaids by identifier (e.g. "BOS", "JFK"). Multiple navaids can share
 the same identifier (e.g. an NDB and a VOR at different locations).
 Case-insensitive. Returns `Navaid[]`.
 
+### `resolver.byIdentAtPosition(ident, lat, lon, toleranceNm?)`
+
+Looks up the single navaid sharing the given identifier that lies nearest to a
+geographic position. Multiple navaids can publish the same identifier (a
+co-located NDB and VOR/DME, or two distant stations reusing a code); this
+disambiguates them by proximity to a known point such as a map-click location or
+an adjacent route waypoint.
+
+| Parameter     | Type   | Description                                                                                             |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| `ident`       | string | Navaid identifier (case-insensitive)                                                                    |
+| `lat`         | number | Latitude of the reference position in decimal degrees (WGS84)                                           |
+| `lon`         | number | Longitude of the reference position in decimal degrees (WGS84)                                          |
+| `toleranceNm` | number | Optional. Maximum great-circle distance in nautical miles. Omit to let the nearest match win regardless |
+
+Returns the nearest matching `Navaid` by great-circle distance, or `undefined`
+when no navaid carries the identifier or none fall within `toleranceNm`.
+
+```typescript
+// Disambiguate a shared identifier against a map-click position
+const navaid = resolver.byIdentAtPosition('AA', 47.45, -122.31);
+```
+
 ### `resolver.byFrequency(query)`
 
 Finds navaids operating on a given frequency. For VOR-family navaids the

--- a/packages/libs/navaids/api/navaids.api.md
+++ b/packages/libs/navaids/api/navaids.api.md
@@ -24,6 +24,7 @@ export interface NavaidFrequencyQuery {
 export interface NavaidResolver {
     byFrequency(query: NavaidFrequencyQuery): Navaid[];
     byIdent(ident: string): Navaid[];
+    byIdentAtPosition(ident: string, lat: number, lon: number, toleranceNm?: number): Navaid | undefined;
     byType(types: ReadonlySet<NavaidType>): Navaid[];
     nearest(query: NearestNavaidQuery): NearestNavaidResult[];
     search(query: NavaidSearchQuery): NavaidSearchResult[];

--- a/packages/libs/navaids/src/resolver.spec.ts
+++ b/packages/libs/navaids/src/resolver.spec.ts
@@ -47,6 +47,66 @@ describe('byIdent', () => {
   });
 });
 
+describe('byIdentAtPosition', () => {
+  it('returns the match nearest to the query position when an identifier is shared', () => {
+    const matches = resolver.byIdent('AA');
+    assert(matches.length >= 2, 'expected multiple AA navaids');
+    const [first, second] = matches;
+    assert(first !== undefined && second !== undefined, 'expected two AA records');
+    assert(
+      first.lat !== second.lat || first.lon !== second.lon,
+      'expected the AA records to sit at distinct positions',
+    );
+
+    const nearFirst = resolver.byIdentAtPosition('AA', first.lat, first.lon);
+    const nearSecond = resolver.byIdentAtPosition('AA', second.lat, second.lon);
+    assert(
+      nearFirst !== undefined && nearSecond !== undefined,
+      'expected a match at each record position',
+    );
+    expect(nearFirst.lat).toBe(first.lat);
+    expect(nearFirst.lon).toBe(first.lon);
+    expect(nearSecond.lat).toBe(second.lat);
+    expect(nearSecond.lon).toBe(second.lon);
+  });
+
+  it('is case-insensitive', () => {
+    const upper = resolver.byIdentAtPosition('ABI', 32.481, -99.863);
+    assert(upper !== undefined, 'expected ABI match');
+    const lower = resolver.byIdentAtPosition('abi', 32.481, -99.863);
+    assert(lower !== undefined, 'expected case-insensitive ABI match');
+    expect(lower.identifier).toBe('ABI');
+  });
+
+  it('returns undefined for an unknown identifier', () => {
+    expect(resolver.byIdentAtPosition('ZZZZZ', 32.481, -99.863)).toBeUndefined();
+  });
+
+  it('returns the nearest match regardless of distance when no tolerance is given', () => {
+    // Query from the mid-Pacific; the nearest AA record still wins.
+    const result = resolver.byIdentAtPosition('AA', 0, -160);
+    assert(result !== undefined, 'expected a match with no tolerance');
+    assert(
+      resolver.byIdent('AA').some((n) => n.lat === result.lat && n.lon === result.lon),
+      'result should be one of the AA records',
+    );
+  });
+
+  it('excludes matches beyond the tolerance', () => {
+    // Mid-Pacific query with a 5 nm tolerance: no AA record is that close.
+    expect(resolver.byIdentAtPosition('AA', 0, -160, 5)).toBeUndefined();
+  });
+
+  it('returns the match when it falls within the tolerance', () => {
+    const first = resolver.byIdent('AA')[0];
+    assert(first !== undefined, 'expected an AA record');
+    const result = resolver.byIdentAtPosition('AA', first.lat, first.lon, 1);
+    assert(result !== undefined, 'expected a within-tolerance match');
+    expect(result.lat).toBe(first.lat);
+    expect(result.lon).toBe(first.lon);
+  });
+});
+
 describe('byFrequency', () => {
   it('finds VOR-type navaids by MHz frequency', () => {
     const results = resolver.byFrequency({ frequency: 113.7 });
@@ -269,6 +329,7 @@ describe('createNavaidResolver with empty dataset', () => {
   it('returns empty results for all lookups', () => {
     const empty = createNavaidResolver({ data: [] });
     expect(empty.byIdent('BOS').length).toBe(0);
+    expect(empty.byIdentAtPosition('BOS', 0, 0)).toBeUndefined();
     expect(empty.byFrequency({ frequency: 113.7 }).length).toBe(0);
     expect(empty.nearest({ lat: 0, lon: 0 }).length).toBe(0);
     expect(empty.byType(new Set<NavaidType>(['VOR'])).length).toBe(0);

--- a/packages/libs/navaids/src/resolver.ts
+++ b/packages/libs/navaids/src/resolver.ts
@@ -94,6 +94,32 @@ export interface NavaidResolver {
   byIdent(ident: string): Navaid[];
 
   /**
+   * Looks up the single navaid sharing the given identifier that lies
+   * nearest to a geographic position. Multiple navaids can publish the
+   * same identifier (a co-located NDB and VOR/DME, or two stations far
+   * apart that reuse a code); this disambiguates them by proximity to a
+   * known point such as a map-click location or an adjacent route waypoint.
+   *
+   * Returns the nearest matching navaid by great-circle distance. When
+   * `toleranceNm` is provided, matches farther than that distance are
+   * excluded and the method returns `undefined` if none qualify. When
+   * `toleranceNm` is omitted, the nearest match is returned regardless of
+   * distance. Returns `undefined` when no navaid carries the identifier.
+   *
+   * @param ident - Navaid identifier (case-insensitive).
+   * @param lat - Latitude of the reference position in decimal degrees (WGS84).
+   * @param lon - Longitude of the reference position in decimal degrees (WGS84).
+   * @param toleranceNm - Optional maximum great-circle distance in nautical miles. When omitted, the nearest match wins regardless of distance.
+   * @returns The nearest matching navaid, or `undefined` when none match or none fall within `toleranceNm`.
+   */
+  byIdentAtPosition(
+    ident: string,
+    lat: number,
+    lon: number,
+    toleranceNm?: number,
+  ): Navaid | undefined;
+
+  /**
    * Finds navaids operating on a given frequency.
    * For VOR-family navaids, frequency is in MHz. For NDB-family, frequency is in kHz.
    * Results are sorted alphabetically by identifier.
@@ -184,6 +210,33 @@ export function createNavaidResolver(options: NavaidResolverOptions): NavaidReso
   return {
     byIdent(ident: string): Navaid[] {
       return byIdentMap.get(ident.toUpperCase()) ?? [];
+    },
+
+    byIdentAtPosition(
+      ident: string,
+      lat: number,
+      lon: number,
+      toleranceNm?: number,
+    ): Navaid | undefined {
+      const matches = byIdentMap.get(ident.toUpperCase());
+      if (matches === undefined || matches.length === 0) {
+        return undefined;
+      }
+
+      let nearest: Navaid | undefined;
+      let nearestDistNm = Infinity;
+      for (const navaid of matches) {
+        const distNm = greatCircle.distanceNm(lat, lon, navaid.lat, navaid.lon);
+        if (distNm < nearestDistNm) {
+          nearest = navaid;
+          nearestDistNm = distNm;
+        }
+      }
+
+      if (toleranceNm !== undefined && nearestDistNm > toleranceNm) {
+        return undefined;
+      }
+      return nearest;
     },
 
     byFrequency(query: NavaidFrequencyQuery): Navaid[] {


### PR DESCRIPTION
## Summary

- Add `byIdentAtPosition(ident, lat, lon, toleranceNm?)` to the navaid and fix resolvers, returning the single record sharing an identifier that lies nearest a reference position. The same identifier can be published by multiple stations (co-located NDB/VOR) or reused across ICAO regions; this disambiguates by proximity to a known point such as a map click or an adjacent route waypoint. Optional `toleranceNm` bounds the match; omit it to take the nearest regardless of distance.
- Expose both through MCP as `get_navaid_by_ident_at_position` and `get_fix_by_ident_at_position`.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added `byIdentAtPosition` specs to `navaids/src/resolver.spec.ts` and `fixes/src/resolver.spec.ts`, plus MCP tool coverage in `mcp/src/tools.spec.ts` and a tool-presence assertion in `mcp/src/server.spec.ts`.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - Minor bump for `@squawk/navaids`, `@squawk/fixes`, and `@squawk/mcp`.