### PR TITLE
Add browser export and document fetch CORS path for @squawk/weather

### DIFF
--- a/.changeset/weather-browser-entry.md
+++ b/.changeset/weather-browser-entry.md
@@ -1,0 +1,8 @@
+---
+'@squawk/weather': minor
+---
+
+### Added
+
+- `@squawk/weather` adds a `/browser` export subpath that aliases the main entry, giving SPAs and edge runtimes an explicit, `publint`-verified browser entry point for the parsers. The separate subpath means a future Node-only import added to the main entry would fail the packaging check rather than silently break browser consumers.
+- Clarifies browser use of the opt-in `/fetch` layer: the AWC API sends no CORS headers, so the `baseUrl` option is the supported way to route browser requests through a same-origin proxy.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -90,7 +90,9 @@ Why: keeping `@squawk/types` focused on genuinely shared models avoids forcing a
 
 ### Browser entries on data and logic packages
 
-Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume the bundled snapshots. Pure-logic query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`) also expose a `/browser` subpath that aliases the main entry, since their resolver code has no Node-specific imports. The `/browser` import is the explicit, supported way for SPAs to consume these packages; the contract is enforced by `lint:pack` (publint) so a future Node-only import would have to split the surface explicitly rather than silently breaking browsers.
+Data packages ship a `/browser` subpath with async `loadUsBundled<X>()` loaders so SPAs and edge runtimes can consume the bundled snapshots. Pure-logic query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`) and the `@squawk/weather` parser library also expose a `/browser` subpath that aliases the main entry, since their core code has no Node-specific imports. The `/browser` import is the explicit, supported way for SPAs to consume these packages; the contract is enforced by `lint:pack` (publint) so a future Node-only import would have to split the surface explicitly rather than silently breaking browsers.
+
+`@squawk/weather` additionally ships an opt-in `/fetch` subpath that calls the AWC text API over the global `fetch`. It runs in the browser, but AWC sends no CORS headers, so browser consumers point the `baseUrl` option at a same-origin proxy they control. The main `@squawk/weather` and `/browser` entries stay pure parsers with no network calls.
 
 `@squawk/icao-registry` is a hybrid: the main entry exposes a runtime `parseFaaRegistryZip` parser that depends on Node's `Buffer` and the `adm-zip` package, so the `/browser` entry is a strict subset that re-exports only `createIcaoRegistry` and the shared types.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -105,11 +105,11 @@ Each data package's metadata includes at least `generatedAt` (ISO timestamp), `r
 
 ## Logic package browser entries
 
-Query libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/icao-registry`) ship a `/browser` exports subpath alongside the default entry. For pure-logic packages with no Node-specific imports, the `/browser` subpath aliases the same compiled `dist/index.js`; the separate entry exists so browser support is an explicit, `publint`-verified part of the public API surface and a future Node-only import has to split the surface intentionally.
+Query and parser libraries (`@squawk/airports`, `@squawk/airspace`, `@squawk/airways`, `@squawk/fixes`, `@squawk/flightplan`, `@squawk/navaids`, `@squawk/procedures`, `@squawk/weather`, `@squawk/icao-registry`) ship a `/browser` exports subpath alongside the default entry. For pure-logic packages with no Node-specific imports, the `/browser` subpath aliases the same compiled `dist/index.js`; the separate entry exists so browser support is an explicit, `publint`-verified part of the public API surface and a future Node-only import has to split the surface intentionally.
 
 Packages that mix pure-logic with a Node-only helper (e.g. `@squawk/icao-registry`'s `parseFaaRegistryZip`) instead expose a thin `src/browser.ts` re-exporting only the browser-safe symbols, with the `/browser` subpath pointing at its compiled output. The Node-only helper stays exported from the default entry.
 
-When adding a new query library, mirror this pattern: add a `./browser` entry to `package.json` `exports`, and create `src/browser.ts` only if the main entry transitively reaches Node-only code.
+When adding a new query or parser library, mirror this pattern: add a `./browser` entry to `package.json` `exports`, and create `src/browser.ts` only if the main entry transitively reaches Node-only code.
 
 ---
 

--- a/packages/libs/weather/README.md
+++ b/packages/libs/weather/README.md
@@ -10,8 +10,10 @@ API, AVWX, local feed, file dump) and the package returns structured results.
 
 An opt-in fetch layer is available at `@squawk/weather/fetch` for consumers
 who want to pull live data directly from the Aviation Weather Center (AWC)
-text API. It uses the Node 22+ global `fetch`; pulling it in is a choice so
-the core parsing import graph stays network-free.
+text API. It uses the platform global `fetch` (Node 22+ or any modern
+browser); pulling it in is a choice so the core parsing import graph stays
+network-free. See [Browser / SPA usage](#browser--spa-usage) for the CORS
+caveat that applies when calling AWC from a browser.
 
 Part of the [@squawk](https://www.npmjs.com/org/squawk) aviation library suite. See all packages on npm.
 
@@ -314,6 +316,38 @@ try {
   }
 }
 ```
+
+## Browser / SPA usage
+
+The core parsers have no Node-specific imports and ship an explicit `/browser`
+subpath for SPAs and edge runtimes:
+
+```typescript
+import { parseMetar, parseTaf } from '@squawk/weather/browser';
+```
+
+The `/browser` entry is identical to the main entry; the separate subpath
+exists so browser support is an explicit, `publint`-verified part of the public
+API surface. A `node:`-dependent import added to the main entry later would
+fail that check rather than silently break browser consumers.
+
+The `/fetch` layer also runs in the browser, since it uses the global `fetch`,
+but the AWC API does not send CORS headers. A direct cross-origin request to
+`aviationweather.gov` from page JavaScript is therefore blocked by the user
+agent. To use the `fetch*` helpers in a browser, point `baseUrl` at a
+same-origin proxy you control - a reverse proxy or an edge function that
+forwards to AWC and returns the upstream body:
+
+```typescript
+import { fetchMetar } from '@squawk/weather/fetch';
+
+// Your own origin serves '/awc' and proxies it through to aviationweather.gov.
+const baseUrl = new URL('/awc', window.location.origin).toString();
+const { metars } = await fetchMetar('KJFK', { baseUrl });
+```
+
+`baseUrl` must be an absolute URL. The package does not ship a proxy; standing
+one up is a deployment concern left to the consumer.
 
 ## Types
 

--- a/packages/libs/weather/package.json
+++ b/packages/libs/weather/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./fetch": {
       "types": "./dist/fetch/index.d.ts",
       "import": "./dist/fetch/index.js"

--- a/packages/libs/weather/src/fetch/client.ts
+++ b/packages/libs/weather/src/fetch/client.ts
@@ -14,7 +14,13 @@ export interface FetchWeatherOptions {
   signal?: AbortSignal;
   /**
    * Override the AWC base URL. Defaults to {@link DEFAULT_AWC_BASE_URL}.
-   * Useful for pointing at a mirror or a proxy during development.
+   *
+   * This is the supported seam for browser use. The AWC API does not send
+   * CORS headers, so a direct cross-origin `fetch` from a browser is blocked
+   * by the user agent. Point `baseUrl` at a same-origin proxy you control (a
+   * reverse proxy or an edge function that forwards to AWC and returns the
+   * upstream body) and the `fetch*` functions work unchanged from the browser.
+   * It is equally useful for pointing at a mirror during development.
    */
   baseUrl?: string;
 }


### PR DESCRIPTION
## Summary

- Add a `./browser` export to `@squawk/weather` that aliases the main entry, giving SPAs and edge runtimes an explicit, publint-verified browser entry point so a future Node-only import cannot silently break browser consumers.
- Document browser use of the opt-in `/fetch` layer: AWC sends no CORS headers, so the `baseUrl` option is the supported seam for routing requests through a same-origin proxy. README, ARCHITECTURE.md, and CONVENTIONS.md updated to match.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - N/A; adds a `./browser` export alias and documentation only, with no runtime logic to test. The existing weather suite (691 tests) still passes.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `@squawk/weather` minor for the new `./browser` export.