### PR TITLE
Add drawable procedure geometry and a get_procedure_geometry MCP tool

### DIFF
--- a/.changeset/procedure-geometry.md
+++ b/.changeset/procedure-geometry.md
@@ -1,0 +1,11 @@
+---
+'@squawk/procedures': minor
+'@squawk/mcp': minor
+---
+
+### Added
+
+- `@squawk/procedures` exposes an expanded procedure's drawable geometry:
+  - `expansionToLineString(legs)` builds a GeoJSON `LineString` (GeoJSON `[lon, lat]` ordering) ready to render as a map polyline, or `undefined` when the leg sequence yields fewer than two drawable points.
+  - `extractLegPoints(legs)` returns the ordered `ProcedureLegPoint[]` of drawable fix points (each with `label`, `lat`, `lon`), skipping non-positional legs (course/heading-to-altitude, DME, radial, intercept, manual, and the HA/HM holds) and suppressing consecutive duplicate points.
+- `@squawk/mcp` adds a `get_procedure_geometry` tool returning the ordered drawable fix points and GeoJSON `LineString` for an expanded procedure (optionally merging a named transition).

--- a/package-lock.json
+++ b/package-lock.json
@@ -14120,7 +14120,8 @@
       "license": "MIT",
       "dependencies": {
         "@squawk/search": "^0.1.0",
-        "@squawk/types": "^0.8.0"
+        "@squawk/types": "^0.8.0",
+        "@types/geojson": "^7946.0.16"
       },
       "devDependencies": {
         "@squawk/procedure-data": "^0.7.2",

--- a/packages/libs/mcp/README.md
+++ b/packages/libs/mcp/README.md
@@ -301,6 +301,7 @@ Covers SIDs, STARs, and Instrument Approach Procedures (IAPs) from FAA CIFP.
 | `find_procedures_by_airport_and_runway`   | Procedures at an airport serving a specific runway (IAP runway match or RW\* transition)    |
 | `find_approaches_by_type`                 | Every IAP of a given approach classification (ILS, RNAV, VOR, etc.)                         |
 | `expand_procedure`                        | Expand a procedure into its leg sequence (with optional transition merge)                   |
+| `get_procedure_geometry`                  | Ordered drawable fix points and a GeoJSON LineString for a procedure                        |
 | `search_procedures`                       | Fuzzy search by name or identifier, optionally filtered by procedure or approach type       |
 
 ### ICAO aircraft registry (`@squawk/icao-registry` + `@squawk/icao-registry-data`)

--- a/packages/libs/mcp/src/tools.spec.ts
+++ b/packages/libs/mcp/src/tools.spec.ts
@@ -1345,6 +1345,55 @@ describe('procedure tools', () => {
       await close();
     }
   });
+
+  it('get_procedure_geometry returns ordered points and a LineString', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_procedure_geometry',
+        arguments: { airportId: 'KJFK', identifier: 'I13L', transitionName: 'BUZON' },
+      });
+      const parsed = z
+        .object({
+          points: z.array(
+            z.object({ label: z.string(), lat: z.number(), lon: z.number() }).passthrough(),
+          ),
+          lineString: z
+            .object({
+              type: z.literal('LineString'),
+              coordinates: z.array(z.array(z.number())),
+            })
+            .nullable()
+            .optional(),
+        })
+        .parse(result.structuredContent);
+      assert(parsed.points.length >= 2);
+      assert(parsed.lineString !== undefined && parsed.lineString !== null);
+      expect(parsed.lineString.coordinates.length).toBe(parsed.points.length);
+    } finally {
+      await close();
+    }
+  });
+
+  it('get_procedure_geometry returns nulls for an unknown procedure', async () => {
+    const { client, close } = await connectTestClient();
+    try {
+      const result = await client.callTool({
+        name: 'get_procedure_geometry',
+        arguments: { airportId: 'KDEN', identifier: 'I04L' },
+      });
+      const parsed = z
+        .object({
+          points: z.null(),
+          lineString: z.null(),
+        })
+        .parse(result.structuredContent);
+      expect(parsed.points).toBeNull();
+      expect(parsed.lineString).toBeNull();
+    } finally {
+      await close();
+    }
+  });
 });
 
 describe('icao registry tools', () => {

--- a/packages/libs/mcp/src/tools/procedures.ts
+++ b/packages/libs/mcp/src/tools/procedures.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
+import { expansionToLineString, extractLegPoints } from '@squawk/procedures';
 import type { ProcedureSearchQuery } from '@squawk/procedures';
 import type { ApproachType, ProcedureType } from '@squawk/types';
 
@@ -171,7 +172,7 @@ export function registerProcedureTools(server: McpServer): void {
     {
       title: 'Expand a procedure into an ordered leg sequence',
       description:
-        "Expands a procedure at an airport into an ordered leg sequence. Without a transition name, returns the procedure's common route. With a transition name, merges the named transition's legs with the common route in flying order (SID: common then transition for enroute exits, transition then common for runway transitions; STAR: transition then common for enroute entries; IAP: approach transition then final approach segment). Returns null when the airport, procedure, or transition is not found.",
+        "Expands a procedure at an airport into an ordered leg sequence. Without a transition name, returns the procedure's common route. With a transition name, merges the named transition's legs with the common route in flying order (SID: common then transition for enroute exits, transition then common for runway transitions; STAR: transition then common for enroute entries; IAP: approach transition then final approach segment). Returns null when the airport, procedure, or transition is not found. To get just the drawable point sequence or a GeoJSON LineString for map rendering, use get_procedure_geometry instead.",
       inputSchema: {
         airportId: z.string().min(1).describe('Airport identifier (case-insensitive).'),
         identifier: z.string().min(1).describe('CIFP procedure identifier (case-insensitive).'),
@@ -198,6 +199,48 @@ export function registerProcedureTools(server: McpServer): void {
       return {
         content: [{ type: 'text', text: JSON.stringify(expansion, null, 2) }],
         structuredContent: { expansion },
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_procedure_geometry',
+    {
+      title: 'Get drawable procedure geometry',
+      description:
+        'Expands a procedure at an airport (optionally merging a named transition, exactly like expand_procedure) and returns its drawable geometry: the ordered sequence of fix points (each with a label and latitude/longitude in decimal degrees) and a GeoJSON LineString ready to render as a polyline on a map. Only legs that terminate at a known fix contribute a point; ARINC 424 legs that end at an altitude, DME distance, radial, intercept, or manual event (CA, FA, VA, CD, FD, VD, CR, VR, CI, VI, FM, VM, and the HA/HM holds) carry no coordinate and are skipped, so the line breaks across them and is an approximation rather than a precise flyable track. Consecutive duplicate points are suppressed. LineString coordinates follow the GeoJSON [lon, lat] ordering. The lineString field is omitted when fewer than two fix points are drawable. Returns null when the airport, procedure, or transition is not found. Use expand_procedure instead when you need the full leg fields (constraints, courses, path terminators) rather than just geometry.',
+      inputSchema: {
+        airportId: z
+          .string()
+          .min(1)
+          .describe('Airport identifier (ICAO or FAA, case-insensitive).'),
+        identifier: z.string().min(1).describe('CIFP procedure identifier (case-insensitive).'),
+        transitionName: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Optional transition name. Omit to use just the common route.'),
+      },
+    },
+    ({ airportId, identifier, transitionName }) => {
+      const expansion = procedureResolver.expand(airportId, identifier, transitionName);
+      if (expansion === undefined) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Could not expand procedure "${identifier}" at "${airportId}"${transitionName ? ` with transition "${transitionName}"` : ''}.`,
+            },
+          ],
+          structuredContent: { points: null, lineString: null },
+        };
+      }
+      const points = extractLegPoints(expansion.legs);
+      const lineString = expansionToLineString(expansion.legs);
+      const result = { points, lineString };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        structuredContent: result,
       };
     },
   );

--- a/packages/libs/procedures/README.md
+++ b/packages/libs/procedures/README.md
@@ -16,7 +16,11 @@ Part of the [@squawk](https://www.npmjs.com/org/squawk) aviation library suite. 
 
 ```typescript
 import { usBundledProcedures } from '@squawk/procedure-data';
-import { createProcedureResolver } from '@squawk/procedures';
+import {
+  createProcedureResolver,
+  expansionToLineString,
+  extractLegPoints,
+} from '@squawk/procedures';
 
 const resolver = createProcedureResolver({ data: usBundledProcedures.records });
 
@@ -51,6 +55,13 @@ const withTransition = resolver.expand('KDEN', 'AALLE4', 'BBOTL');
 // Fuzzy-search by identifier or name (scored, best match first)
 const results = resolver.search({ text: 'AALLE', type: 'STAR' });
 console.log(results[0]?.procedure.identifier, results[0]?.score);
+
+// Turn an expansion into renderable map geometry (non-positional legs are skipped)
+if (withTransition) {
+  const points = extractLegPoints(withTransition.legs);
+  const line = expansionToLineString(withTransition.legs);
+  // `line` is a GeoJSON LineString, or undefined when fewer than two fixes are drawable
+}
 ```
 
 Consumers who have their own procedure data can use this package standalone:
@@ -170,3 +181,24 @@ for (const { procedure, score, matchedField } of results) {
   console.log(procedure.identifier, score, `(matched ${matchedField})`);
 }
 ```
+
+### `extractLegPoints(legs)`
+
+Extracts the ordered drawable points from an expanded leg sequence (the `legs`
+array of a `ProcedureExpansionResult`). Only legs that terminate at a known fix
+contribute a point; legs whose ARINC 424 path terminator ends at an altitude,
+DME distance, radial, intercept, or manual event (`CA`, `FA`, `VA`, `CD`, `FD`,
+`VD`, `CR`, `VR`, `CI`, `VI`, `FM`, `VM`, and the `HA`/`HM` holds) carry no
+coordinate and are skipped, so a non-positional leg in the middle of a sequence
+leaves a gap. Consecutive duplicate points are suppressed. Returns
+`ProcedureLegPoint[]`, each with `label`, `lat`, and `lon`.
+
+### `expansionToLineString(legs)`
+
+Builds a GeoJSON `LineString` from an expanded leg sequence, ready to render as a
+polyline on a map (for example MapLibre or Leaflet). Coordinates follow the
+GeoJSON `[lon, lat]` ordering. Because non-positional legs are skipped (see
+`extractLegPoints`), the line connects only the fix-terminated legs and is an
+approximation that omits the non-drawable segments rather than a precise flyable
+track. Returns `LineString | undefined` - `undefined` when the legs yield fewer
+than two drawable points, since a `LineString` requires at least two positions.

--- a/packages/libs/procedures/api/procedures.api.md
+++ b/packages/libs/procedures/api/procedures.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ApproachType } from '@squawk/types';
+import type { LineString } from 'geojson';
 import { MatchRange } from '@squawk/search';
 import type { Procedure } from '@squawk/types';
 import type { ProcedureLeg } from '@squawk/types';
@@ -15,12 +16,25 @@ import type { ProcedureType } from '@squawk/types';
 // @public
 export function createProcedureResolver(options: ProcedureResolverOptions): ProcedureResolver;
 
+// @public
+export function expansionToLineString(legs: ProcedureLeg[]): LineString | undefined;
+
+// @public
+export function extractLegPoints(legs: ProcedureLeg[]): ProcedureLegPoint[];
+
 export { MatchRange }
 
 // @public
 export interface ProcedureExpansionResult {
     legs: ProcedureLeg[];
     procedure: Procedure;
+}
+
+// @public
+export interface ProcedureLegPoint {
+    label: string;
+    lat: number;
+    lon: number;
 }
 
 // @public

--- a/packages/libs/procedures/package.json
+++ b/packages/libs/procedures/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@squawk/search": "^0.1.0",
-    "@squawk/types": "^0.8.0"
+    "@squawk/types": "^0.8.0",
+    "@types/geojson": "^7946.0.16"
   },
   "devDependencies": {
     "@squawk/procedure-data": "^0.7.2",

--- a/packages/libs/procedures/src/index.ts
+++ b/packages/libs/procedures/src/index.ts
@@ -13,3 +13,5 @@ export type {
   ProcedureSearchQuery,
   ProcedureSearchResult,
 } from './resolver.js';
+export { extractLegPoints, expansionToLineString } from './leg-geometry.js';
+export type { ProcedureLegPoint } from './leg-geometry.js';

--- a/packages/libs/procedures/src/leg-geometry.spec.ts
+++ b/packages/libs/procedures/src/leg-geometry.spec.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+
+import { describe, it } from 'vitest';
+
+import type { ProcedureLeg, ProcedureLegPathTerminator } from '@squawk/types';
+
+import { expansionToLineString, extractLegPoints } from './leg-geometry.js';
+
+/** Builds a fix-terminated leg at a coordinate. */
+function fixLeg(
+  fixIdentifier: string,
+  lat: number,
+  lon: number,
+  pathTerminator: ProcedureLegPathTerminator = 'TF',
+): ProcedureLeg {
+  return { pathTerminator, fixIdentifier, lat, lon };
+}
+
+/** Builds a non-positional leg (terminates at an altitude, intercept, etc.). */
+function nonPositionalLeg(pathTerminator: ProcedureLegPathTerminator): ProcedureLeg {
+  return { pathTerminator };
+}
+
+// ---------------------------------------------------------------------------
+// extractLegPoints
+// ---------------------------------------------------------------------------
+
+describe('extractLegPoints', () => {
+  it('returns an empty array for an empty leg sequence', () => {
+    assert.deepEqual(extractLegPoints([]), []);
+  });
+
+  it('returns label/lat/lon for fix-terminated legs in order', () => {
+    const points = extractLegPoints([
+      fixLeg('ALPHA', 40.0, -74.0, 'IF'),
+      fixLeg('BRAVO', 40.5, -74.0),
+      fixLeg('CHRLI', 41.0, -74.0),
+    ]);
+
+    assert.deepEqual(points, [
+      { label: 'ALPHA', lat: 40.0, lon: -74.0 },
+      { label: 'BRAVO', lat: 40.5, lon: -74.0 },
+      { label: 'CHRLI', lat: 41.0, lon: -74.0 },
+    ]);
+  });
+
+  it('skips non-positional legs that lack a fix coordinate', () => {
+    const points = extractLegPoints([
+      fixLeg('RW34', 40.0, -74.0, 'IF'),
+      nonPositionalLeg('CA'),
+      nonPositionalLeg('VA'),
+      fixLeg('TOPPP', 40.5, -74.0, 'DF'),
+    ]);
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['RW34', 'TOPPP'],
+    );
+  });
+
+  it('skips a leg that carries a fix identifier but no coordinates', () => {
+    const points = extractLegPoints([
+      fixLeg('ALPHA', 40.0, -74.0),
+      { pathTerminator: 'CF', fixIdentifier: 'NOCRD' },
+      fixLeg('BRAVO', 41.0, -74.0),
+    ]);
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['ALPHA', 'BRAVO'],
+    );
+  });
+
+  it('suppresses consecutive duplicate points (e.g. a hold over the prior fix)', () => {
+    const points = extractLegPoints([
+      fixLeg('HOLDR', 40.0, -74.0, 'TF'),
+      fixLeg('HOLDR', 40.0, -74.0, 'HF'),
+      fixLeg('NEXTT', 41.0, -74.0),
+    ]);
+
+    assert.deepEqual(
+      points.map((p) => p.label),
+      ['HOLDR', 'NEXTT'],
+    );
+  });
+
+  it('keeps a later point that revisits an earlier non-consecutive coordinate', () => {
+    const points = extractLegPoints([
+      fixLeg('A', 40.0, -74.0),
+      fixLeg('B', 41.0, -74.0),
+      fixLeg('A2', 40.0, -74.0),
+    ]);
+
+    assert.equal(points.length, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expansionToLineString
+// ---------------------------------------------------------------------------
+
+describe('expansionToLineString', () => {
+  it('builds a LineString with [lon, lat] coordinates', () => {
+    const line = expansionToLineString([fixLeg('A', 40.0, -74.0), fixLeg('B', 41.0, -73.0)]);
+
+    assert.deepEqual(line, {
+      type: 'LineString',
+      coordinates: [
+        [-74.0, 40.0],
+        [-73.0, 41.0],
+      ],
+    });
+  });
+
+  it('returns undefined for an empty leg sequence', () => {
+    assert.equal(expansionToLineString([]), undefined);
+  });
+
+  it('returns undefined when only one leg is drawable', () => {
+    assert.equal(
+      expansionToLineString([fixLeg('SOLO', 40.0, -74.0), nonPositionalLeg('VM')]),
+      undefined,
+    );
+  });
+
+  it('returns undefined when every leg is non-positional', () => {
+    assert.equal(
+      expansionToLineString([
+        nonPositionalLeg('CA'),
+        nonPositionalLeg('VA'),
+        nonPositionalLeg('FM'),
+      ]),
+      undefined,
+    );
+  });
+});

--- a/packages/libs/procedures/src/leg-geometry.ts
+++ b/packages/libs/procedures/src/leg-geometry.ts
@@ -1,0 +1,125 @@
+/**
+ * Drawable geometry extraction for expanded instrument-procedure leg
+ * sequences. Walks the ordered {@link ProcedureLeg} array returned by
+ * {@link ProcedureResolver.expand} into the subset of legs that terminate at
+ * a known fix and exposes that sequence both as plain
+ * {@link ProcedureLegPoint} values and as a GeoJSON `LineString` for map
+ * rendering.
+ *
+ * Many ARINC 424 path terminators end at an altitude, DME distance, radial,
+ * intercept, or manual event rather than at a fix (for example `CA`, `FA`,
+ * `VA`, `CD`, `FD`, `VD`, `CR`, `VR`, `CI`, `VI`, `FM`, `VM`, and the `HA` /
+ * `HM` holds). Those legs carry no `lat` / `lon` and therefore contribute no
+ * point, so a path drawn through the result is not a precise flyable track:
+ * it omits the non-positional legs and breaks across them.
+ */
+
+import type { LineString } from 'geojson';
+
+import type { ProcedureLeg } from '@squawk/types';
+
+/**
+ * A single drawable geographic point along an expanded procedure, in leg
+ * order.
+ */
+export interface ProcedureLegPoint {
+  /** Fix identifier at the leg termination. */
+  label: string;
+  /** Latitude in decimal degrees, positive north. */
+  lat: number;
+  /** Longitude in decimal degrees, positive east. */
+  lon: number;
+}
+
+/** Epsilon for comparing coordinates to detect duplicate points. */
+const COORD_EPSILON = 1e-9;
+
+/**
+ * Returns true if two points share the same coordinates (within epsilon).
+ */
+function samePosition(a: ProcedureLegPoint, b: ProcedureLegPoint): boolean {
+  return Math.abs(a.lat - b.lat) < COORD_EPSILON && Math.abs(a.lon - b.lon) < COORD_EPSILON;
+}
+
+/**
+ * Extracts the ordered sequence of drawable geographic points from an
+ * expanded procedure leg sequence (the `legs` array of a
+ * {@link ProcedureExpansionResult}).
+ *
+ * Only legs that terminate at a known fix contribute a point: a leg is
+ * drawable when it carries a `fixIdentifier`, `lat`, and `lon`. Legs whose
+ * path terminator ends at an altitude, DME distance, radial, intercept, or
+ * manual event (`CA`, `FA`, `VA`, `CD`, `FD`, `VD`, `CR`, `VR`, `CI`, `VI`,
+ * `FM`, `VM`, and the `HA` / `HM` holds) have no coordinate and are skipped.
+ * Because a skipped leg leaves a gap, the returned points are not guaranteed
+ * to be contiguous: a non-positional leg in the middle of a sequence creates
+ * a break in any line drawn through the points, and such legs cannot be
+ * rendered from this data alone (they need a flyable geometry computed from
+ * the aircraft state, navaid, or altitude).
+ *
+ * Consecutive duplicate points (within a small epsilon) are suppressed, so a
+ * hold or fix repeated back-to-back yields a single point.
+ *
+ * ```typescript
+ * import { createProcedureResolver, extractLegPoints } from '@squawk/procedures';
+ *
+ * const resolver = createProcedureResolver({ data: procedures });
+ * const expansion = resolver.expand('KDEN', 'AALLE4');
+ * const points = expansion ? extractLegPoints(expansion.legs) : [];
+ * ```
+ *
+ * @param legs - Ordered procedure legs, e.g. `expand(...).legs`.
+ * @returns Ordered drawable points along the procedure.
+ */
+export function extractLegPoints(legs: ProcedureLeg[]): ProcedureLegPoint[] {
+  const points: ProcedureLegPoint[] = [];
+  for (const leg of legs) {
+    if (leg.fixIdentifier === undefined || leg.lat === undefined || leg.lon === undefined) {
+      continue;
+    }
+    const point: ProcedureLegPoint = { label: leg.fixIdentifier, lat: leg.lat, lon: leg.lon };
+    if (points.length > 0 && samePosition(points[points.length - 1]!, point)) {
+      continue;
+    }
+    points.push(point);
+  }
+  return points;
+}
+
+/**
+ * Builds a GeoJSON `LineString` from an expanded procedure leg sequence,
+ * ready to render as a polyline on a map (e.g. MapLibre, Leaflet).
+ *
+ * Coordinates follow the GeoJSON `[lon, lat]` ordering. Returns `undefined`
+ * when the legs yield fewer than two drawable points, since a `LineString`
+ * requires at least two positions to be valid.
+ *
+ * Non-positional legs are skipped (see {@link extractLegPoints}), so the
+ * line connects only the fix-terminated legs in order. When a procedure
+ * mixes positional and non-positional legs the line is an approximation that
+ * omits the non-drawable segments rather than a precise flyable track.
+ *
+ * ```typescript
+ * import { createProcedureResolver, expansionToLineString } from '@squawk/procedures';
+ *
+ * const resolver = createProcedureResolver({ data: procedures });
+ * const expansion = resolver.expand('KDEN', 'AALLE4');
+ * const line = expansion ? expansionToLineString(expansion.legs) : undefined;
+ * if (line) {
+ *   map.addSource('procedure', { type: 'geojson', data: line });
+ * }
+ * ```
+ *
+ * @param legs - Ordered procedure legs, e.g. `expand(...).legs`.
+ * @returns A GeoJSON `LineString`, or `undefined` if fewer than two points.
+ */
+export function expansionToLineString(legs: ProcedureLeg[]): LineString | undefined {
+  const points = extractLegPoints(legs);
+  if (points.length < 2) {
+    return undefined;
+  }
+  return {
+    type: 'LineString',
+    coordinates: points.map((p) => [p.lon, p.lat]),
+  };
+}


### PR DESCRIPTION
## Summary

- `@squawk/procedures` gains `extractLegPoints(legs)` and `expansionToLineString(legs)` to turn an expanded procedure's leg sequence into drawable map geometry: an ordered list of fix points (label, lat, lon) and a GeoJSON `LineString`. Non-positional legs (course/heading-to-altitude, DME, radial, intercept, manual, and HA/HM holds) carry no coordinate and are skipped, so the line breaks across them; consecutive duplicate points are suppressed.
- `@squawk/mcp` adds a `get_procedure_geometry` tool wrapping the new helpers, and `expand_procedure` now points callers to it when they only need map-ready geometry.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added `leg-geometry.spec.ts` covering `extractLegPoints`/`expansionToLineString`, plus two `get_procedure_geometry` end-to-end cases in mcp `tools.spec.ts`.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `procedure-geometry.md`: `@squawk/procedures` minor, `@squawk/mcp` minor.