### PR TITLE
Add position-disambiguated waypoint resolution to flightplan routes

### DIFF
--- a/.changeset/flightplan-waypoint-disambiguation.md
+++ b/.changeset/flightplan-waypoint-disambiguation.md
@@ -1,0 +1,24 @@
+---
+'@squawk/flightplan': minor
+'@squawk/mcp': patch
+---
+
+### Added
+
+- **@squawk/flightplan** `FlightplanFixLookup` and `FlightplanNavaidLookup` gain an
+  optional `byIdentAtPosition(ident, lat, lon, toleranceNm?)` method. When a provider
+  implements it, `createFlightplanResolver(...).parse()` resolves a fix or navaid token
+  whose identifier is published in more than one region to the candidate nearest the most
+  recently resolved positional element (a preceding airport, coordinate, waypoint, airway
+  exit fix, or procedure terminus) rather than taking the first `byIdent` match. The first
+  token in a route has no anchor, and providers exposing only `byIdent` are unaffected;
+  both fall back to the first match.
+
+### Changed
+
+- **@squawk/mcp** the flightplan route tools (`parse_flightplan_route`,
+  `compute_route_distance`, `get_route_geometry`, `get_route_timing`) now disambiguate
+  shared-identifier route waypoints by proximity, because the bundled fix and navaid
+  resolvers implement `byIdentAtPosition`. The tool surface is unchanged; a shared
+  identifier that previously resolved to whichever record sorted first now resolves to the
+  one nearest the surrounding route.

--- a/packages/libs/flightplan/README.md
+++ b/packages/libs/flightplan/README.md
@@ -95,8 +95,8 @@ Creates a resolver from optional lookup providers.
 **Parameters:**
 
 - `options.airports` - airport lookup (must provide `byFaaId` and `byIcao`)
-- `options.navaids` - navaid lookup (must provide `byIdent`)
-- `options.fixes` - fix lookup (must provide `byIdent`)
+- `options.navaids` - navaid lookup (must provide `byIdent`; may also provide `byIdentAtPosition` for proximity disambiguation)
+- `options.fixes` - fix lookup (must provide `byIdent`; may also provide `byIdentAtPosition` for proximity disambiguation)
 - `options.airways` - airway lookup (must provide `byDesignation` and `expand`)
 - `options.procedures` - procedure lookup (must provide `byIdentifier` and `expand`)
 
@@ -159,6 +159,14 @@ both an airport and a navaid), the resolver uses this priority order:
 3. Procedure (SID/STAR)
 4. Fix
 5. Navaid
+
+The same fix or navaid identifier is sometimes published in more than one
+region. When the `fixes` or `navaids` provider exposes `byIdentAtPosition`, the
+resolver disambiguates such a token by proximity to the most recently resolved
+positional element (a preceding airport, coordinate, waypoint, airway exit fix,
+or procedure terminus). The first token in a route has no such anchor, and a
+provider that exposes only `byIdent` cannot disambiguate; both cases fall back
+to the first `byIdent` match.
 
 ### `computeRouteDistance(route, groundSpeedKt?)`
 

--- a/packages/libs/flightplan/api/flightplan.api.md
+++ b/packages/libs/flightplan/api/flightplan.api.md
@@ -78,11 +78,13 @@ export interface FlightplanAirwayLookup {
 // @public
 export interface FlightplanFixLookup {
     byIdent(ident: string): Fix[];
+    byIdentAtPosition?(ident: string, lat: number, lon: number, toleranceNm?: number): Fix | undefined;
 }
 
 // @public
 export interface FlightplanNavaidLookup {
     byIdent(ident: string): Navaid[];
+    byIdentAtPosition?(ident: string, lat: number, lon: number, toleranceNm?: number): Navaid | undefined;
 }
 
 // @public

--- a/packages/libs/flightplan/src/resolver.spec.ts
+++ b/packages/libs/flightplan/src/resolver.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, beforeAll, expect, assert } from 'vitest';
 
+import type { Airport, Fix, Navaid } from '@squawk/types';
+
 import { createFlightplanResolver } from './resolver.js';
 import type {
   FlightplanResolver,
@@ -856,5 +858,155 @@ describe('FAA Coded Departure Routes', () => {
     expect(el4.type).toBe('star');
 
     expect(result.elements[5]!.type).toBe('airport');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Same-identifier waypoint disambiguation by proximity
+// ---------------------------------------------------------------------------
+
+describe('waypoint disambiguation by proximity', () => {
+  // Two waypoints published under one identifier at opposite ends of the
+  // country. byIdent returns the eastern record first, so taking results[0]
+  // would always pick it; byIdentAtPosition should instead pick whichever is
+  // nearer the anchor inferred from the preceding route element.
+  const DUPE_EAST = { lat: 40, lon: -70 };
+  const DUPE_WEST = { lat: 34, lon: -118 };
+
+  function fixRecord(identifier: string, lat: number, lon: number): Fix {
+    return { identifier, lat, lon } as Fix;
+  }
+
+  function navaidRecord(identifier: string, lat: number, lon: number): Navaid {
+    return { identifier, lat, lon } as Navaid;
+  }
+
+  function nearest<T extends { lat: number; lon: number }>(
+    records: T[],
+    lat: number,
+    lon: number,
+  ): T | undefined {
+    let best: T | undefined;
+    let bestDistSq = Infinity;
+    for (const record of records) {
+      const distSq = (record.lat - lat) ** 2 + (record.lon - lon) ** 2;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        best = record;
+      }
+    }
+    return best;
+  }
+
+  function fixLookup(records: Fix[], withPosition: boolean): FlightplanFixLookup {
+    const byIdent = (ident: string): Fix[] =>
+      records.filter((r) => r.identifier.toUpperCase() === ident.toUpperCase());
+    if (!withPosition) {
+      return { byIdent };
+    }
+    return {
+      byIdent,
+      byIdentAtPosition: (ident, lat, lon) => nearest(byIdent(ident), lat, lon),
+    };
+  }
+
+  function navaidLookup(records: Navaid[]): FlightplanNavaidLookup {
+    const byIdent = (ident: string): Navaid[] =>
+      records.filter((r) => r.identifier.toUpperCase() === ident.toUpperCase());
+    return {
+      byIdent,
+      byIdentAtPosition: (ident, lat, lon) => nearest(byIdent(ident), lat, lon),
+    };
+  }
+
+  function airportLookup(
+    records: { icao: string; lat: number; lon: number }[],
+  ): FlightplanAirportLookup {
+    return {
+      byIcao: (icao) => {
+        const r = records.find((rec) => rec.icao.toUpperCase() === icao.toUpperCase());
+        return r ? ({ icao: r.icao, lat: r.lat, lon: r.lon } as Airport) : undefined;
+      },
+      byFaaId: () => undefined,
+    };
+  }
+
+  const airportStub = airportLookup([
+    { icao: 'KEAST', lat: DUPE_EAST.lat, lon: DUPE_EAST.lon },
+    { icao: 'KWEST', lat: DUPE_WEST.lat, lon: DUPE_WEST.lon },
+  ]);
+  const dupeFixes = [
+    fixRecord('DUPE', DUPE_EAST.lat, DUPE_EAST.lon),
+    fixRecord('DUPE', DUPE_WEST.lat, DUPE_WEST.lon),
+  ];
+
+  it('disambiguates a shared-identifier fix by proximity to the preceding airport', () => {
+    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, true) });
+
+    const west = resolver.parse('KWEST DUPE').elements[1]!;
+    assert(west.type === 'waypoint');
+    expect(west.lat).toBe(DUPE_WEST.lat);
+    expect(west.lon).toBe(DUPE_WEST.lon);
+
+    const east = resolver.parse('KEAST DUPE').elements[1]!;
+    assert(east.type === 'waypoint');
+    expect(east.lat).toBe(DUPE_EAST.lat);
+    expect(east.lon).toBe(DUPE_EAST.lon);
+  });
+
+  it('falls back to the first byIdent match when no prior element anchors the waypoint', () => {
+    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, true) });
+    const el = resolver.parse('DUPE').elements[0]!;
+    assert(el.type === 'waypoint');
+    // The eastern record is returned first by byIdent and wins without an anchor.
+    expect(el.lat).toBe(DUPE_EAST.lat);
+    expect(el.lon).toBe(DUPE_EAST.lon);
+  });
+
+  it('falls back to the first byIdent match when the provider lacks byIdentAtPosition', () => {
+    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, false) });
+    // KWEST anchors near the western record, but the provider cannot
+    // disambiguate, so the first byIdent match (eastern) is used.
+    const el = resolver.parse('KWEST DUPE').elements[1]!;
+    assert(el.type === 'waypoint');
+    expect(el.lat).toBe(DUPE_EAST.lat);
+    expect(el.lon).toBe(DUPE_EAST.lon);
+  });
+
+  it('disambiguates a shared-identifier navaid by proximity to the preceding airport', () => {
+    const navaidStub = navaidLookup([
+      navaidRecord('NDUP', DUPE_EAST.lat, DUPE_EAST.lon),
+      navaidRecord('NDUP', DUPE_WEST.lat, DUPE_WEST.lon),
+    ]);
+    const resolver = createFlightplanResolver({ airports: airportStub, navaids: navaidStub });
+
+    const west = resolver.parse('KWEST NDUP').elements[1]!;
+    assert(west.type === 'waypoint');
+    assert(west.navaid, 'expected NDUP to resolve as a navaid');
+    expect(west.lat).toBe(DUPE_WEST.lat);
+    expect(west.lon).toBe(DUPE_WEST.lon);
+  });
+
+  it('uses a preceding lat/lon coordinate as the disambiguation anchor', () => {
+    const resolver = createFlightplanResolver({ fixes: fixLookup(dupeFixes, true) });
+    // 34N118W sits on top of the western record.
+    const el = resolver.parse('34N118W DUPE').elements[1]!;
+    assert(el.type === 'waypoint');
+    expect(el.lat).toBe(DUPE_WEST.lat);
+    expect(el.lon).toBe(DUPE_WEST.lon);
+  });
+
+  it('advances the anchor along the route as each waypoint resolves', () => {
+    const near = fixRecord('NEAR', DUPE_WEST.lat, DUPE_WEST.lon + 1);
+    const resolver = createFlightplanResolver({
+      airports: airportStub,
+      fixes: fixLookup([...dupeFixes, near], true),
+    });
+    // KEAST anchors east, but the intermediate NEAR fix moves the anchor west,
+    // so DUPE resolves to the western record despite the eastern departure.
+    const el = resolver.parse('KEAST NEAR DUPE').elements[2]!;
+    assert(el.type === 'waypoint');
+    expect(el.lat).toBe(DUPE_WEST.lat);
+    expect(el.lon).toBe(DUPE_WEST.lon);
   });
 });

--- a/packages/libs/flightplan/src/resolver.spec.ts
+++ b/packages/libs/flightplan/src/resolver.spec.ts
@@ -941,7 +941,10 @@ describe('waypoint disambiguation by proximity', () => {
   ];
 
   it('disambiguates a shared-identifier fix by proximity to the preceding airport', () => {
-    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, true) });
+    const resolver = createFlightplanResolver({
+      airports: airportStub,
+      fixes: fixLookup(dupeFixes, true),
+    });
 
     const west = resolver.parse('KWEST DUPE').elements[1]!;
     assert(west.type === 'waypoint');
@@ -955,7 +958,10 @@ describe('waypoint disambiguation by proximity', () => {
   });
 
   it('falls back to the first byIdent match when no prior element anchors the waypoint', () => {
-    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, true) });
+    const resolver = createFlightplanResolver({
+      airports: airportStub,
+      fixes: fixLookup(dupeFixes, true),
+    });
     const el = resolver.parse('DUPE').elements[0]!;
     assert(el.type === 'waypoint');
     // The eastern record is returned first by byIdent and wins without an anchor.
@@ -964,7 +970,10 @@ describe('waypoint disambiguation by proximity', () => {
   });
 
   it('falls back to the first byIdent match when the provider lacks byIdentAtPosition', () => {
-    const resolver = createFlightplanResolver({ airports: airportStub, fixes: fixLookup(dupeFixes, false) });
+    const resolver = createFlightplanResolver({
+      airports: airportStub,
+      fixes: fixLookup(dupeFixes, false),
+    });
     // KWEST anchors near the western record, but the provider cannot
     // disambiguate, so the first byIdent match (eastern) is used.
     const el = resolver.parse('KWEST DUPE').elements[1]!;

--- a/packages/libs/flightplan/src/resolver.ts
+++ b/packages/libs/flightplan/src/resolver.ts
@@ -30,6 +30,18 @@ export interface FlightplanAirportLookup {
 export interface FlightplanNavaidLookup {
   /** Looks up navaids by identifier. Returns an empty array if none found. */
   byIdent(ident: string): Navaid[];
+  /**
+   * Optionally looks up the single navaid sharing the identifier that lies
+   * nearest a reference position, disambiguating same-identifier collisions by
+   * proximity to the previously resolved route waypoint. When omitted, the
+   * resolver falls back to the first `byIdent` match.
+   */
+  byIdentAtPosition?(
+    ident: string,
+    lat: number,
+    lon: number,
+    toleranceNm?: number,
+  ): Navaid | undefined;
 }
 
 /**
@@ -39,6 +51,18 @@ export interface FlightplanNavaidLookup {
 export interface FlightplanFixLookup {
   /** Looks up fixes by identifier. Returns an empty array if none found. */
   byIdent(ident: string): Fix[];
+  /**
+   * Optionally looks up the single fix sharing the identifier that lies nearest
+   * a reference position, disambiguating same-identifier collisions by proximity
+   * to the previously resolved route waypoint. When omitted, the resolver falls
+   * back to the first `byIdent` match.
+   */
+  byIdentAtPosition?(
+    ident: string,
+    lat: number,
+    lon: number,
+    toleranceNm?: number,
+  ): Fix | undefined;
 }
 
 /**
@@ -370,6 +394,17 @@ function parseSpeedAltitude(token: string): SpeedAltitudeRouteElement | undefine
 // ---------------------------------------------------------------------------
 
 /**
+ * A geographic anchor used to disambiguate same-identifier waypoints by
+ * proximity to the most recently resolved positional route element.
+ */
+interface RouteAnchor {
+  /** Latitude in decimal degrees, positive north. */
+  lat: number;
+  /** Longitude in decimal degrees, positive east. */
+  lon: number;
+}
+
+/**
  * Attempts to resolve a token as an airport (ICAO or FAA ID).
  */
 function tryAirport(
@@ -446,38 +481,48 @@ function tryProcedure(
 }
 
 /**
- * Attempts to resolve a token as a fix waypoint.
+ * Attempts to resolve a token as a fix waypoint. When an anchor is supplied and
+ * the lookup provides `byIdentAtPosition`, the identifier is disambiguated by
+ * proximity to the anchor; otherwise the first `byIdent` match is used.
  */
 function tryFix(
   token: string,
   fixes: FlightplanFixLookup | undefined,
+  anchor: RouteAnchor | undefined,
 ): WaypointRouteElement | undefined {
   if (!fixes) {
     return undefined;
   }
 
-  const results = fixes.byIdent(token);
-  if (results.length > 0) {
-    const fix = results[0]!;
+  const fix =
+    anchor && fixes.byIdentAtPosition
+      ? fixes.byIdentAtPosition(token, anchor.lat, anchor.lon)
+      : fixes.byIdent(token)[0];
+  if (fix) {
     return { type: 'waypoint', raw: token, fix, lat: fix.lat, lon: fix.lon };
   }
   return undefined;
 }
 
 /**
- * Attempts to resolve a token as a navaid waypoint.
+ * Attempts to resolve a token as a navaid waypoint. When an anchor is supplied
+ * and the lookup provides `byIdentAtPosition`, the identifier is disambiguated
+ * by proximity to the anchor; otherwise the first `byIdent` match is used.
  */
 function tryNavaid(
   token: string,
   navaids: FlightplanNavaidLookup | undefined,
+  anchor: RouteAnchor | undefined,
 ): WaypointRouteElement | undefined {
   if (!navaids) {
     return undefined;
   }
 
-  const results = navaids.byIdent(token);
-  if (results.length > 0) {
-    const navaid = results[0]!;
+  const navaid =
+    anchor && navaids.byIdentAtPosition
+      ? navaids.byIdentAtPosition(token, anchor.lat, anchor.lon)
+      : navaids.byIdent(token)[0];
+  if (navaid) {
     return { type: 'waypoint', raw: token, navaid, lat: navaid.lat, lon: navaid.lon };
   }
   return undefined;
@@ -538,6 +583,7 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
       const elements: RouteElement[] = [];
       let lastWaypointIdent: string | undefined;
       let lastAirportIdent: string | undefined;
+      let lastPosition: RouteAnchor | undefined;
 
       let i = 0;
       while (i < tokens.length) {
@@ -555,6 +601,7 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
         if (coord) {
           elements.push({ type: 'coordinate', raw: token, lat: coord.lat, lon: coord.lon });
           lastWaypointIdent = undefined;
+          lastPosition = { lat: coord.lat, lon: coord.lon };
           i++;
           continue;
         }
@@ -584,6 +631,10 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
               });
               // The exit fix is consumed as part of the airway; update last waypoint
               lastWaypointIdent = exitFix;
+              const exitWaypoint = expansion.waypoints[expansion.waypoints.length - 1];
+              if (exitWaypoint) {
+                lastPosition = { lat: exitWaypoint.lat, lon: exitWaypoint.lon };
+              }
               i += 2;
               continue;
             }
@@ -617,6 +668,7 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
           // airport and a navaid on V16).
           lastWaypointIdent = token;
           lastAirportIdent = airportElement.airport.icao ?? airportElement.airport.faaId;
+          lastPosition = { lat: airportElement.airport.lat, lon: airportElement.airport.lon };
           i++;
           continue;
         }
@@ -628,9 +680,12 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
           // Update last waypoint to the last fix in the procedure expansion
           // that actually terminates at a fix (some leg types have no fix).
           for (let j = procElement.legs.length - 1; j >= 0; j--) {
-            const fixIdent = procElement.legs[j]?.fixIdentifier;
-            if (fixIdent !== undefined) {
-              lastWaypointIdent = fixIdent;
+            const leg = procElement.legs[j];
+            if (leg?.fixIdentifier !== undefined) {
+              lastWaypointIdent = leg.fixIdentifier;
+              if (leg.lat !== undefined && leg.lon !== undefined) {
+                lastPosition = { lat: leg.lat, lon: leg.lon };
+              }
               break;
             }
           }
@@ -639,19 +694,21 @@ export function createFlightplanResolver(options: FlightplanResolverOptions): Fl
         }
 
         // Try fix
-        const fixElement = tryFix(token, fixes);
+        const fixElement = tryFix(token, fixes, lastPosition);
         if (fixElement) {
           elements.push(fixElement);
           lastWaypointIdent = token;
+          lastPosition = { lat: fixElement.lat, lon: fixElement.lon };
           i++;
           continue;
         }
 
         // Try navaid
-        const navaidElement = tryNavaid(token, navaids);
+        const navaidElement = tryNavaid(token, navaids, lastPosition);
         if (navaidElement) {
           elements.push(navaidElement);
           lastWaypointIdent = token;
+          lastPosition = { lat: navaidElement.lat, lon: navaidElement.lon };
           i++;
           continue;
         }


### PR DESCRIPTION
## Summary

- `@squawk/flightplan`'s resolver now disambiguates a fix or navaid token whose identifier is published in more than one region, choosing the candidate nearest the most recently resolved positional element (preceding airport, coordinate, waypoint, airway exit fix, or procedure terminus) instead of the first `byIdent` match. `FlightplanFixLookup` / `FlightplanNavaidLookup` gain an optional `byIdentAtPosition`; the first route token (no anchor) and providers without the method fall back to the first match.
- `@squawk/mcp`'s flightplan route tools pick this up transparently through the bundled fix and navaid resolvers, with no tool surface change.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Added six proximity-disambiguation cases to `resolver.spec.ts`: airport and coordinate anchors, the anchor advancing along the route, and both first-match fallback paths.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - `@squawk/flightplan` minor; `@squawk/mcp` patch.