### PR TITLE
Add position-disambiguated navaid and fix selections to Atlas chart mode

### DIFF
--- a/apps/atlas/src/modes/chart/chart-mode.tsx
+++ b/apps/atlas/src/modes/chart/chart-mode.tsx
@@ -4,6 +4,7 @@ import type { MapLayerMouseEvent } from '@vis.gl/react-maplibre';
 import type { ReactElement } from 'react';
 import { useCallback, useState } from 'react';
 
+import { useAmbiguousPointIdentifiers } from '../../shared/inspector/entity-resolver.ts';
 import { EntityInspector } from '../../shared/inspector/inspector.tsx';
 import { MapCanvas } from '../../shared/map/map-canvas.tsx';
 import type { ViewStateChange } from '../../shared/map/map-canvas.tsx';
@@ -78,6 +79,10 @@ function clickQueryRadiusPx(zoom: number): number {
 export function ChartMode(): ReactElement {
   const { lat, lon, zoom, pitch, layers, airspaceClasses, selected } = route.useSearch();
   const navigate = useNavigate({ from: CHART_ROUTE_PATH });
+  // Shared navaid / fix identifier sets, used to decide when a click or
+  // popover selection needs a position suffix so a duplicated identifier
+  // resolves to the clicked record rather than the first dataset match.
+  const ambiguousIdentifiers = useAmbiguousPointIdentifiers();
   // Snapshot of every feature returned by the most recent map click. The
   // inspector reads this to render an "Also here" chip strip so the user
   // can switch between stacked features (e.g. Class B and ARTCC at the
@@ -221,14 +226,14 @@ export function ChartMode(): ReactElement {
       setFeaturesAtLastClick(features);
       const next =
         classification.kind === 'unambiguous'
-          ? selectedFromFeature(classification.winner)
+          ? selectedFromFeature(classification.winner, ambiguousIdentifiers)
           : undefined;
       void navigate({
         search: (prev) => ({ ...prev, selected: next }),
         replace: true,
       });
     },
-    [navigate],
+    [navigate, ambiguousIdentifiers],
   );
 
   const handleDisambiguationSelect = useCallback(
@@ -363,6 +368,7 @@ export function ChartMode(): ReactElement {
           <DisambiguationPopover
             screen={pendingDisambiguation.screen}
             candidates={pendingDisambiguation.candidates}
+            ambiguous={ambiguousIdentifiers}
             onSelect={handleDisambiguationSelect}
             onDismiss={handleDisambiguationDismiss}
           />

--- a/apps/atlas/src/modes/chart/interaction/click-to-select.spec.ts
+++ b/apps/atlas/src/modes/chart/interaction/click-to-select.spec.ts
@@ -28,6 +28,24 @@ function buildFeature(layerId: string, properties: Record<string, unknown>): Ins
   return { layer: { id: layerId }, properties };
 }
 
+/**
+ * Builds an `InspectableFeature` carrying a Point geometry, used to
+ * exercise the navaid / fix position-suffix encoding which sources its
+ * coordinates from `feature.geometry`.
+ */
+function buildPointFeature(
+  layerId: string,
+  properties: Record<string, unknown>,
+  lon: number,
+  lat: number,
+): InspectableFeature {
+  return {
+    layer: { id: layerId },
+    properties,
+    geometry: { type: 'Point', coordinates: [lon, lat] },
+  };
+}
+
 describe('selectedFromFeature', () => {
   it('encodes an airport feature using its faaId', () => {
     expect(selectedFromFeature(buildFeature(AIRPORTS_LAYER_ID, { faaId: 'BOS' }))).toBe(
@@ -44,6 +62,41 @@ describe('selectedFromFeature', () => {
   it('encodes a fix feature using its identifier', () => {
     expect(selectedFromFeature(buildFeature(FIXES_LAYER_ID, { identifier: 'MERIT' }))).toBe(
       'fix:MERIT',
+    );
+  });
+
+  it('appends a position suffix for a shared-identifier navaid, sourced from its geometry', () => {
+    const feature = buildPointFeature(
+      NAVAIDS_LAYER_ID,
+      { identifier: 'DUPE' },
+      -71.00472,
+      42.35778,
+    );
+    expect(selectedFromFeature(feature, { navaids: new Set(['DUPE']), fixes: new Set() })).toBe(
+      'navaid:DUPE/c:-71.00472,42.35778',
+    );
+  });
+
+  it('appends a position suffix for a shared-identifier fix, sourced from its geometry', () => {
+    const feature = buildPointFeature(FIXES_LAYER_ID, { identifier: 'DUPE' }, -90.5, 30.123);
+    expect(selectedFromFeature(feature, { navaids: new Set(), fixes: new Set(['DUPE']) })).toBe(
+      'fix:DUPE/c:-90.50000,30.12300',
+    );
+  });
+
+  it('encodes a unique navaid bare even when ambiguity sets are supplied', () => {
+    const feature = buildPointFeature(NAVAIDS_LAYER_ID, { identifier: 'SOLO' }, -71, 42);
+    expect(selectedFromFeature(feature, { navaids: new Set(['DUPE']), fixes: new Set() })).toBe(
+      'navaid:SOLO',
+    );
+  });
+
+  it('encodes a shared-identifier navaid bare when the feature has no geometry', () => {
+    // A hand-built or stub feature without geometry cannot supply a
+    // position; the bare identifier remains the only stable handle.
+    const feature = buildFeature(NAVAIDS_LAYER_ID, { identifier: 'DUPE' });
+    expect(selectedFromFeature(feature, { navaids: new Set(['DUPE']), fixes: new Set() })).toBe(
+      'navaid:DUPE',
     );
   });
 

--- a/apps/atlas/src/modes/chart/interaction/click-to-select.ts
+++ b/apps/atlas/src/modes/chart/interaction/click-to-select.ts
@@ -3,6 +3,8 @@ import type { GeoJsonProperties, Geometry } from 'geojson';
 import { polygonGeoJson } from '@squawk/geo';
 
 import { AIRSPACE_MATCH_KEY_PROPERTY } from '../../../shared/inspector/airspace-feature.ts';
+import { encodePointId } from '../../../shared/inspector/entity.ts';
+import type { AmbiguousPointIdentifiers, PointPosition } from '../../../shared/inspector/entity.ts';
 import { AIRPORTS_LAYER_ID } from '../layers/airports-layer.tsx';
 import {
   AIRSPACE_FILL_EXTRUSION_LAYER_ID,
@@ -218,14 +220,26 @@ export function classifyClick(features: readonly InspectableFeature[]): ClickCla
  * discriminating field. Used downstream of {@link pickFeatureByPriority},
  * which selects the winner among any features that hit the click point.
  *
+ * Navaid and fix features whose identifier is shared by multiple records
+ * (per `ambiguous`) gain a `/c:LON,LAT` suffix sourced from the feature's
+ * Point geometry, so the inspector resolves the clicked record rather than
+ * whichever sorts first. Unique identifiers - and every feature when
+ * `ambiguous` is omitted - encode in the bare `navaid:IDENT` / `fix:IDENT`
+ * form, keeping the common case short.
+ *
  * Pure: no map, navigation, or DOM dependencies. Tested independently of
  * the click handler.
  *
  * @param feature - The picked feature to encode.
+ * @param ambiguous - Optional shared-identifier sets; when a navaid / fix
+ *   identifier is present, a position suffix is appended for disambiguation.
  * @returns The encoded `selected` string, or undefined if the feature
  *   cannot be encoded.
  */
-export function selectedFromFeature(feature: InspectableFeature): string | undefined {
+export function selectedFromFeature(
+  feature: InspectableFeature,
+  ambiguous?: AmbiguousPointIdentifiers,
+): string | undefined {
   switch (feature.layer.id) {
     case AIRPORTS_LAYER_ID: {
       const faaId = readString(feature.properties, 'faaId');
@@ -233,11 +247,17 @@ export function selectedFromFeature(feature: InspectableFeature): string | undef
     }
     case NAVAIDS_LAYER_ID: {
       const identifier = readString(feature.properties, 'identifier');
-      return identifier === undefined ? undefined : `navaid:${identifier}`;
+      if (identifier === undefined) {
+        return undefined;
+      }
+      return `navaid:${encodePointId(identifier, disambiguatingPosition(feature, identifier, ambiguous?.navaids))}`;
     }
     case FIXES_LAYER_ID: {
       const identifier = readString(feature.properties, 'identifier');
-      return identifier === undefined ? undefined : `fix:${identifier}`;
+      if (identifier === undefined) {
+        return undefined;
+      }
+      return `fix:${encodePointId(identifier, disambiguatingPosition(feature, identifier, ambiguous?.fixes))}`;
     }
     case AIRWAYS_LAYER_ID: {
       const designation = readString(feature.properties, 'designation');
@@ -324,6 +344,53 @@ export function polygonCentroidFromGeometry(
     return undefined;
   }
   return polygonGeoJson.polygonCentroid(geometry);
+}
+
+/**
+ * Returns the position to embed in a navaid / fix selection, or undefined
+ * when no disambiguator is needed or available. A position is emitted only
+ * when the identifier is in `ambiguousSet` (shared by multiple records) AND
+ * the feature carries a Point geometry to read coordinates from; unique
+ * identifiers and geometry-less features (some test stubs) encode bare.
+ *
+ * @param feature - The feature being encoded.
+ * @param identifier - The feature's navaid / fix identifier.
+ * @param ambiguousSet - Identifiers shared by 2+ records, or undefined to disable suffixing.
+ * @returns The disambiguating position, or undefined to encode the bare identifier.
+ */
+function disambiguatingPosition(
+  feature: InspectableFeature,
+  identifier: string,
+  ambiguousSet: ReadonlySet<string> | undefined,
+): PointPosition | undefined {
+  if (ambiguousSet === undefined || !ambiguousSet.has(identifier)) {
+    return undefined;
+  }
+  const coords = pointCoordsFromGeometry(feature.geometry);
+  if (coords === undefined) {
+    return undefined;
+  }
+  return { lon: coords[0], lat: coords[1] };
+}
+
+/**
+ * Extracts `[lon, lat]` from a Point geometry, or undefined when the
+ * geometry is missing or not a Point. Sources the disambiguating position
+ * for a shared navaid / fix identifier from the clicked point feature.
+ *
+ * @param geometry - Optional GeoJSON geometry from the clicked feature.
+ * @returns The point coordinates as `[lon, lat]`, or undefined when unavailable.
+ */
+function pointCoordsFromGeometry(geometry: Geometry | undefined): [number, number] | undefined {
+  if (geometry === undefined || geometry.type !== 'Point') {
+    return undefined;
+  }
+  const lon = geometry.coordinates[0];
+  const lat = geometry.coordinates[1];
+  if (typeof lon !== 'number' || typeof lat !== 'number') {
+    return undefined;
+  }
+  return [lon, lat];
 }
 
 /**

--- a/apps/atlas/src/modes/chart/interaction/disambiguation-popover.spec.tsx
+++ b/apps/atlas/src/modes/chart/interaction/disambiguation-popover.spec.tsx
@@ -27,6 +27,20 @@ function buildFeature(layerId: string, properties: Record<string, unknown>): Ins
   return { layer: { id: layerId }, properties };
 }
 
+/** Builds a popover candidate carrying a Point geometry, for the navaid / fix position-suffix path. */
+function buildPointFeature(
+  layerId: string,
+  properties: Record<string, unknown>,
+  lon: number,
+  lat: number,
+): InspectableFeature {
+  return {
+    layer: { id: layerId },
+    properties,
+    geometry: { type: 'Point', coordinates: [lon, lat] },
+  };
+}
+
 /**
  * Pulls the `movestart` handler that the popover most recently
  * registered with the map. Tests fire it directly to simulate a
@@ -112,6 +126,46 @@ describe('DisambiguationPopover', () => {
 
     const items = screen.getAllByRole('menuitem');
     expect(items).toHaveLength(2);
+  });
+
+  it('keeps two same-identifier candidates distinct when ambiguity sets supply position suffixes', () => {
+    const onSelect = vi.fn();
+    const east = buildPointFeature(NAVAIDS_LAYER_ID, { identifier: 'DUPE' }, -71, 42);
+    const west = buildPointFeature(NAVAIDS_LAYER_ID, { identifier: 'DUPE' }, -120, 40);
+    render(
+      <DisambiguationPopover
+        screen={{ x: 0, y: 0 }}
+        candidates={[east, west]}
+        ambiguous={{ navaids: new Set(['DUPE']), fixes: new Set() }}
+        onSelect={onSelect}
+        onDismiss={vi.fn()}
+      />,
+      { wrapper: withProvider(vi.fn()) },
+    );
+
+    const items = screen.getAllByRole('menuitem');
+    expect(items).toHaveLength(2);
+    fireEvent.click(items[0]!);
+    expect(onSelect).toHaveBeenCalledWith('navaid:DUPE/c:-71.00000,42.00000');
+  });
+
+  it('collapses two same-identifier candidates to nothing without ambiguity sets', () => {
+    // Both encode to the bare `navaid:DUPE`, so the dedupe pass leaves one
+    // row and the <2 guard renders nothing - the regression the position
+    // suffix fixes.
+    const east = buildPointFeature(NAVAIDS_LAYER_ID, { identifier: 'DUPE' }, -71, 42);
+    const west = buildPointFeature(NAVAIDS_LAYER_ID, { identifier: 'DUPE' }, -120, 40);
+    const { container } = render(
+      <DisambiguationPopover
+        screen={{ x: 0, y: 0 }}
+        candidates={[east, west]}
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+      { wrapper: withProvider(vi.fn()) },
+    );
+
+    expect(container.firstChild).toBeNull();
   });
 
   it('drops candidates whose layer is not encodeable', () => {

--- a/apps/atlas/src/modes/chart/interaction/disambiguation-popover.tsx
+++ b/apps/atlas/src/modes/chart/interaction/disambiguation-popover.tsx
@@ -8,6 +8,7 @@ import {
   readAirspaceAltitudeKey,
 } from '../../../shared/inspector/airspace-feature.ts';
 import type { AirspaceAltitudeKey } from '../../../shared/inspector/airspace-feature.ts';
+import type { AmbiguousPointIdentifiers } from '../../../shared/inspector/entity.ts';
 import { FLOATING_SURFACE_CLASSES } from '../../../shared/styles/style-tokens.ts';
 import { useCanHover } from '../../../shared/styles/use-can-hover.ts';
 import { useSetHoveredChipSelection } from '../highlight-context.ts';
@@ -50,6 +51,13 @@ export interface DisambiguationPopoverProps {
    */
   candidates: readonly InspectableFeature[];
   /**
+   * Shared navaid / fix identifier sets. When two candidates carry the
+   * same duplicated identifier, the position suffix keeps their rows
+   * distinct (and resolving to the right record) instead of collapsing
+   * to one via the dedupe pass. Omit to encode every row bare.
+   */
+  ambiguous?: AmbiguousPointIdentifiers;
+  /**
    * Called with a chosen feature's encoded selection string when the
    * user clicks an entry. The caller is responsible for clearing the
    * pending state that drove this popover; the popover unmounts on
@@ -89,6 +97,7 @@ export interface DisambiguationPopoverProps {
 export function DisambiguationPopover({
   screen,
   candidates,
+  ambiguous,
   onSelect,
   onDismiss,
 }: DisambiguationPopoverProps): ReactElement | null {
@@ -120,7 +129,7 @@ export function DisambiguationPopover({
     const nonAirspace: PopoverEntry[] = [];
     const airspace: { entry: PopoverEntry; key: AirspaceAltitudeKey }[] = [];
     for (const feature of candidates) {
-      const selection = selectedFromFeature(feature);
+      const selection = selectedFromFeature(feature, ambiguous);
       if (selection === undefined) {
         continue;
       }
@@ -150,7 +159,7 @@ export function DisambiguationPopover({
     }
     airspace.sort((a, b) => compareAirspaceByAltitudeDesc(a.key, b.key));
     return [...nonAirspace, ...airspace.map((it) => it.entry)];
-  }, [candidates]);
+  }, [candidates, ambiguous]);
 
   useEffect((): (() => void) => {
     function handleKeyDown(event: KeyboardEvent): void {

--- a/apps/atlas/src/modes/chart/layers/fixes-layer.spec.tsx
+++ b/apps/atlas/src/modes/chart/layers/fixes-layer.spec.tsx
@@ -6,9 +6,10 @@ import type { FixDataset } from '@squawk/fix-data';
 
 import { FIXES_HIGHLIGHT_LAYER_ID, FIXES_LAYER_ID, FixesLayer } from './fixes-layer.tsx';
 
-const { useFixDatasetMock, useActiveHighlightRefMock } = vi.hoisted(() => ({
+const { useFixDatasetMock, useActiveHighlightRefMock, layerPropsLog } = vi.hoisted(() => ({
   useFixDatasetMock: vi.fn(),
   useActiveHighlightRefMock: vi.fn(),
+  layerPropsLog: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('../../../shared/data/fix-dataset.ts', () => ({
@@ -21,12 +22,16 @@ vi.mock('../highlight-context.ts', () => ({
 
 // Stub MapLibre primitives. `Source` renders its children inside a
 // findable container so the test can assert the layer mounted; `Layer`
-// is a no-op since real MapLibre paint props need a live map context.
+// records the props it receives so tests can assert paint / filter values
+// without a live map context.
 vi.mock('@vis.gl/react-maplibre', () => ({
   Source: ({ children }: { children?: ReactNode }): ReactElement => (
     <div data-testid="maplibre-source">{children}</div>
   ),
-  Layer: (): null => null,
+  Layer: (props: Record<string, unknown>): null => {
+    layerPropsLog.push(props);
+    return null;
+  },
 }));
 
 const EMPTY_DATASET: FixDataset = {
@@ -57,6 +62,7 @@ function buildFix(
 describe('FixesLayer', () => {
   beforeEach(() => {
     useActiveHighlightRefMock.mockReturnValue(undefined);
+    layerPropsLog.length = 0;
   });
 
   it('exports stable MapLibre layer ids consumed by chart-mode click handling', () => {
@@ -103,7 +109,24 @@ describe('FixesLayer', () => {
   it('switches the highlight filter when a fix is selected', () => {
     useActiveHighlightRefMock.mockReturnValue({ type: 'fix', id: 'MERIT' });
     useFixDatasetMock.mockReturnValue({ status: 'loaded', dataset: EMPTY_DATASET });
-    const { getByTestId } = render(<FixesLayer />);
-    expect(getByTestId('maplibre-source')).toBeInTheDocument();
+    const highlight = renderAndReadHighlightFilter();
+    expect(highlight).toEqual(['==', ['get', 'identifier'], 'MERIT']);
+  });
+
+  it('strips a position suffix from the highlight filter so it matches the bare identifier', () => {
+    useActiveHighlightRefMock.mockReturnValue({ type: 'fix', id: 'DUPE/c:-90.50000,30.12300' });
+    useFixDatasetMock.mockReturnValue({ status: 'loaded', dataset: EMPTY_DATASET });
+    const highlight = renderAndReadHighlightFilter();
+    expect(highlight).toEqual(['==', ['get', 'identifier'], 'DUPE']);
   });
 });
+
+/**
+ * Renders the layer and returns the `filter` prop of the highlight layer,
+ * read from the captured MapLibre `Layer` props.
+ */
+function renderAndReadHighlightFilter(): unknown {
+  render(<FixesLayer />);
+  const highlightLayer = layerPropsLog.find((props) => props.id === FIXES_HIGHLIGHT_LAYER_ID);
+  return highlightLayer?.filter;
+}

--- a/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/fixes-layer.tsx
@@ -8,6 +8,7 @@ import type { ReactElement } from 'react';
 import type { Fix, FixUseCode } from '@squawk/types';
 
 import { useFixDataset } from '../../../shared/data/fix-dataset.ts';
+import { decodePointId } from '../../../shared/inspector/entity.ts';
 import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { LAYER_MIN_ZOOM } from '../url-state.ts';
@@ -166,7 +167,11 @@ export function FixesLayer(): ReactElement | null {
   // empty viewport when the user is zoomed out below the threshold.
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const filter: ExpressionSpecification =
-      activeRef?.type === 'fix' ? ['==', ['get', 'identifier'], activeRef.id] : MATCH_NONE_FILTER;
+      activeRef?.type === 'fix'
+        ? // Strip any `/c:LON,LAT` disambiguator so the highlight matches on
+          // the bare identifier carried by the feature properties.
+          ['==', ['get', 'identifier'], decodePointId(activeRef.id).ident]
+        : MATCH_NONE_FILTER;
     return {
       id: FIXES_HIGHLIGHT_LAYER_ID,
       source: FIXES_SOURCE_ID,

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.spec.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.spec.tsx
@@ -6,9 +6,10 @@ import type { NavaidDataset } from '@squawk/navaid-data';
 
 import { NAVAIDS_HIGHLIGHT_LAYER_ID, NAVAIDS_LAYER_ID, NavaidsLayer } from './navaids-layer.tsx';
 
-const { useNavaidDatasetMock, useActiveHighlightRefMock } = vi.hoisted(() => ({
+const { useNavaidDatasetMock, useActiveHighlightRefMock, layerPropsLog } = vi.hoisted(() => ({
   useNavaidDatasetMock: vi.fn(),
   useActiveHighlightRefMock: vi.fn(),
+  layerPropsLog: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('../../../shared/data/navaid-dataset.ts', () => ({
@@ -21,12 +22,16 @@ vi.mock('../highlight-context.ts', () => ({
 
 // Stub MapLibre primitives. `Source` renders its children inside a
 // findable container so the test can assert the layer mounted; `Layer`
-// is a no-op since real MapLibre paint props need a live map context.
+// records the props it receives so tests can assert paint / filter values
+// without a live map context.
 vi.mock('@vis.gl/react-maplibre', () => ({
   Source: ({ children }: { children?: ReactNode }): ReactElement => (
     <div data-testid="maplibre-source">{children}</div>
   ),
-  Layer: (): null => null,
+  Layer: (props: Record<string, unknown>): null => {
+    layerPropsLog.push(props);
+    return null;
+  },
 }));
 
 const EMPTY_DATASET: NavaidDataset = {
@@ -52,6 +57,7 @@ function buildNavaid(
 describe('NavaidsLayer', () => {
   beforeEach(() => {
     useActiveHighlightRefMock.mockReturnValue(undefined);
+    layerPropsLog.length = 0;
   });
 
   it('exports stable MapLibre layer ids consumed by chart-mode click handling', () => {
@@ -97,7 +103,24 @@ describe('NavaidsLayer', () => {
   it('switches the highlight filter when a navaid is selected', () => {
     useActiveHighlightRefMock.mockReturnValue({ type: 'navaid', id: 'BOS' });
     useNavaidDatasetMock.mockReturnValue({ status: 'loaded', dataset: EMPTY_DATASET });
-    const { getByTestId } = render(<NavaidsLayer />);
-    expect(getByTestId('maplibre-source')).toBeInTheDocument();
+    const highlight = renderAndReadHighlightFilter();
+    expect(highlight).toEqual(['==', ['get', 'identifier'], 'BOS']);
+  });
+
+  it('strips a position suffix from the highlight filter so it matches the bare identifier', () => {
+    useActiveHighlightRefMock.mockReturnValue({ type: 'navaid', id: 'DUPE/c:-71.00472,42.35778' });
+    useNavaidDatasetMock.mockReturnValue({ status: 'loaded', dataset: EMPTY_DATASET });
+    const highlight = renderAndReadHighlightFilter();
+    expect(highlight).toEqual(['==', ['get', 'identifier'], 'DUPE']);
   });
 });
+
+/**
+ * Renders the layer and returns the `filter` prop of the highlight layer,
+ * read from the captured MapLibre `Layer` props.
+ */
+function renderAndReadHighlightFilter(): unknown {
+  render(<NavaidsLayer />);
+  const highlightLayer = layerPropsLog.find((props) => props.id === NAVAIDS_HIGHLIGHT_LAYER_ID);
+  return highlightLayer?.filter;
+}

--- a/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
+++ b/apps/atlas/src/modes/chart/layers/navaids-layer.tsx
@@ -8,6 +8,7 @@ import type { ReactElement } from 'react';
 import type { Navaid, NavaidType } from '@squawk/types';
 
 import { useNavaidDataset } from '../../../shared/data/navaid-dataset.ts';
+import { decodePointId } from '../../../shared/inspector/entity.ts';
 import { useChartColors } from '../../../shared/styles/chart-colors.ts';
 import { useActiveHighlightRef } from '../highlight-context.ts';
 import { LAYER_MIN_ZOOM } from '../url-state.ts';
@@ -162,7 +163,9 @@ export function NavaidsLayer(): ReactElement | null {
   const highlightLayerProps = useMemo<LayerProps>(() => {
     const filter: ExpressionSpecification =
       activeRef?.type === 'navaid'
-        ? ['==', ['get', 'identifier'], activeRef.id]
+        ? // Strip any `/c:LON,LAT` disambiguator so the highlight matches on
+          // the bare identifier carried by the feature properties.
+          ['==', ['get', 'identifier'], decodePointId(activeRef.id).ident]
         : MATCH_NONE_FILTER;
     return {
       id: NAVAIDS_HIGHLIGHT_LAYER_ID,

--- a/apps/atlas/src/modes/chart/search/search-features.spec.ts
+++ b/apps/atlas/src/modes/chart/search/search-features.spec.ts
@@ -15,6 +15,7 @@ import type {
   Navaid,
 } from '@squawk/types';
 
+import type { AmbiguousPointIdentifiers } from '../../../shared/inspector/entity.ts';
 import { RENDERED_AIRPORT_FACILITY_TYPES, RENDERED_NAVAID_TYPES } from '../layers/drawable-sets.ts';
 
 import { DEFAULT_RESULT_LIMIT, searchChartFeatures } from './search-features.ts';
@@ -251,6 +252,8 @@ function run(params: {
   limit?: number;
   /** Minimum score forwarded to resolvers. */
   minScore?: number;
+  /** Shared navaid / fix identifier sets for position-suffix encoding. */
+  ambiguous?: AmbiguousPointIdentifiers;
 }): ChartSearchResult[] {
   return searchChartFeatures({
     text: params.text ?? 'bos',
@@ -259,6 +262,7 @@ function run(params: {
     visibility: params.visibility ?? makeVisibility(),
     ...(params.limit !== undefined && { limit: params.limit }),
     ...(params.minScore !== undefined && { minScore: params.minScore }),
+    ...(params.ambiguous !== undefined && { ambiguous: params.ambiguous }),
   });
 }
 
@@ -445,6 +449,53 @@ describe('searchChartFeatures', () => {
     const result = results[0];
     expect(result?.selection).toBe('airspace:CLASS_E5/c:1.60000,1.60000');
     expect(result?.label).toBe('PODUNK E5');
+  });
+
+  it('appends a position suffix to a shared-identifier navaid selection', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        navaids: [
+          navaidMatch(makeNavaid({ identifier: 'DUPE', lat: 42.35778, lon: -71.00472 }), 0.9),
+        ],
+      }),
+      scope: makeScope({ navaids: { enabled: true, types: RENDERED_NAVAID_TYPES } }),
+      ambiguous: { navaids: new Set(['DUPE']), fixes: new Set() },
+    });
+    expect(results[0]?.selection).toBe('navaid:DUPE/c:-71.00472,42.35778');
+  });
+
+  it('appends a position suffix to a shared-identifier fix selection', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        fixes: [fixMatch(makeFix({ identifier: 'DUPE', lat: 30.123, lon: -90.5 }), 0.9)],
+      }),
+      scope: makeScope({ fixes: { enabled: true } }),
+      ambiguous: { navaids: new Set(), fixes: new Set(['DUPE']) },
+    });
+    expect(results[0]?.selection).toBe('fix:DUPE/c:-90.50000,30.12300');
+  });
+
+  it('encodes a unique navaid selection bare even when ambiguity sets are supplied', () => {
+    const results = run({
+      resolvers: makeResolvers({ navaids: [navaidMatch(makeNavaid({ identifier: 'SOLO' }), 0.9)] }),
+      scope: makeScope({ navaids: { enabled: true, types: RENDERED_NAVAID_TYPES } }),
+      ambiguous: { navaids: new Set(['DUPE']), fixes: new Set() },
+    });
+    expect(results[0]?.selection).toBe('navaid:SOLO');
+  });
+
+  it('encodes navaid and fix selections bare when no ambiguity sets are supplied', () => {
+    const results = run({
+      resolvers: makeResolvers({
+        navaids: [navaidMatch(makeNavaid({ identifier: 'DUPE' }), 0.9)],
+        fixes: [fixMatch(makeFix({ identifier: 'DUPE' }), 0.8)],
+      }),
+      scope: makeScope({
+        navaids: { enabled: true, types: RENDERED_NAVAID_TYPES },
+        fixes: { enabled: true },
+      }),
+    });
+    expect(results.map((result) => result.selection)).toEqual(['navaid:DUPE', 'fix:DUPE']);
   });
 
   it('selects the navaid matched text by matched field', () => {

--- a/apps/atlas/src/modes/chart/search/search-features.ts
+++ b/apps/atlas/src/modes/chart/search/search-features.ts
@@ -7,7 +7,8 @@ import type { NavaidResolver, NavaidSearchField, NavaidSearchResult } from '@squ
 import type { MatchRange } from '@squawk/search';
 import type { Airport, AirspaceFeature, AirspaceType, AirwayType, NavaidType } from '@squawk/types';
 
-import { encodeSelected } from '../../../shared/inspector/entity.ts';
+import { encodePointId, encodeSelected } from '../../../shared/inspector/entity.ts';
+import type { AmbiguousPointIdentifiers, PointPosition } from '../../../shared/inspector/entity.ts';
 import {
   bboxFromCoords,
   bboxFromWaypoints,
@@ -172,6 +173,13 @@ export interface ChartSearchParams {
   limit?: number;
   /** Minimum match score (exclusive) forwarded to each resolver. When omitted, every match is kept. */
   minScore?: number;
+  /**
+   * Shared navaid / fix identifier sets. When a result's identifier is
+   * present, its selection gains a `/c:LON,LAT` suffix so choosing the row
+   * resolves the intended record rather than the first identifier match.
+   * Omit to encode every result bare.
+   */
+  ambiguous?: AmbiguousPointIdentifiers;
 }
 
 /**
@@ -220,16 +228,48 @@ function buildAirportResult(
 }
 
 /**
+ * Returns the disambiguating position for a shared point-feature
+ * identifier, or undefined when the identifier is unique (so the
+ * selection encodes bare). The coordinates come straight from the
+ * matched record, so unlike the click path there is no tile-quantized
+ * geometry to contend with.
+ *
+ * @param identifier - The matched record's identifier.
+ * @param lat - The record latitude in decimal degrees (WGS84).
+ * @param lon - The record longitude in decimal degrees (WGS84).
+ * @param ambiguousSet - Identifiers shared by 2+ records, or undefined to disable suffixing.
+ * @returns The disambiguating position, or undefined to encode the bare identifier.
+ */
+function positionForSharedIdentifier(
+  identifier: string,
+  lat: number,
+  lon: number,
+  ambiguousSet: ReadonlySet<string> | undefined,
+): PointPosition | undefined {
+  if (ambiguousSet === undefined || !ambiguousSet.has(identifier)) {
+    return undefined;
+  }
+  return { lat, lon };
+}
+
+/**
  * Builds a navaid result row from a resolver match.
  */
 function buildNavaidResult(
   match: NavaidSearchResult,
   visibility: LayerVisibility,
+  ambiguousNavaids: ReadonlySet<string> | undefined,
 ): NavaidChartSearchResult {
   const navaid = match.navaid;
+  const position = positionForSharedIdentifier(
+    navaid.identifier,
+    navaid.lat,
+    navaid.lon,
+    ambiguousNavaids,
+  );
   return {
     kind: 'navaid',
-    selection: encodeSelected({ type: 'navaid', id: navaid.identifier }),
+    selection: encodeSelected({ type: 'navaid', id: encodePointId(navaid.identifier, position) }),
     label: navaid.identifier,
     sublabel: navaid.name,
     subtype: navaid.type,
@@ -245,11 +285,16 @@ function buildNavaidResult(
 /**
  * Builds a fix result row from a resolver match.
  */
-function buildFixResult(match: FixSearchResult, visibility: LayerVisibility): FixChartSearchResult {
+function buildFixResult(
+  match: FixSearchResult,
+  visibility: LayerVisibility,
+  ambiguousFixes: ReadonlySet<string> | undefined,
+): FixChartSearchResult {
   const fix = match.fix;
+  const position = positionForSharedIdentifier(fix.identifier, fix.lat, fix.lon, ambiguousFixes);
   return {
     kind: 'fix',
-    selection: encodeSelected({ type: 'fix', id: fix.identifier }),
+    selection: encodeSelected({ type: 'fix', id: encodePointId(fix.identifier, position) }),
     label: fix.identifier,
     sublabel: undefined,
     matchedField: match.matchedField,
@@ -389,7 +434,7 @@ export function searchChartFeatures(params: ChartSearchParams): ChartSearchResul
       if (!isDrawableNavaid(match.navaid)) {
         continue;
       }
-      results.push(buildNavaidResult(match, visibility));
+      results.push(buildNavaidResult(match, visibility, params.ambiguous?.navaids));
     }
   }
 
@@ -400,7 +445,7 @@ export function searchChartFeatures(params: ChartSearchParams): ChartSearchResul
       ...(minScore !== undefined && { minScore }),
     });
     for (const match of matches) {
-      results.push(buildFixResult(match, visibility));
+      results.push(buildFixResult(match, visibility, params.ambiguous?.fixes));
     }
   }
 

--- a/apps/atlas/src/modes/chart/search/use-chart-search.spec.ts
+++ b/apps/atlas/src/modes/chart/search/use-chart-search.spec.ts
@@ -6,12 +6,14 @@ import { useChartSearch } from './use-chart-search.ts';
 const {
   useSearchMock,
   useChartSearchResolversMock,
+  useAmbiguousPointIdentifiersMock,
   computeLayerVisibilityMock,
   computeSearchScopeMock,
   searchChartFeaturesMock,
 } = vi.hoisted(() => ({
   useSearchMock: vi.fn(),
   useChartSearchResolversMock: vi.fn(),
+  useAmbiguousPointIdentifiersMock: vi.fn(),
   computeLayerVisibilityMock: vi.fn(),
   computeSearchScopeMock: vi.fn(),
   searchChartFeaturesMock: vi.fn(),
@@ -23,6 +25,9 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('./search-resolvers.ts', () => ({
   useChartSearchResolvers: useChartSearchResolversMock,
 }));
+vi.mock('../../../shared/inspector/entity-resolver.ts', () => ({
+  useAmbiguousPointIdentifiers: useAmbiguousPointIdentifiersMock,
+}));
 vi.mock('./search-scope.ts', () => ({
   computeLayerVisibility: computeLayerVisibilityMock,
   computeSearchScope: computeSearchScopeMock,
@@ -32,6 +37,7 @@ vi.mock('./search-features.ts', () => ({
 }));
 
 const resolversSentinel = { airports: { search: vi.fn() } };
+const ambiguousSentinel = { navaids: new Set<string>(), fixes: new Set<string>() };
 const visibilitySentinel = { visibility: true };
 const scopeSentinel = { scope: true };
 
@@ -51,6 +57,7 @@ describe('useChartSearch', () => {
     vi.clearAllMocks();
     useSearchMock.mockReturnValue(search);
     useChartSearchResolversMock.mockReturnValue(resolversSentinel);
+    useAmbiguousPointIdentifiersMock.mockReturnValue(ambiguousSentinel);
     computeLayerVisibilityMock.mockReturnValue(visibilitySentinel);
     computeSearchScopeMock.mockReturnValue(scopeSentinel);
     searchChartFeaturesMock.mockReturnValue([]);
@@ -93,6 +100,7 @@ describe('useChartSearch', () => {
       resolvers: resolversSentinel,
       scope: scopeSentinel,
       visibility: visibilitySentinel,
+      ambiguous: ambiguousSentinel,
     });
   });
 

--- a/apps/atlas/src/modes/chart/search/use-chart-search.ts
+++ b/apps/atlas/src/modes/chart/search/use-chart-search.ts
@@ -1,6 +1,7 @@
 import { getRouteApi } from '@tanstack/react-router';
 import { useDeferredValue, useMemo } from 'react';
 
+import { useAmbiguousPointIdentifiers } from '../../../shared/inspector/entity-resolver.ts';
 import { CHART_ROUTE_PATH } from '../url-state.ts';
 
 import { searchChartFeatures } from './search-features.ts';
@@ -34,6 +35,7 @@ export function useChartSearch(query: string): ChartSearchResult[] {
     searchIncludeHidden,
   } = route.useSearch();
   const resolvers = useChartSearchResolvers();
+  const ambiguous = useAmbiguousPointIdentifiers();
   const deferredQuery = useDeferredValue(query);
 
   const visibility = useMemo(
@@ -64,7 +66,7 @@ export function useChartSearch(query: string): ChartSearchResult[] {
   );
 
   return useMemo(
-    () => searchChartFeatures({ text: deferredQuery, resolvers, scope, visibility }),
-    [deferredQuery, resolvers, scope, visibility],
+    () => searchChartFeatures({ text: deferredQuery, resolvers, scope, visibility, ambiguous }),
+    [deferredQuery, resolvers, scope, visibility, ambiguous],
   );
 }

--- a/apps/atlas/src/shared/inspector/chip-builders.spec.ts
+++ b/apps/atlas/src/shared/inspector/chip-builders.spec.ts
@@ -1,11 +1,12 @@
 import type { Feature, Polygon } from 'geojson';
 import { describe, it, expect } from 'vitest';
 
-import type { Airway, AirspaceFeature } from '@squawk/types';
+import type { Airway, AirspaceFeature, Navaid } from '@squawk/types';
 
 import type { InspectableFeature } from '../../modes/chart/interaction/click-to-select.ts';
 import { AIRPORTS_LAYER_ID } from '../../modes/chart/layers/airports-layer.tsx';
 import { AIRSPACE_FILL_LAYER_ID } from '../../modes/chart/layers/airspace-layer.tsx';
+import { NAVAIDS_LAYER_ID } from '../../modes/chart/layers/navaids-layer.tsx';
 
 import { AIRSPACE_CEILING_FT_PROPERTY, AIRSPACE_FLOOR_FT_PROPERTY } from './airspace-feature.ts';
 import {
@@ -114,6 +115,7 @@ function buildDatasetStates(
     airspaceFeatures?: Feature<Polygon>[];
     airwayRecords?: Airway[];
     airportRecords?: unknown[];
+    navaidRecords?: Navaid[];
   } = {},
 ): ChartDatasetStates {
   return {
@@ -121,7 +123,7 @@ function buildDatasetStates(
       status: 'loaded',
       dataset: { records: overrides.airportRecords ?? [] },
     } as never,
-    navaid: { status: 'loaded', dataset: { records: [] } } as never,
+    navaid: { status: 'loaded', dataset: { records: overrides.navaidRecords ?? [] } } as never,
     fix: { status: 'loaded', dataset: { records: [] } } as never,
     airway: {
       status: 'loaded',
@@ -592,6 +594,38 @@ describe('buildInspectorChipList', () => {
       viewportBounds: undefined,
     });
     expect(result).toHaveLength(1);
+  });
+
+  it('encodes a shared-identifier navaid sibling with a position suffix when ambiguity sets are passed', () => {
+    const east: Navaid = {
+      identifier: 'DUPE',
+      name: 'EAST',
+      type: 'VOR',
+      status: 'OPERATIONAL_IFR',
+      lat: 42,
+      lon: -71,
+      country: 'US',
+    };
+    const west: Navaid = { ...east, name: 'WEST', lat: 40, lon: -120 };
+    const datasets = buildDatasetStates({ navaidRecords: [east, west] });
+    const navaidSibling: InspectableFeature = {
+      layer: { id: NAVAIDS_LAYER_ID },
+      properties: { identifier: 'DUPE' },
+      geometry: { type: 'Point', coordinates: [-71, 42] },
+    };
+    const result = buildInspectorChipList({
+      siblings: [navaidSibling],
+      selected: undefined,
+      datasets,
+      state: { status: 'idle' },
+      layers: ['navaids'],
+      airspaceClasses: [],
+      viewportBounds: undefined,
+      ambiguous: { navaids: new Set(['DUPE']), fixes: new Set() },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.selection).toBe('navaid:DUPE/c:-71.00000,42.00000');
+    expect(result[0]?.type).toBe('navaid');
   });
 
   it('extends the chip list with bbox-overlap airspace chips for an airspace selection', () => {

--- a/apps/atlas/src/shared/inspector/chip-builders.ts
+++ b/apps/atlas/src/shared/inspector/chip-builders.ts
@@ -17,7 +17,7 @@ import type { AirspaceAltitudeKey } from './airspace-feature.ts';
 import { resolveSelectionFromState } from './entity-resolver.ts';
 import type { ChartDatasetStates, ResolvedEntityState } from './entity-resolver.ts';
 import { parseSelected } from './entity.ts';
-import type { EntityType } from './entity.ts';
+import type { AmbiguousPointIdentifiers, EntityType } from './entity.ts';
 import { bboxFromWaypoints, combinedBboxFromAirspaceFeatures } from './geometry.ts';
 import type { BoundingBox } from './geometry.ts';
 
@@ -292,12 +292,18 @@ export function buildInspectorChipList(input: {
   airspaceClasses: readonly AirspaceClass[];
   /** Viewport bbox snapshot used to drop offscreen overlap chips. */
   viewportBounds: BoundingBox | undefined;
+  /**
+   * Shared navaid / fix identifier sets so a sibling chip for a duplicated
+   * identifier encodes a position suffix and resolves to the clicked
+   * record. Omit to encode every sibling bare.
+   */
+  ambiguous?: AmbiguousPointIdentifiers;
 }): readonly Chip[] {
   const seen = new Set<string>();
   const result: Chip[] = [];
 
   for (const feature of input.siblings) {
-    const selection = selectedFromFeature(feature);
+    const selection = selectedFromFeature(feature, input.ambiguous);
     if (selection === undefined) {
       continue;
     }

--- a/apps/atlas/src/shared/inspector/entity-resolver.spec.ts
+++ b/apps/atlas/src/shared/inspector/entity-resolver.spec.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { Airport, Airway, AirspaceFeature, Fix, Navaid } from '@squawk/types';
 
-import { useResolvedEntity } from './entity-resolver.ts';
+import {
+  computeAmbiguousIdentifiers,
+  useAmbiguousPointIdentifiers,
+  useResolvedEntity,
+} from './entity-resolver.ts';
 
 const { airportStateMock, navaidStateMock, fixStateMock, airwayStateMock, airspaceStateMock } =
   vi.hoisted(() => ({
@@ -177,6 +181,34 @@ describe('useResolvedEntity', () => {
     if (result.current.status === 'resolved' && result.current.entity.kind === 'airway') {
       expect(result.current.entity.record.designation).toBe('V16');
     }
+  });
+
+  it('resolves a position-suffixed navaid selection to the nearest shared-identifier record', () => {
+    const east: Navaid = { ...sampleNavaid, identifier: 'DUPE', lat: 42, lon: -71 };
+    const west: Navaid = { ...sampleNavaid, identifier: 'DUPE', lat: 40, lon: -120 };
+    navaidStateMock.mockReturnValue({ status: 'loaded', dataset: { records: [east, west] } });
+    const { result } = renderHook(() => useResolvedEntity('navaid:DUPE/c:-120.00000,40.00000'));
+    expect(result.current.status).toBe('resolved');
+    if (result.current.status === 'resolved' && result.current.entity.kind === 'navaid') {
+      expect(result.current.entity.record.lon).toBe(-120);
+    }
+  });
+
+  it('resolves a position-suffixed fix selection to the nearest shared-identifier record', () => {
+    const east: Fix = { ...sampleFix, identifier: 'DUPE', lat: 42, lon: -71 };
+    const west: Fix = { ...sampleFix, identifier: 'DUPE', lat: 40, lon: -120 };
+    fixStateMock.mockReturnValue({ status: 'loaded', dataset: { records: [east, west] } });
+    const { result } = renderHook(() => useResolvedEntity('fix:DUPE/c:-71.00000,42.00000'));
+    expect(result.current.status).toBe('resolved');
+    if (result.current.status === 'resolved' && result.current.entity.kind === 'fix') {
+      expect(result.current.entity.record.lon).toBe(-71);
+    }
+  });
+
+  it('returns not-found when a position-suffixed selection matches no identifier', () => {
+    navaidStateMock.mockReturnValue({ status: 'loaded', dataset: { records: [sampleNavaid] } });
+    const { result } = renderHook(() => useResolvedEntity('navaid:UNKNOWN/c:-71.00000,42.00000'));
+    expect(result.current.status).toBe('not-found');
   });
 
   it('resolves an airspace compound key to all matching features', () => {
@@ -395,5 +427,56 @@ describe('useResolvedEntity', () => {
       expect(ceilings).toEqual([10000, 10000, 7000]);
       expect(floors).toEqual([3000, 0, 0]);
     }
+  });
+});
+
+describe('computeAmbiguousIdentifiers', () => {
+  it('returns only identifiers that appear on two or more records', () => {
+    expect(computeAmbiguousIdentifiers(['A', 'B', 'A', 'C', 'C', 'C'])).toEqual(
+      new Set(['A', 'C']),
+    );
+  });
+
+  it('returns an empty set when every identifier is unique', () => {
+    expect(computeAmbiguousIdentifiers(['A', 'B', 'C'])).toEqual(new Set());
+  });
+
+  it('returns an empty set for no identifiers', () => {
+    expect(computeAmbiguousIdentifiers([])).toEqual(new Set());
+  });
+});
+
+describe('useAmbiguousPointIdentifiers', () => {
+  it('collects navaid and fix identifiers shared by two or more records', () => {
+    navaidStateMock.mockReturnValue({
+      status: 'loaded',
+      dataset: {
+        records: [
+          { ...sampleNavaid, identifier: 'DUPE' },
+          { ...sampleNavaid, identifier: 'DUPE' },
+          { ...sampleNavaid, identifier: 'SOLO' },
+        ],
+      },
+    });
+    fixStateMock.mockReturnValue({
+      status: 'loaded',
+      dataset: {
+        records: [
+          { ...sampleFix, identifier: 'TWIN' },
+          { ...sampleFix, identifier: 'TWIN' },
+        ],
+      },
+    });
+    const { result } = renderHook(() => useAmbiguousPointIdentifiers());
+    expect(result.current.navaids).toEqual(new Set(['DUPE']));
+    expect(result.current.fixes).toEqual(new Set(['TWIN']));
+  });
+
+  it('returns empty sets while the datasets are loading', () => {
+    navaidStateMock.mockReturnValue({ status: 'loading' });
+    fixStateMock.mockReturnValue({ status: 'loading' });
+    const { result } = renderHook(() => useAmbiguousPointIdentifiers());
+    expect(result.current.navaids.size).toBe(0);
+    expect(result.current.fixes.size).toBe(0);
   });
 });

--- a/apps/atlas/src/shared/inspector/entity-resolver.ts
+++ b/apps/atlas/src/shared/inspector/entity-resolver.ts
@@ -14,8 +14,8 @@ import { getNavaidResolver, useNavaidDataset } from '../data/navaid-dataset.ts';
 import type { NavaidDatasetState } from '../data/navaid-dataset.ts';
 
 import { compareAirspaceByAltitudeDesc } from './airspace-feature.ts';
-import { parseSelected } from './entity.ts';
-import type { EntityRef } from './entity.ts';
+import { decodePointId, parseSelected } from './entity.ts';
+import type { AmbiguousPointIdentifiers, EntityRef } from './entity.ts';
 
 /**
  * A successfully resolved entity. The discriminator `kind` mirrors the URL
@@ -147,6 +147,64 @@ export function useDatasetStates(): ChartDatasetStates {
 }
 
 /**
+ * Stable empty set reused while a dataset is loading or errored, so the
+ * ambiguity hook's memoized value only changes on a real data transition.
+ */
+const EMPTY_IDENTIFIER_SET: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Computes the set of identifiers that appear on two or more records via a
+ * single linear pass: an identifier seen a second time is promoted to the
+ * ambiguous set. Pure and dataset-agnostic so it is unit-testable with
+ * plain string inputs; {@link useAmbiguousPointIdentifiers} feeds it the
+ * navaid and fix record identifiers.
+ *
+ * @param identifiers - Every record identifier in a dataset, duplicates included.
+ * @returns The identifiers shared by two or more records.
+ */
+export function computeAmbiguousIdentifiers(identifiers: Iterable<string>): Set<string> {
+  const seen = new Set<string>();
+  const ambiguous = new Set<string>();
+  for (const identifier of identifiers) {
+    if (seen.has(identifier)) {
+      ambiguous.add(identifier);
+    } else {
+      seen.add(identifier);
+    }
+  }
+  return ambiguous;
+}
+
+/**
+ * Subscribes to the navaid and fix datasets and returns the identifiers
+ * each publishes on more than one record. Memoized on the two dataset
+ * states so the linear ambiguity scan runs once per load rather than per
+ * render. Consumed by the selection-encode paths (map click, sibling
+ * chips, disambiguation popover, feature search) to decide when a navaid /
+ * fix URL value needs a `/c:LON,LAT` disambiguator; an identifier absent
+ * from these sets encodes bare.
+ *
+ * @returns The ambiguous navaid and fix identifier sets (empty while a dataset is loading or errored).
+ */
+export function useAmbiguousPointIdentifiers(): AmbiguousPointIdentifiers {
+  const navaid = useNavaidDataset();
+  const fix = useFixDataset();
+  return useMemo(
+    () => ({
+      navaids:
+        navaid.status === 'loaded'
+          ? computeAmbiguousIdentifiers(navaid.dataset.records.map((record) => record.identifier))
+          : EMPTY_IDENTIFIER_SET,
+      fixes:
+        fix.status === 'loaded'
+          ? computeAmbiguousIdentifiers(fix.dataset.records.map((record) => record.identifier))
+          : EMPTY_IDENTIFIER_SET,
+    }),
+    [navaid, fix],
+  );
+}
+
+/**
  * Pure resolver: looks up a `selected` URL value against pre-fetched
  * dataset states. No React hooks; safe to call in a loop. The chip-strip
  * filtering in `inspector.tsx` calls this once per sibling so chips that
@@ -187,7 +245,16 @@ export function resolveSelectionFromState(
       if (states.navaid.status === 'error') {
         return { status: 'not-found', ref };
       }
-      const record = getNavaidResolver(states.navaid.dataset).byIdent(ref.id)[0];
+      const { ident, position } = decodePointId(ref.id);
+      const resolver = getNavaidResolver(states.navaid.dataset);
+      // A position suffix means the identifier is shared by multiple
+      // records; resolve to the one nearest the encoded point. A bare id
+      // keeps the first-match behavior, so unchanged and stale share-links
+      // resolve exactly as before.
+      const record =
+        position === undefined
+          ? resolver.byIdent(ident)[0]
+          : resolver.byIdentAtPosition(ident, position.lat, position.lon);
       if (record === undefined) {
         return { status: 'not-found', ref };
       }
@@ -200,7 +267,12 @@ export function resolveSelectionFromState(
       if (states.fix.status === 'error') {
         return { status: 'not-found', ref };
       }
-      const record = getFixResolver(states.fix.dataset).byIdent(ref.id)[0];
+      const { ident, position } = decodePointId(ref.id);
+      const resolver = getFixResolver(states.fix.dataset);
+      const record =
+        position === undefined
+          ? resolver.byIdent(ident)[0]
+          : resolver.byIdentAtPosition(ident, position.lat, position.lon);
       if (record === undefined) {
         return { status: 'not-found', ref };
       }

--- a/apps/atlas/src/shared/inspector/entity.spec.ts
+++ b/apps/atlas/src/shared/inspector/entity.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { encodeSelected, parseSelected } from './entity.ts';
+import { decodePointId, encodePointId, encodeSelected, parseSelected } from './entity.ts';
 
 describe('parseSelected', () => {
   it('returns undefined for an undefined input', () => {
@@ -70,5 +70,51 @@ describe('encodeSelected', () => {
 
   it('encodes a compound airspace reference', () => {
     expect(encodeSelected({ type: 'airspace', id: 'CLASS_B/JFK' })).toBe('airspace:CLASS_B/JFK');
+  });
+});
+
+describe('encodePointId', () => {
+  it('returns the bare identifier when no position is given', () => {
+    expect(encodePointId('BOS')).toBe('BOS');
+  });
+
+  it('appends a c:LON,LAT suffix (longitude first) rounded to five places', () => {
+    expect(encodePointId('BOS', { lat: 42.357776, lon: -71.004722 })).toBe(
+      'BOS/c:-71.00472,42.35778',
+    );
+  });
+});
+
+describe('decodePointId', () => {
+  it('returns the bare identifier and no position for an id without a suffix', () => {
+    expect(decodePointId('BOS')).toEqual({ ident: 'BOS', position: undefined });
+  });
+
+  it('splits an identifier and its position suffix', () => {
+    expect(decodePointId('BOS/c:-71.00472,42.35778')).toEqual({
+      ident: 'BOS',
+      position: { lat: 42.35778, lon: -71.00472 },
+    });
+  });
+
+  it('ignores a suffix that does not have exactly two parts', () => {
+    expect(decodePointId('MERIT/c:1,2,3')).toEqual({ ident: 'MERIT', position: undefined });
+  });
+
+  it('ignores a suffix with a non-finite coordinate', () => {
+    expect(decodePointId('MERIT/c:-71.0,abc')).toEqual({ ident: 'MERIT', position: undefined });
+  });
+
+  it('round-trips a position through encodePointId, parseSelected, and decodePointId', () => {
+    const id = encodePointId('DUPE', { lat: 30.123, lon: -90.5 });
+    const ref = parseSelected(`navaid:${id}`);
+    expect(ref).toEqual({ type: 'navaid', id: 'DUPE/c:-90.50000,30.12300' });
+    if (ref === undefined) {
+      return;
+    }
+    expect(decodePointId(ref.id)).toEqual({
+      ident: 'DUPE',
+      position: { lat: 30.123, lon: -90.5 },
+    });
   });
 });

--- a/apps/atlas/src/shared/inspector/entity.ts
+++ b/apps/atlas/src/shared/inspector/entity.ts
@@ -66,6 +66,91 @@ export function encodeSelected(ref: EntityRef): string {
 }
 
 /**
+ * A geographic point used to disambiguate a navaid or fix selection whose
+ * bare identifier is shared by more than one dataset record. Encoded into
+ * the URL `selected` value as a `/c:LON,LAT` suffix on the id and resolved
+ * back through the navaid / fix resolver's `byIdentAtPosition` lookup.
+ */
+export interface PointPosition {
+  /** Latitude in decimal degrees (WGS84). */
+  lat: number;
+  /** Longitude in decimal degrees (WGS84). */
+  lon: number;
+}
+
+/**
+ * The result of decoding a navaid or fix {@link EntityRef} `id` into its
+ * bare identifier and optional disambiguating position.
+ */
+export interface DecodedPointId {
+  /** Bare navaid / fix identifier with any position suffix stripped. */
+  ident: string;
+  /** Decoded disambiguating position, or undefined for a bare id. */
+  position: PointPosition | undefined;
+}
+
+/**
+ * The sets of navaid and fix identifiers that more than one dataset record
+ * shares. Consumed at selection-encode time to decide whether a navaid /
+ * fix URL value needs a disambiguating position suffix: identifiers absent
+ * from these sets are unique and encode as the bare `navaid:IDENT` /
+ * `fix:IDENT` form, keeping the common case short.
+ */
+export interface AmbiguousPointIdentifiers {
+  /** Navaid identifiers published on two or more records. */
+  navaids: ReadonlySet<string>;
+  /** Fix identifiers published on two or more records. */
+  fixes: ReadonlySet<string>;
+}
+
+/**
+ * Encodes the `id` portion of a navaid or fix {@link EntityRef}. Returns the
+ * bare identifier when `position` is undefined; when a position is supplied
+ * (the identifier is shared by multiple records) it appends a `/c:LON,LAT`
+ * suffix - the same `c:` convention the airspace centroid encoding uses - so
+ * the value round-trips through {@link parseSelected}'s first-colon split and
+ * resolves via the navaid / fix resolver's position-aware lookup.
+ *
+ * @param ident - Bare navaid / fix identifier (e.g. `BOS`, `MERIT`).
+ * @param position - Optional disambiguating position; omit for unique identifiers.
+ * @returns The encoded id, bare or position-suffixed.
+ */
+export function encodePointId(ident: string, position?: PointPosition): string {
+  if (position === undefined) {
+    return ident;
+  }
+  return `${ident}/c:${position.lon.toFixed(5)},${position.lat.toFixed(5)}`;
+}
+
+/**
+ * Splits a navaid or fix {@link EntityRef} `id` into its bare identifier and
+ * an optional disambiguating position. Ids in the bare `IDENT` form return
+ * just the identifier; ids carrying the `IDENT/c:LON,LAT` suffix return both.
+ * A malformed or non-finite suffix is treated as absent so a stale share-link
+ * still resolves to the first identifier match rather than failing.
+ *
+ * @param id - The `id` field of a parsed navaid / fix reference.
+ * @returns The bare identifier and the optional decoded position.
+ */
+export function decodePointId(id: string): DecodedPointId {
+  const markerIndex = id.indexOf('/c:');
+  if (markerIndex < 0) {
+    return { ident: id, position: undefined };
+  }
+  const ident = id.slice(0, markerIndex);
+  const parts = id.slice(markerIndex + '/c:'.length).split(',');
+  if (parts.length !== 2) {
+    return { ident, position: undefined };
+  }
+  const lon = Number(parts[0]);
+  const lat = Number(parts[1]);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+    return { ident, position: undefined };
+  }
+  return { ident, position: { lat, lon } };
+}
+
+/**
  * Type-guard checking whether an arbitrary string is a known entity type
  * literal. Used by {@link parseSelected} to reject unknown type prefixes
  * before constructing a typed reference.

--- a/apps/atlas/src/shared/inspector/inspector.spec.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.spec.tsx
@@ -53,10 +53,14 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: useNavigateMock,
 }));
 
-vi.mock('./entity-resolver.ts', () => ({
-  useDatasetStates: useDatasetStatesMock,
-  resolveSelectionFromState: resolveMock,
-}));
+vi.mock('./entity-resolver.ts', () => {
+  const ambiguous = { navaids: new Set<string>(), fixes: new Set<string>() };
+  return {
+    useDatasetStates: useDatasetStatesMock,
+    resolveSelectionFromState: resolveMock,
+    useAmbiguousPointIdentifiers: (): typeof ambiguous => ambiguous,
+  };
+});
 
 vi.mock('../../modes/chart/highlight-context.ts', () => ({
   useSetHoveredChipSelection: () => setHoveredChipSelectionMock,

--- a/apps/atlas/src/shared/inspector/inspector.tsx
+++ b/apps/atlas/src/shared/inspector/inspector.tsx
@@ -9,7 +9,11 @@ import { CHART_ROUTE_PATH } from '../../modes/chart/url-state.ts';
 
 import { buildInspectorChipList } from './chip-builders.ts';
 import type { Chip } from './chip-builders.ts';
-import { useDatasetStates, resolveSelectionFromState } from './entity-resolver.ts';
+import {
+  useAmbiguousPointIdentifiers,
+  useDatasetStates,
+  resolveSelectionFromState,
+} from './entity-resolver.ts';
 import type { BoundingBox } from './geometry.ts';
 import { InspectorBody } from './inspector-body.tsx';
 import { InspectorGrabHandle } from './inspector-grab-handle.tsx';
@@ -92,6 +96,7 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
   const { selected, lat, lon, zoom, layers, airspaceClasses } = route.useSearch();
   const navigate = useNavigate({ from: CHART_ROUTE_PATH });
   const datasets = useDatasetStates();
+  const ambiguous = useAmbiguousPointIdentifiers();
   const map = useMap();
   const mapRef = map.current ?? map.default;
   // Approximate viewport bounds, recomputed when the URL view-state
@@ -248,8 +253,9 @@ export function EntityInspector({ siblings = [] }: EntityInspectorProps): ReactE
         layers,
         airspaceClasses,
         viewportBounds: chipViewportBounds,
+        ambiguous,
       }),
-    [siblings, selected, datasets, state, layers, airspaceClasses, chipViewportBounds],
+    [siblings, selected, datasets, state, layers, airspaceClasses, chipViewportBounds, ambiguous],
   );
 
   // Publish the mobile sheet's live occlusion height and the matching


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

Chart-mode navaid and fix selections now resolve shared identifiers (e.g. a fix `MERIT` published in two ICAO regions, or an NDB and a VOR both `BOS`) to the right record by position, via the `byIdentAtPosition` lookup already shipped in `@squawk/navaids` / `@squawk/fixes`. They previously always picked whichever record sorted first - on click, in feature search, and when rebuilding a selection from a share-link.

- Shared identifiers get a `/c:LON,LAT` URL suffix (matching the airspace centroid convention) decoded back through `byIdentAtPosition`; unique identifiers stay bare, so common-case URLs and existing bare share-links are unchanged.
- Covers all three emit paths (map click, feature search, disambiguation popover); the navaid and fix highlight filters strip the suffix to keep matching on the bare identifier.

## Related issue

<!--
External contributions must reference an existing squawk issue. Use `Closes #N` to auto-close the issue on merge, or `Refs #N` to link without closing.
Maintainer-driven PRs may omit this when no related issue exists.
-->

## Checklist

- [x] Tests added or updated (or N/A - explain why)
  - Updated `entity.spec.ts`, `entity-resolver.spec.ts`, `click-to-select.spec.ts`, `search-features.spec.ts`, `chip-builders.spec.ts`, `disambiguation-popover.spec.tsx`, `navaids-layer.spec.tsx`, `fixes-layer.spec.tsx`, and `use-chart-search.spec.ts`.
- [x] Changeset added under `.changeset/` for any user-facing change to a published `@squawk/*` package (or N/A - internal-only / docs / tooling)
  - N/A; `apps/atlas` is `private: true` and not published.

<!--
For the changeset format, see CONVENTIONS.md (Changeset format).
For CI gate details, see ARCHITECTURE.md (Quality gates).
For security vulnerabilities, do not use this template - see SECURITY.md.
-->
